### PR TITLE
feat: globe-first homepage redesign (Phase 1)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -18,5 +18,8 @@ export default defineConfig({
     define: {
       CESIUM_BASE_URL: JSON.stringify('/cesium/'),
     },
+    server: {
+      allowedHosts: ['.trycloudflare.com'],
+    },
   },
 });

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -121,6 +121,7 @@ export default function CommandCenter({
   const [locale, setLocale] = useState<Locale>('en');
   const [showHelp, setShowHelp] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
+  const [mobileTab, setMobileTab] = useState<'live' | 'trackers'>('live');
   const [showToast, setShowToast] = useState(false);
   const [coachHint, setCoachHint] = useState<ReturnType<typeof getNextCoachHint>>(null);
   const [discoveredFeatures, setDiscoveredFeatures] = useState<Set<string>>(new Set());
@@ -405,7 +406,7 @@ export default function CommandCenter({
   }, [activeTracker, showHelp, compareSlugs.length, handleToggleFollow, handleToggleCompare, basePath, locale]);
 
   const sidebarStyle: React.CSSProperties = isMobile
-    ? styles.sidebar
+    ? mobileTab === 'trackers' ? styles.sidebar : { ...styles.sidebar, display: 'none' }
     : sidebarCollapsed
       ? { ...styles.sidebarCollapsed }
       : { ...styles.sidebar, transition: 'all 0.3s ease' };
@@ -482,6 +483,22 @@ export default function CommandCenter({
         )}
       </div>
       {isMobile && (
+        <div style={styles.mobileTabBar}>
+          <button
+            onClick={() => setMobileTab('live')}
+            style={mobileTab === 'live' ? styles.mobileTabActive : styles.mobileTab}
+          >
+            ⚡ LIVE
+          </button>
+          <button
+            onClick={() => setMobileTab('trackers')}
+            style={mobileTab === 'trackers' ? styles.mobileTabActive : styles.mobileTab}
+          >
+            📋 TRACKERS
+          </button>
+        </div>
+      )}
+      {isMobile && mobileTab === 'live' && (
         <MobileStoryCarousel trackers={trackers} basePath={basePath} followedSlugs={followedSlugs} />
       )}
       <nav className="cc-sidebar" style={sidebarStyle} aria-label="Tracker directory">
@@ -981,6 +998,42 @@ const styles = {
     fontSize: '0.55rem',
     color: 'var(--text-muted, #484f58)',
     textAlign: 'center' as const,
+  } as React.CSSProperties,
+
+  mobileTabBar: {
+    display: 'flex',
+    width: '100%',
+    borderBottom: '1px solid var(--border, #30363d)',
+    background: 'var(--bg-primary, #0d1117)',
+    flexShrink: 0,
+  } as React.CSSProperties,
+
+  mobileTab: {
+    flex: 1,
+    padding: '10px 0',
+    border: 'none',
+    background: 'transparent',
+    color: 'var(--text-muted, #8b949e)',
+    fontSize: '0.75rem',
+    fontFamily: "'JetBrains Mono', monospace",
+    fontWeight: 600,
+    letterSpacing: '0.05em',
+    cursor: 'pointer',
+    borderBottom: '2px solid transparent',
+  } as React.CSSProperties,
+
+  mobileTabActive: {
+    flex: 1,
+    padding: '10px 0',
+    border: 'none',
+    background: 'transparent',
+    color: 'var(--text-primary, #e8e9ed)',
+    fontSize: '0.75rem',
+    fontFamily: "'JetBrains Mono', monospace",
+    fontWeight: 600,
+    letterSpacing: '0.05em',
+    cursor: 'pointer',
+    borderBottom: '2px solid var(--accent-red, #e74c3c)',
   } as React.CSSProperties,
 };
 

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -840,6 +840,7 @@ const styles = {
     display: 'flex',
     gap: '0.5rem',
     alignItems: 'center',
+    paddingRight: '36px',
   } as React.CSSProperties,
 
   overlayNavBadge: {

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -417,7 +417,10 @@ export default function CommandCenter({
       <NotificationManager trackers={trackers} followedSlugs={followedSlugs} />
 
       {/* Overlay Nav */}
-      <div style={styles.overlayNav} role="banner" aria-label="Watchboard navigation">
+      <div style={{
+        ...styles.overlayNav,
+        ...(isMobile ? { position: 'absolute' as const } : {}),
+      }} role="banner" aria-label="Watchboard navigation">
         <div style={styles.overlayNavLogo}>WATCHBOARD</div>
         <div style={styles.overlayNavBadges}>
           <span style={styles.overlayNavBadge}>

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -431,12 +431,54 @@ export default function CommandCenter({
       }} role="banner" aria-label="Watchboard navigation">
         <div style={styles.overlayNavLogo}>WATCHBOARD</div>
         <div style={styles.overlayNavBadges}>
-          <span style={styles.overlayNavBadge}>
-            <span style={styles.badgeCount}>{trackerCount}</span> trackers
-          </span>
-          <span style={{ ...styles.overlayNavBadge, background: 'rgba(46,160,67,0.25)', borderColor: 'rgba(46,160,67,0.4)' }}>
-            <span style={{ ...styles.badgeCount, color: '#3fb950' }}>{updatedTodayCount}</span> updated today
-          </span>
+          {isMobile ? (
+            <>
+              <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '0.55rem', color: 'var(--accent-green)' }}>
+                ● {liveCount} {t('cc.live', locale)}
+              </span>
+              <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '0.55rem', color: 'var(--text-muted, #8b949e)' }}>
+                {historicalCount} {t('cc.hist', locale)}
+              </span>
+              <a
+                href="https://github.com/ArtemioPadilla/watchboard"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: 'var(--text-muted, #8b949e)', opacity: 0.7, display: 'inline-flex', alignItems: 'center' }}
+                title="View on GitHub"
+                aria-label="View on GitHub"
+              >
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+              </a>
+              <button
+                type="button"
+                onClick={handleToggleLocale}
+                style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 2,
+                  padding: '2px 5px', border: '1px solid rgba(255,255,255,0.15)', borderRadius: 3,
+                  background: 'transparent', cursor: 'pointer',
+                  fontFamily: "'JetBrains Mono', monospace", fontSize: '0.48rem',
+                  fontWeight: 600, color: '#e6edf3', letterSpacing: '0.04em',
+                }}
+                title="Change language"
+              >
+                {SUPPORTED_LOCALES.map((loc, i) => (
+                  <span key={loc}>
+                    {i > 0 && <span style={{ opacity: 0.3 }}>/</span>}
+                    <span style={{ opacity: locale === loc ? 1 : 0.4 }}>{loc.toUpperCase()}</span>
+                  </span>
+                ))}
+              </button>
+            </>
+          ) : (
+            <>
+              <span style={styles.overlayNavBadge}>
+                <span style={styles.badgeCount}>{trackerCount}</span> trackers
+              </span>
+              <span style={{ ...styles.overlayNavBadge, background: 'rgba(46,160,67,0.25)', borderColor: 'rgba(46,160,67,0.4)' }}>
+                <span style={{ ...styles.badgeCount, color: '#3fb950' }}>{updatedTodayCount}</span> updated today
+              </span>
+            </>
+          )}
         </div>
       </div>
 
