### PR TITLE
fix: trigger deploy after hourly scan pushes breaking news

### DIFF
--- a/.github/workflows/hourly-scan.yml
+++ b/.github/workflows/hourly-scan.yml
@@ -495,3 +495,21 @@ jobs:
           if [ -f /tmp/tweet-text.txt ]; then
             echo "- **Tweet:** $(cat /tmp/tweet-text.txt)" >> "$GITHUB_STEP_SUMMARY"
           fi
+
+  trigger-deploy:
+    needs: act
+    if: needs.act.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger deploy if breaking news was published
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if any act job actually pushed changes by looking at recent commits
+          LATEST=$(gh api repos/${{ github.repository }}/commits?per_page=1 --jq '.[0].commit.message')
+          if echo "$LATEST" | grep -qE "^(chore|feat)\(hourly\):"; then
+            echo "Hourly scan pushed changes — triggering deploy"
+            gh workflow run deploy.yml --repo ${{ github.repository }}
+          else
+            echo "No hourly changes detected — skipping deploy trigger"
+          fi

--- a/.github/workflows/hourly-scan.yml
+++ b/.github/workflows/hourly-scan.yml
@@ -496,20 +496,21 @@ jobs:
             echo "- **Tweet:** $(cat /tmp/tweet-text.txt)" >> "$GITHUB_STEP_SUMMARY"
           fi
 
+
   trigger-deploy:
     needs: act
-    if: needs.act.result == 'success'
+    if: always() && needs.act.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger deploy if breaking news was published
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Check if any act job actually pushed changes by looking at recent commits
-          LATEST=$(gh api repos/${{ github.repository }}/commits?per_page=1 --jq '.[0].commit.message')
-          if echo "$LATEST" | grep -qE "^(chore|feat)\(hourly\):"; then
+          # Check recent commits from this workflow (last 5 to handle matrix concurrency)
+          COMMITS=$(gh api repos/${{ github.repository }}/commits?per_page=5 --jq '.[].commit.message')
+          if echo "$COMMITS" | grep -qE "^(chore|feat)\(hourly\):"; then
             echo "Hourly scan pushed changes — triggering deploy"
-            gh workflow run deploy.yml --repo ${{ github.repository }}
+            gh workflow run deploy.yml --repo ${{ github.repository }} --ref main
           else
             echo "No hourly changes detected — skipping deploy trigger"
           fi


### PR DESCRIPTION
Hourly scan pushes to main with GITHUB_TOKEN which doesn't trigger other workflows. Added trigger-deploy job that fires deploy.yml when breaking news is published.

Enables push notifications within ~20 min of breaking news detection.