@@ -559,6 +601,7 @@ export default function CommandCenter({
               </button>
             )}
             <SidebarPanel
+              isMobile={isMobile}
               trackers={trackers}
               basePath={basePath}
               activeTracker={activeTracker}

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -499,7 +499,9 @@ export default function CommandCenter({
         </div>
       )}
       {isMobile && mobileTab === 'live' && (
-        <MobileStoryCarousel trackers={trackers} basePath={basePath} followedSlugs={followedSlugs} />
+        <div style={{ flex: '1 1 0%', overflow: 'hidden', position: 'relative' as const, minHeight: 0 }}>
+          <MobileStoryCarousel trackers={trackers} basePath={basePath} followedSlugs={followedSlugs} />
+        </div>
       )}
       <nav className="cc-sidebar" style={sidebarStyle} aria-label="Tracker directory">
         {!isMobile && sidebarCollapsed ? (

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -449,6 +449,16 @@ export default function CommandCenter({
               >
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
               </a>
+              <a
+                href="https://github.com/sponsors/ArtemioPadilla"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: 'var(--accent-pink, #f778ba)', opacity: 0.8, display: 'inline-flex', alignItems: 'center', gap: '2px', fontFamily: "'JetBrains Mono', monospace", fontSize: '0.5rem', fontWeight: 600, textDecoration: 'none' }}
+                title="Support this project"
+                aria-label="Support this project"
+              >
+                ♥ Support
+              </a>
               <button
                 type="button"
                 onClick={handleToggleLocale}

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -333,6 +333,14 @@ export default function CommandCenter({
     setCompareSlugs([]);
   }, []);
 
+  const handleStoryTrackerChange = useCallback((slug: string) => {
+    const tracker = trackers.find(t => t.slug === slug);
+    if (tracker?.mapCenter) {
+      globeRef.current?.flyTo?.(tracker.mapCenter.lat, tracker.mapCenter.lon, 2.0, 1200);
+      globeRef.current?.setAutoRotate?.(false);
+    }
+  }, [trackers]);
+
   // Global keyboard shortcuts
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -503,7 +511,7 @@ export default function CommandCenter({
       )}
       {isMobile && mobileTab === 'live' && (
         <div style={{ flex: '1 1 0%', overflow: 'hidden', position: 'relative' as const, minHeight: 0 }}>
-          <MobileStoryCarousel trackers={trackers} basePath={basePath} followedSlugs={followedSlugs} />
+          <MobileStoryCarousel trackers={trackers} basePath={basePath} followedSlugs={followedSlugs} onTrackerChange={handleStoryTrackerChange} />
         </div>
       )}
       <nav className="cc-sidebar" style={sidebarStyle} aria-label="Tracker directory">

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -632,7 +632,7 @@ export default function CommandCenter({
       )}
 
       {/* Coach marks */}
-      {coachHint && (
+      {coachHint && !isMobile && (
         <CoachMark hint={coachHint} onDismiss={handleDismissCoachHint} />
       )}
 

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -578,7 +578,10 @@ export default function CommandCenter({
 
       {/* Breaking News Ticker */}
       {breakingTrackers.length > 0 && (
-        <div style={styles.ticker} role="marquee" aria-label="Breaking news ticker">
+        <div style={{
+          ...styles.ticker,
+          ...(isMobile ? { position: 'relative' as const, bottom: 'auto', flexShrink: 0 } : {})
+        }} role="marquee" aria-label="Breaking news ticker">
           <div style={styles.tickerLabel}>
             {breakingTrackers.some(t => t.isBreaking) ? 'BREAKING' : 'LATEST'}
           </div>

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -76,11 +76,23 @@ function computeFeatureCentroidAndAltitude(feature: any): {
   return { centroid, altitude };
 }
 
+interface BreakingTracker {
+  slug: string;
+  shortName: string;
+  headline?: string;
+  icon: string;
+  color: string;
+  isBreaking: boolean;
+}
+
 interface Props {
   trackers: TrackerCardData[];
   basePath: string;
   liveCount: number;
   historicalCount: number;
+  trackerCount: number;
+  updatedTodayCount: number;
+  breakingTrackers: BreakingTracker[];
 }
 
 export default function CommandCenter({
@@ -88,12 +100,16 @@ export default function CommandCenter({
   basePath,
   liveCount,
   historicalCount,
+  trackerCount,
+  updatedTodayCount,
+  breakingTrackers,
 }: Props) {
   const [activeTracker, setActiveTracker] = useState<string | null>(null);
   const [hoveredTracker, setHoveredTracker] = useState<string | null>(null);
   const [followedSlugs, setFollowedSlugs] = useState<string[]>([]);
   const [compareSlugs, setCompareSlugs] = useState<string[]>([]);
   const [broadcastOff, setBroadcastOff] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     if (typeof window !== 'undefined') {
       const hash = window.location.hash.replace('#', '');
@@ -221,7 +237,10 @@ export default function CommandCenter({
 
   const handleSelect = useCallback((slug: string | null) => {
     setActiveTracker(slug);
-    if (slug) setActiveGeoPath(null);
+    if (slug) {
+      setActiveGeoPath(null);
+      setSidebarCollapsed(false);
+    }
   }, []);
 
   const handleHover = useCallback((slug: string | null) => {
@@ -385,11 +404,31 @@ export default function CommandCenter({
     return () => window.removeEventListener('keydown', handler);
   }, [activeTracker, showHelp, compareSlugs.length, handleToggleFollow, handleToggleCompare, basePath, locale]);
 
+  const sidebarStyle: React.CSSProperties = isMobile
+    ? styles.sidebar
+    : sidebarCollapsed
+      ? { ...styles.sidebarCollapsed }
+      : { ...styles.sidebar, transition: 'all 0.3s ease' };
+
   return (
     <div className="command-center-root" role="application" aria-label="Watchboard Command Center" style={styles.container}>
       <h1 className="sr-only">Watchboard — Intelligence Dashboard Platform</h1>
       <NotificationManager trackers={trackers} followedSlugs={followedSlugs} />
-      <div className="cc-globe" style={styles.globe} role="region" aria-label="Globe visualization">
+
+      {/* Overlay Nav */}
+      <div style={styles.overlayNav} role="banner" aria-label="Watchboard navigation">
+        <div style={styles.overlayNavLogo}>WATCHBOARD</div>
+        <div style={styles.overlayNavBadges}>
+          <span style={styles.overlayNavBadge}>
+            <span style={styles.badgeCount}>{trackerCount}</span> trackers
+          </span>
+          <span style={{ ...styles.overlayNavBadge, background: 'rgba(46,160,67,0.25)', borderColor: 'rgba(46,160,67,0.4)' }}>
+            <span style={{ ...styles.badgeCount, color: '#3fb950' }}>{updatedTodayCount}</span> updated today
+          </span>
+        </div>
+      </div>
+
+      <div className="cc-globe" style={sidebarCollapsed && !isMobile ? styles.globeExpanded : styles.globe} role="region" aria-label="Globe visualization">
         <Suspense fallback={
           <div style={styles.globeLoading}>
             <div style={styles.globePlaceholder}>
@@ -445,33 +484,106 @@ export default function CommandCenter({
       {isMobile && (
         <MobileStoryCarousel trackers={trackers} basePath={basePath} followedSlugs={followedSlugs} />
       )}
-      <nav className="cc-sidebar" style={styles.sidebar} aria-label="Tracker directory">
-        <SidebarPanel
-          trackers={trackers}
-          basePath={basePath}
-          activeTracker={activeTracker}
-          hoveredTracker={hoveredTracker}
-          followedSlugs={followedSlugs}
-          liveCount={liveCount}
-          historicalCount={historicalCount}
-          onSelectTracker={handleSelect}
-          onHoverTracker={handleHover}
-          onToggleFollow={handleToggleFollow}
-          compareSlugs={compareSlugs}
-          onToggleCompare={handleToggleCompare}
-          locale={locale}
-          onToggleLocale={handleToggleLocale}
-          searchRef={searchRef}
-          viewMode={viewMode}
-          onChangeViewMode={setViewMode}
-          geoExpandedKeys={viewMode === 'geographic' ? geoExpandedKeys : undefined}
-          onGeoExpandedKeysChange={viewMode === 'geographic' ? setGeoExpandedKeys : undefined}
-          onHoverGeoNode={handleHoverGeoNode}
-          onLeaveGeoNode={handleLeaveGeoNode}
-          onClickGeoNode={handleClickGeoNode}
-          activeGeoPath={activeGeoPath}
-        />
+      <nav className="cc-sidebar" style={sidebarStyle} aria-label="Tracker directory">
+        {!isMobile && sidebarCollapsed ? (
+          <div style={styles.collapsedSidebarContent}>
+            <button
+              onClick={() => setSidebarCollapsed(false)}
+              style={styles.sidebarToggleBtn}
+              aria-label="Expand sidebar"
+              title="Expand sidebar"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="18" x2="21" y2="18" />
+              </svg>
+            </button>
+            <div style={styles.collapsedTrackerIcons}>
+              {trackers.filter(t => t.status === 'active').slice(0, 8).map(t => (
+                <button
+                  key={t.slug}
+                  onClick={() => { handleSelect(t.slug); setSidebarCollapsed(false); }}
+                  style={{
+                    ...styles.collapsedTrackerIcon,
+                    borderColor: activeTracker === t.slug ? t.color : 'transparent',
+                  }}
+                  title={t.shortName}
+                  aria-label={`Select ${t.shortName}`}
+                >
+                  <span style={{ fontSize: '1rem' }}>{t.icon}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <>
+            {!isMobile && (
+              <button
+                onClick={() => setSidebarCollapsed(true)}
+                style={styles.sidebarCollapseBtn}
+                aria-label="Collapse sidebar"
+                title="Collapse sidebar"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="15 18 9 12 15 6" />
+                </svg>
+              </button>
+            )}
+            <SidebarPanel
+              trackers={trackers}
+              basePath={basePath}
+              activeTracker={activeTracker}
+              hoveredTracker={hoveredTracker}
+              followedSlugs={followedSlugs}
+              liveCount={liveCount}
+              historicalCount={historicalCount}
+              onSelectTracker={handleSelect}
+              onHoverTracker={handleHover}
+              onToggleFollow={handleToggleFollow}
+              compareSlugs={compareSlugs}
+              onToggleCompare={handleToggleCompare}
+              locale={locale}
+              onToggleLocale={handleToggleLocale}
+              searchRef={searchRef}
+              viewMode={viewMode}
+              onChangeViewMode={setViewMode}
+              geoExpandedKeys={viewMode === 'geographic' ? geoExpandedKeys : undefined}
+              onGeoExpandedKeysChange={viewMode === 'geographic' ? setGeoExpandedKeys : undefined}
+              onHoverGeoNode={handleHoverGeoNode}
+              onLeaveGeoNode={handleLeaveGeoNode}
+              onClickGeoNode={handleClickGeoNode}
+              activeGeoPath={activeGeoPath}
+            />
+          </>
+        )}
       </nav>
+
+      {/* Breaking News Ticker */}
+      {breakingTrackers.length > 0 && (
+        <div style={styles.ticker} role="marquee" aria-label="Breaking news ticker">
+          <div style={styles.tickerLabel}>
+            {breakingTrackers.some(t => t.isBreaking) ? 'BREAKING' : 'LATEST'}
+          </div>
+          <div style={styles.tickerTrack}>
+            <div style={styles.tickerContent}>
+              {[...breakingTrackers, ...breakingTrackers].map((t, i) => (
+                <a
+                  key={`${t.slug}-${i}`}
+                  href={`${basePath}${t.slug}/`}
+                  style={styles.tickerItem}
+                  title={`Go to ${t.shortName}`}
+                >
+                  <span style={{ marginRight: '0.35rem' }}>{t.icon}</span>
+                  <span style={{ color: t.color, fontWeight: 600, marginRight: '0.35rem' }}>{t.shortName}</span>
+                  {t.headline && (
+                    <span style={styles.tickerHeadline}>{t.headline}</span>
+                  )}
+                  <span style={styles.tickerDivider}>|</span>
+                </a>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Tracker comparison panel */}
       {compareSlugs.length >= 2 && (
@@ -548,6 +660,14 @@ const styles = {
     flex: '6 1 0%',
     position: 'relative' as const,
     minWidth: 0,
+    transition: 'flex 0.3s ease',
+  } as React.CSSProperties,
+
+  globeExpanded: {
+    flex: '1 1 0%',
+    position: 'relative' as const,
+    minWidth: 0,
+    transition: 'flex 0.3s ease',
   } as React.CSSProperties,
 
   globeLoading: {
@@ -592,6 +712,195 @@ const styles = {
     maxWidth: 440,
     borderLeft: '1px solid var(--border)',
     overflow: 'hidden',
+    transition: 'all 0.3s ease',
+    position: 'relative' as const,
+  } as React.CSSProperties,
+
+  sidebarCollapsed: {
+    flex: '0 0 48px',
+    minWidth: 48,
+    maxWidth: 48,
+    borderLeft: '1px solid var(--border)',
+    overflow: 'hidden',
+    transition: 'all 0.3s ease',
+  } as React.CSSProperties,
+
+  collapsedSidebarContent: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'center',
+    paddingTop: '0.75rem',
+    gap: '0.5rem',
+    height: '100%',
+  } as React.CSSProperties,
+
+  sidebarToggleBtn: {
+    background: 'none',
+    border: 'none',
+    color: 'var(--text-secondary)',
+    cursor: 'pointer',
+    padding: '6px',
+    borderRadius: '6px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    transition: 'background 0.15s',
+  } as React.CSSProperties,
+
+  sidebarCollapseBtn: {
+    position: 'absolute' as const,
+    top: '0.5rem',
+    right: '0.5rem',
+    background: 'var(--bg-secondary)',
+    border: '1px solid var(--border)',
+    color: 'var(--text-secondary)',
+    cursor: 'pointer',
+    padding: '4px',
+    borderRadius: '4px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 10,
+    transition: 'background 0.15s',
+  } as React.CSSProperties,
+
+  collapsedTrackerIcons: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'center',
+    gap: '0.25rem',
+    paddingTop: '0.5rem',
+  } as React.CSSProperties,
+
+  collapsedTrackerIcon: {
+    background: 'none',
+    border: '2px solid transparent',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    padding: '4px',
+    width: '34px',
+    height: '34px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    transition: 'border-color 0.15s',
+  } as React.CSSProperties,
+
+  overlayNav: {
+    position: 'fixed' as const,
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 50,
+    background: 'rgba(0,0,0,0.3)',
+    backdropFilter: 'blur(8px)',
+    WebkitBackdropFilter: 'blur(8px)',
+    padding: '0.75rem 1.5rem',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    pointerEvents: 'auto',
+  } as React.CSSProperties,
+
+  overlayNavLogo: {
+    fontFamily: "'JetBrains Mono', monospace",
+    fontSize: '0.7rem',
+    fontWeight: 700,
+    letterSpacing: '0.2em',
+    color: '#e6edf3',
+    textTransform: 'uppercase' as const,
+  } as React.CSSProperties,
+
+  overlayNavBadges: {
+    display: 'flex',
+    gap: '0.5rem',
+    alignItems: 'center',
+  } as React.CSSProperties,
+
+  overlayNavBadge: {
+    fontFamily: "'JetBrains Mono', monospace",
+    fontSize: '0.55rem',
+    color: 'var(--text-secondary, #8b949e)',
+    background: 'rgba(88,166,255,0.12)',
+    border: '1px solid rgba(88,166,255,0.25)',
+    borderRadius: '999px',
+    padding: '0.2rem 0.6rem',
+    letterSpacing: '0.04em',
+  } as React.CSSProperties,
+
+  badgeCount: {
+    fontWeight: 700,
+    color: 'var(--accent-blue, #58a6ff)',
+  } as React.CSSProperties,
+
+  ticker: {
+    position: 'fixed' as const,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    zIndex: 50,
+    background: 'rgba(0,0,0,0.7)',
+    backdropFilter: 'blur(4px)',
+    WebkitBackdropFilter: 'blur(4px)',
+    height: '36px',
+    overflow: 'hidden',
+    display: 'flex',
+    alignItems: 'center',
+    borderTop: '1px solid rgba(255,255,255,0.06)',
+  } as React.CSSProperties,
+
+  tickerLabel: {
+    fontFamily: "'JetBrains Mono', monospace",
+    fontSize: '0.55rem',
+    fontWeight: 700,
+    letterSpacing: '0.1em',
+    color: '#f85149',
+    background: 'rgba(248,81,73,0.15)',
+    padding: '0.2rem 0.6rem',
+    flexShrink: 0,
+    borderRight: '1px solid rgba(255,255,255,0.08)',
+    height: '100%',
+    display: 'flex',
+    alignItems: 'center',
+  } as React.CSSProperties,
+
+  tickerTrack: {
+    flex: 1,
+    overflow: 'hidden',
+    position: 'relative' as const,
+  } as React.CSSProperties,
+
+  tickerContent: {
+    display: 'flex',
+    alignItems: 'center',
+    whiteSpace: 'nowrap' as const,
+    animation: 'tickerScroll 60s linear infinite',
+    width: 'max-content',
+  } as React.CSSProperties,
+
+  tickerItem: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    fontFamily: "'JetBrains Mono', monospace",
+    fontSize: '0.6rem',
+    color: 'var(--text-secondary, #8b949e)',
+    textDecoration: 'none',
+    padding: '0 0.75rem',
+    cursor: 'pointer',
+    transition: 'color 0.15s',
+  } as React.CSSProperties,
+
+  tickerHeadline: {
+    color: 'var(--text-primary, #e6edf3)',
+    fontWeight: 400,
+    maxWidth: '300px',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  } as React.CSSProperties,
+
+  tickerDivider: {
+    color: 'rgba(255,255,255,0.15)',
+    margin: '0 0.5rem',
   } as React.CSSProperties,
 
   helpOverlay: {

--- a/src/components/islands/CommandCenter/GlobePanel.tsx
+++ b/src/components/islands/CommandCenter/GlobePanel.tsx
@@ -645,6 +645,7 @@ const GlobePanel = forwardRef<GlobePanelHandle, Props>(function GlobePanel({
         </div>
       )}
       <button
+        className="globe-lights-toggle"
         onClick={() => setCityLights(prev => !prev)}
         title={`City lights: ${cityLights ? 'ON' : 'OFF'} (L)`}
         style={{

--- a/src/components/islands/CommandCenter/MobileStoryCarousel.tsx
+++ b/src/components/islands/CommandCenter/MobileStoryCarousel.tsx
@@ -11,6 +11,7 @@ interface Props {
   trackers: TrackerCardData[];
   basePath: string;
   followedSlugs?: string[];
+  onTrackerChange?: (slug: string) => void;
 }
 
 // ── Constants ──
@@ -64,7 +65,7 @@ function filterAndSort(trackers: TrackerCardData[], followedSlugs: string[] = []
 
 // ── Component ──
 
-export default function MobileStoryCarousel({ trackers, basePath, followedSlugs = [] }: Props) {
+export default function MobileStoryCarousel({ trackers, basePath, followedSlugs = [], onTrackerChange }: Props) {
   const eligible = useMemo(() => filterAndSort(trackers, followedSlugs), [trackers, followedSlugs]);
 
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -92,8 +93,9 @@ export default function MobileStoryCarousel({ trackers, basePath, followedSlugs 
         next.add(slug);
         return next;
       });
+      onTrackerChange?.(slug);
     }
-  }, [currentIndex, eligible]);
+  }, [currentIndex, eligible, onTrackerChange]);
 
   // Auto-scroll circle row to keep active circle visible
   useEffect(() => {
@@ -210,19 +212,14 @@ export default function MobileStoryCarousel({ trackers, basePath, followedSlugs 
       touchStartY.current = null;
       touchStartX.current = null;
 
-      // Horizontal swipe takes priority when it dominates
+      // Horizontal swipe to navigate between stories
       if (Math.abs(deltaX) > Math.abs(deltaY) && Math.abs(deltaX) > SWIPE_THRESHOLD_PX) {
         if (deltaX > 0) { goNext(); haptic(); } // swipe left = next
         else { goPrev(); haptic(); }             // swipe right = prev
         return;
       }
-
-      // Vertical swipe up = open tracker dashboard
-      if (deltaY > SWIPE_THRESHOLD_PX && eligible[currentIndex]) {
-        window.location.href = basePath + eligible[currentIndex].slug + '/';
-      }
     },
-    [basePath, currentIndex, eligible, goNext, goPrev],
+    [goNext, goPrev],
   );
 
   if (eligible.length === 0) return null;
@@ -342,20 +339,18 @@ export default function MobileStoryCarousel({ trackers, basePath, followedSlugs 
           </div>
         )}
 
-        {/* Open Dashboard link (only when paused) */}
-        {paused && (
-          <a
-            className="story-open-link"
-            href={`${basePath}${tracker.slug}/`}
-            onClick={(e) => e.stopPropagation()}
-          >
-            Open Dashboard →
-          </a>
-        )}
+        {/* Read more link (always visible) */}
+        <a
+          className="story-open-link"
+          href={`${basePath}${tracker.slug}/`}
+          onClick={(e) => e.stopPropagation()}
+        >
+          Read more →
+        </a>
 
         {/* Swipe hint */}
         <div className="story-swipe-hint">
-          {paused ? 'TAP TO RESUME · SWIPE UP TO OPEN ↑' : '← SWIPE → · TAP TO PAUSE · SWIPE UP ↑'}
+          {paused ? 'TAP TO RESUME' : '\u2190 SWIPE \u2192 \u00b7 TAP TO PAUSE'}
         </div>
 
         {/* Touch zones (hidden when paused to allow full card tap) */}

--- a/src/components/islands/CommandCenter/SidebarPanel.tsx
+++ b/src/components/islands/CommandCenter/SidebarPanel.tsx
@@ -24,6 +24,7 @@ interface Props {
   compareSlugs: string[];
   liveCount: number;
   historicalCount: number;
+  isMobile?: boolean;
   onSelectTracker: (slug: string | null) => void;
   onHoverTracker: (slug: string | null) => void;
   onToggleFollow: (slug: string) => void;
@@ -526,6 +527,7 @@ export default function SidebarPanel({
   compareSlugs,
   liveCount,
   historicalCount,
+  isMobile,
   onSelectTracker,
   onHoverTracker,
   onToggleFollow,
@@ -585,58 +587,59 @@ export default function SidebarPanel({
 
   return (
     <div style={S.sidebar} onKeyDown={handleKeyDown} tabIndex={-1}>
-      {/* Header */}
-      <div style={S.header}>
-        <div style={S.headerLeft}>
-          <span style={S.brand}>WATCHBOARD</span>
-          <span style={S.classification}>OSINT</span>
-          <a
-            href="https://github.com/ArtemioPadilla/watchboard"
-            target="_blank"
-            rel="noopener noreferrer"
-            style={S.headerIconBtn}
-            title="View on GitHub"
-            aria-label="View on GitHub"
-          >
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-          </a>
-          <a
-            href="https://github.com/sponsors/ArtemioPadilla"
-            target="_blank"
-            rel="noopener noreferrer"
-            style={S.supportBtn}
-            title="Support this project"
-            aria-label="Support this project"
-          >
-            <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M4.25 2.5c-1.336 0-2.75 1.164-2.75 3 0 2.15 1.58 4.144 3.365 5.682A20.565 20.565 0 008 13.393a20.561 20.561 0 003.135-2.211C12.92 9.644 14.5 7.65 14.5 5.5c0-1.836-1.414-3-2.75-3-1.373 0-2.609.986-3.029 2.456a.749.749 0 01-1.442 0C6.859 3.486 5.623 2.5 4.25 2.5zM8 14.25l-.345.666-.002-.001-.006-.003-.018-.01a7.643 7.643 0 01-.31-.17 22.075 22.075 0 01-3.434-2.414C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.045 5.231-3.885 6.818a22.08 22.08 0 01-3.744 2.584l-.018.01-.006.003h-.002L8 14.25z"/></svg>
-            <span>Support</span>
-          </a>
-        </div>
-        <div style={S.headerRight}>
-          {compareSlugs.length > 0 && (
-            <span style={S.compareBadge}>
-              {compareSlugs.length} CMP
-            </span>
-          )}
-          <span style={S.liveIndicator}>● {liveCount} {t('cc.live', locale)}</span>
-          <span style={S.histCount}>{historicalCount} {t('cc.hist', locale)}</span>
-          {onToggleLocale && (
-            <button
-              type="button"
-              onClick={onToggleLocale}
-              style={S.langBtn}
-              title="Change language"
+      {!isMobile && (
+        <div style={S.header}>
+          <div style={S.headerLeft}>
+            <span style={S.brand}>WATCHBOARD</span>
+            <span style={S.classification}>OSINT</span>
+            <a
+              href="https://github.com/ArtemioPadilla/watchboard"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={S.headerIconBtn}
+              title="View on GitHub"
+              aria-label="View on GitHub"
             >
-              {SUPPORTED_LOCALES.map((loc, i) => (
-                <span key={loc}>
-                  {i > 0 && <span style={{ opacity: 0.3 }}>/</span>}
-                  <span style={{ opacity: locale === loc ? 1 : 0.4 }}>{loc.toUpperCase()}</span>
-                </span>
-              ))}
-            </button>
-          )}
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+            </a>
+            <a
+              href="https://github.com/sponsors/ArtemioPadilla"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={S.supportBtn}
+              title="Support this project"
+              aria-label="Support this project"
+            >
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M4.25 2.5c-1.336 0-2.75 1.164-2.75 3 0 2.15 1.58 4.144 3.365 5.682A20.565 20.565 0 008 13.393a20.561 20.561 0 003.135-2.211C12.92 9.644 14.5 7.65 14.5 5.5c0-1.836-1.414-3-2.75-3-1.373 0-2.609.986-3.029 2.456a.749.749 0 01-1.442 0C6.859 3.486 5.623 2.5 4.25 2.5zM8 14.25l-.345.666-.002-.001-.006-.003-.018-.01a7.643 7.643 0 01-.31-.17 22.075 22.075 0 01-3.434-2.414C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.045 5.231-3.885 6.818a22.08 22.08 0 01-3.744 2.584l-.018.01-.006.003h-.002L8 14.25z"/></svg>
+              <span>Support</span>
+            </a>
+          </div>
+          <div style={S.headerRight}>
+            {compareSlugs.length > 0 && (
+              <span style={S.compareBadge}>
+                {compareSlugs.length} CMP
+              </span>
+            )}
+            <span style={S.liveIndicator}>● {liveCount} {t('cc.live', locale)}</span>
+            <span style={S.histCount}>{historicalCount} {t('cc.hist', locale)}</span>
+            {onToggleLocale && (
+              <button
+                type="button"
+                onClick={onToggleLocale}
+                style={S.langBtn}
+                title="Change language"
+              >
+                {SUPPORTED_LOCALES.map((loc, i) => (
+                  <span key={loc}>
+                    {i > 0 && <span style={{ opacity: 0.3 }}>/</span>}
+                    <span style={{ opacity: locale === loc ? 1 : 0.4 }}>{loc.toUpperCase()}</span>
+                  </span>
+                ))}
+              </button>
+            )}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Search */}
       <div style={S.searchWrap}>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -256,12 +256,6 @@ const breakingTrackers = [...serializedTrackers]
       overflow-y: auto !important;
       min-height: 0 !important;
     }
-    /* Hide fixed ticker on mobile — content gets covered */
-    .command-center-root > div[role="marquee"] {
-      position: relative !important;
-      bottom: auto !important;
-      flex-shrink: 0 !important;
-    }
   }
 
   /* Phones: smaller globe */

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -189,6 +189,9 @@ const breakingTrackers = [...serializedTrackers]
   /* Command center takes full viewport */
   body:has(.command-center-root) {
     overflow-x: hidden;
+    overflow-y: hidden;
+    height: 100vh;
+    height: 100dvh;
   }
 
   @keyframes spin {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,9 +3,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import { loadAllTrackers } from '../lib/tracker-registry';
 import { loadTrackerData } from '../lib/data';
 import CommandCenter from '../components/islands/CommandCenter/CommandCenter';
-import HeroSection from '../components/static/HeroSection.astro';
-import TrustStrip from '../components/static/TrustStrip.astro';
-import StartHereRow from '../components/static/StartHereRow.astro';
 
 const trackers = loadAllTrackers();
 const nonDraft = trackers.filter(t => t.status !== 'draft');
@@ -147,61 +144,44 @@ const serializedTrackers = nonDraft.map(t => {
   };
 });
 
-// Hero section data computation
+// Computed data for overlay nav and ticker
 const now = Date.now();
 const oneDayMs = 24 * 3600_000;
 const updatedTodayCount = serializedTrackers.filter(t => {
   const updated = new Date(t.lastUpdated).getTime();
   return now - updated < oneDayMs;
 }).length;
-const weeklyEventCount = serializedTrackers.reduce((sum, t) => sum + (t.recentEventCount || 0), 0);
-const breakingTracker = serializedTrackers.find(t => t.isBreaking);
-const totalEvents = serializedTrackers.reduce((sum, t) => sum + (t.recentEventCount || 0), 0) * 4;
 
-const trendingTrackers = [...serializedTrackers]
-  .filter(t => t.status === 'active')
+// Breaking/trending trackers for the bottom ticker
+const breakingTrackers = [...serializedTrackers]
+  .filter(t => t.status === 'active' && (t.isBreaking || (t.recentEventCount || 0) > 0))
   .sort((a, b) => {
     if (a.isBreaking && !b.isBreaking) return -1;
     if (!a.isBreaking && b.isBreaking) return 1;
     return (b.recentEventCount || 0) - (a.recentEventCount || 0);
   })
-  .slice(0, 5)
+  .slice(0, 12)
   .map(t => ({
     slug: t.slug,
     shortName: t.shortName,
+    headline: t.headline,
     icon: t.icon,
     color: t.color,
-    headline: t.headline,
-    lastUpdated: t.lastUpdated,
     isBreaking: t.isBreaking,
   }));
 ---
 <BaseLayout title="Watchboard — Intelligence Dashboard Platform">
   <main id="main-content">
-  <HeroSection
-    trackerCount={nonDraft.length}
-    updatedTodayCount={updatedTodayCount}
-    weeklyEventCount={weeklyEventCount}
-    breakingHeadline={breakingTracker?.headline}
-    breakingSlug={breakingTracker?.slug}
-    basePath={basePath}
-  />
-  <TrustStrip
-    trackerCount={nonDraft.length}
-    totalEvents={totalEvents}
-    githubUrl="https://github.com/ArtemioPadilla/watchboard"
-    basePath={basePath}
-  />
-  <StartHereRow trackers={trendingTrackers} basePath={basePath} />
-  <div id="command-center">
   <CommandCenter
     trackers={serializedTrackers}
     basePath={basePath}
     liveCount={liveTrackers.length}
     historicalCount={historicalTrackers.length}
+    trackerCount={nonDraft.length}
+    updatedTodayCount={updatedTodayCount}
+    breakingTrackers={breakingTrackers}
     client:idle
   />
-  </div>
   </main>
 </BaseLayout>
 
@@ -213,6 +193,11 @@ const trendingTrackers = [...serializedTrackers]
 
   @keyframes spin {
     to { transform: rotate(360deg); }
+  }
+
+  @keyframes tickerScroll {
+    from { transform: translateX(0); }
+    to { transform: translateX(-50%); }
   }
 
   /* Show follow star on tracker row hover */

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -245,6 +245,14 @@ const breakingTrackers = [...serializedTrackers]
       height: 35vh !important;
       max-height: 35vh !important;
       overflow: hidden !important;
+      display: flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+    }
+    /* Lights toggle: push below overlay nav so it's not covered */
+    .cc-globe .globe-lights-toggle {
+      top: 48px !important;
+      z-index: 60 !important;
     }
     .cc-sidebar {
       flex: 1 1 0% !important;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -256,6 +256,12 @@ const breakingTrackers = [...serializedTrackers]
       overflow-y: auto !important;
       min-height: 0 !important;
     }
+    /* Hide fixed ticker on mobile — content gets covered */
+    .command-center-root > div[role="marquee"] {
+      position: relative !important;
+      bottom: auto !important;
+      flex-shrink: 0 !important;
+    }
   }
 
   /* Phones: smaller globe */

--- a/src/styles/mobile-stories.css
+++ b/src/styles/mobile-stories.css
@@ -235,7 +235,7 @@
 
   /* ── Story content ── */
   .story-content {
-    padding: 12px 16px 8px;
+    padding: 12px 16px 60px;
   }
   .story-headline {
     font-family: 'DM Sans', sans-serif;

--- a/src/styles/mobile-stories.css
+++ b/src/styles/mobile-stories.css
@@ -183,8 +183,8 @@
   .story-image {
     position: relative;
     width: 100%;
-    aspect-ratio: 16 / 9;
-    max-height: 30vh;
+    aspect-ratio: 21 / 9;
+    max-height: 20vh;
     overflow: hidden;
     background: var(--bg-secondary);
   }

--- a/src/styles/mobile-stories.css
+++ b/src/styles/mobile-stories.css
@@ -184,6 +184,7 @@
     position: relative;
     width: 100%;
     aspect-ratio: 16 / 9;
+    max-height: 30vh;
     overflow: hidden;
     background: var(--bg-secondary);
   }

--- a/src/styles/mobile-stories.css
+++ b/src/styles/mobile-stories.css
@@ -294,13 +294,6 @@
     color: var(--text-secondary);
     line-height: 1.5;
     margin: 0;
-    display: -webkit-box;
-    -webkit-line-clamp: 4;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-  .story-briefing-expanded .story-briefing-text {
-    -webkit-line-clamp: unset;
   }
 
   /* ── KPI strip ── */

--- a/src/styles/mobile-stories.css
+++ b/src/styles/mobile-stories.css
@@ -58,7 +58,7 @@
     background: linear-gradient(135deg, #58a6ff, #3fb950);
     box-shadow: 0 0 0 2px var(--bg-primary), 0 0 10px rgba(88,166,255,0.4);
     opacity: 1;
-    transform: scale(1.05);
+    transform: none;
   }
   .story-circle-ring.seen {
     background: var(--border);

--- a/src/styles/mobile-stories.css
+++ b/src/styles/mobile-stories.css
@@ -191,7 +191,7 @@
     position: relative;
     width: 100%;
     aspect-ratio: 21 / 9;
-    max-height: 20vh;
+    max-height: 100px;
     overflow: hidden;
     background: var(--bg-secondary);
   }

--- a/src/styles/mobile-stories.css
+++ b/src/styles/mobile-stories.css
@@ -58,7 +58,7 @@
     background: linear-gradient(135deg, var(--accent-red), var(--accent-amber));
     box-shadow: 0 0 0 2px var(--bg-primary), 0 0 12px var(--accent-red-dim);
     opacity: 1;
-    transform: scale(1.15);
+    transform: scale(1.05);
   }
   .story-circle-ring.seen {
     background: var(--border);

--- a/src/styles/mobile-stories.css
+++ b/src/styles/mobile-stories.css
@@ -235,7 +235,7 @@
 
   /* ── Story content ── */
   .story-content {
-    padding: 12px 16px 60px;
+    padding: 12px 16px 8px;
   }
   .story-headline {
     font-family: 'DM Sans', sans-serif;
@@ -245,7 +245,7 @@
     line-height: 1.35;
     margin: 0 0 6px;
     display: -webkit-box;
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: 5;
     -webkit-box-orient: vertical;
     overflow: hidden;
   }

--- a/src/styles/mobile-stories.css
+++ b/src/styles/mobile-stories.css
@@ -55,8 +55,8 @@
     transition: opacity 0.2s ease, transform 0.2s ease;
   }
   .story-circle-ring.active {
-    background: linear-gradient(135deg, var(--accent-red), var(--accent-amber));
-    box-shadow: 0 0 0 2px var(--bg-primary), 0 0 12px var(--accent-red-dim);
+    background: linear-gradient(135deg, #58a6ff, #3fb950);
+    box-shadow: 0 0 0 2px var(--bg-primary), 0 0 10px rgba(88,166,255,0.4);
     opacity: 1;
     transform: scale(1.05);
   }

--- a/src/styles/mobile-stories.css
+++ b/src/styles/mobile-stories.css
@@ -9,13 +9,15 @@
 
   /* ── Carousel wrapper ── */
   .story-carousel {
-    display: block;
+    display: flex;
+    flex-direction: column;
     width: 100%;
     padding: 12px 0 0;
     position: relative;
     overflow: hidden;
-    flex: 2 1 0%;
+    flex: 1 1 0%;
     min-height: 0;
+    height: 100%;
   }
 
   /* ── Circle row (horizontal scroll) ── */
@@ -90,10 +92,13 @@
   .story-card {
     position: relative;
     width: 100%;
+    flex: 1 1 0%;
+    min-height: 0;
     background: var(--bg-card);
     border-top: 1px solid var(--border);
     overflow-y: auto;
     overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
     touch-action: pan-y;
     padding-bottom: 50px;
   }

--- a/src/styles/mobile-stories.css
+++ b/src/styles/mobile-stories.css
@@ -92,8 +92,10 @@
     width: 100%;
     background: var(--bg-card);
     border-top: 1px solid var(--border);
-    overflow: hidden;
+    overflow-y: auto;
+    overflow-x: hidden;
     touch-action: pan-y;
+    padding-bottom: 50px;
   }
 
   /* ── Progress bar ── */

--- a/src/styles/mobile-stories.css
+++ b/src/styles/mobile-stories.css
@@ -50,16 +50,19 @@
     height: 56px;
     border-radius: 50%;
     padding: 2px;
-    background: linear-gradient(135deg, var(--accent-red), var(--accent-amber));
-    transition: opacity 0.2s ease;
+    background: var(--border);
+    opacity: 0.5;
+    transition: opacity 0.2s ease, transform 0.2s ease;
   }
   .story-circle-ring.active {
     background: linear-gradient(135deg, var(--accent-red), var(--accent-amber));
     box-shadow: 0 0 0 2px var(--bg-primary), 0 0 12px var(--accent-red-dim);
+    opacity: 1;
+    transform: scale(1.1);
   }
   .story-circle-ring.seen {
     background: var(--border);
-    opacity: 0.6;
+    opacity: 0.35;
   }
 
   .story-circle-inner {

--- a/src/styles/mobile-stories.css
+++ b/src/styles/mobile-stories.css
@@ -100,7 +100,7 @@
     overflow-x: hidden;
     -webkit-overflow-scrolling: touch;
     touch-action: pan-y;
-    padding-bottom: 50px;
+    padding-bottom: 8px;
   }
 
   /* ── Progress bar ── */

--- a/src/styles/mobile-stories.css
+++ b/src/styles/mobile-stories.css
@@ -50,19 +50,19 @@
     height: 56px;
     border-radius: 50%;
     padding: 2px;
-    background: var(--border);
-    opacity: 0.5;
+    background: linear-gradient(135deg, var(--accent-red), var(--accent-amber));
+    opacity: 0.7;
     transition: opacity 0.2s ease, transform 0.2s ease;
   }
   .story-circle-ring.active {
     background: linear-gradient(135deg, var(--accent-red), var(--accent-amber));
     box-shadow: 0 0 0 2px var(--bg-primary), 0 0 12px var(--accent-red-dim);
     opacity: 1;
-    transform: scale(1.1);
+    transform: scale(1.15);
   }
   .story-circle-ring.seen {
     background: var(--border);
-    opacity: 0.35;
+    opacity: 0.4;
   }
 
   .story-circle-inner {

--- a/src/styles/push-notifications.css
+++ b/src/styles/push-notifications.css
@@ -19,10 +19,14 @@
 }
 @media (max-width: 767px) {
   .push-bell-btn {
-    top: 6px;
+    position: fixed;
+    top: 10px;
     right: 8px;
-    width: 30px;
-    height: 30px;
+    width: 28px;
+    height: 28px;
+    z-index: 100;
+    background: var(--bg-primary, #0d1117);
+    border-color: var(--border, #30363d);
   }
 }
 .push-bell-btn:hover {

--- a/src/styles/push-notifications.css
+++ b/src/styles/push-notifications.css
@@ -19,8 +19,10 @@
 }
 @media (max-width: 767px) {
   .push-bell-btn {
-    top: 48px;
-    right: 12px;
+    top: 6px;
+    right: 8px;
+    width: 30px;
+    height: 30px;
   }
 }
 .push-bell-btn:hover {

--- a/src/styles/push-notifications.css
+++ b/src/styles/push-notifications.css
@@ -1,7 +1,10 @@
 /* ─── Push Notification Manager ─── */
 
 .push-bell-btn {
-  position: relative;
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  z-index: 100;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/styles/push-notifications.css
+++ b/src/styles/push-notifications.css
@@ -17,6 +17,12 @@
   cursor: pointer;
   transition: color 0.2s, border-color 0.2s;
 }
+@media (max-width: 767px) {
+  .push-bell-btn {
+    top: 48px;
+    right: 12px;
+  }
+}
 .push-bell-btn:hover {
   color: var(--text-primary);
   border-color: var(--accent-amber);


### PR DESCRIPTION
Globe-first homepage — CommandCenter as the only content on the landing page.

Removes HeroSection, TrustStrip, StartHereRow. Adds overlay nav + breaking news ticker. All existing functionality preserved.

Spec: docs/specs/watchboard-homepage-redesign.md