### PR TITLE
feat: compact tracker pages — data-first, remove hero section

### DIFF
--- a/e2e/tracker-page.spec.ts
+++ b/e2e/tracker-page.spec.ts
@@ -1,11 +1,11 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Tracker Page', () => {
-  test('iran-conflict page loads with hero headline', async ({ page }) => {
+  test('iran-conflict page loads with header headline', async ({ page }) => {
     await page.goto('./iran-conflict/');
 
-    // The page should have a hero headline
-    const headline = page.locator('.hero-kpi-headline');
+    // The page should have a headline in the header bar
+    const headline = page.locator('.header-headline-text');
     await expect(headline).toBeVisible();
     await expect(headline).not.toBeEmpty();
 
@@ -14,18 +14,18 @@ test.describe('Tracker Page', () => {
     await expect(header).toBeVisible();
   });
 
-  test('KPI strip shows values', async ({ page }) => {
+  test('KPI ticker shows values', async ({ page }) => {
     await page.goto('./iran-conflict/');
 
-    // KPI items should be visible in the hero section
-    const kpiItems = page.locator('.hero-kpi-item');
+    // KPI items should be visible in the ticker strip
+    const kpiItems = page.locator('.kpi-ticker-item');
     const count = await kpiItems.count();
     expect(count).toBeGreaterThan(0);
 
     // Each KPI should have a label and a value
     const firstKpi = kpiItems.first();
-    const label = firstKpi.locator('.hero-kpi-label');
-    const value = firstKpi.locator('.hero-kpi-value');
+    const label = firstKpi.locator('.kpi-ticker-label');
+    const value = firstKpi.locator('.kpi-ticker-value');
     await expect(label).toBeVisible();
     await expect(value).toBeVisible();
     await expect(value).not.toBeEmpty();
@@ -54,8 +54,8 @@ test.describe('Tracker Page', () => {
   test('/es/iran-conflict/ loads Spanish version', async ({ page }) => {
     await page.goto('./es/iran-conflict/');
 
-    // The page should load successfully with a hero headline
-    const headline = page.locator('.hero-kpi-headline');
+    // The page should load successfully with a header headline
+    const headline = page.locator('.header-headline-text');
     await expect(headline).toBeVisible();
     await expect(headline).not.toBeEmpty();
 

--- a/src/components/static/Header.astro
+++ b/src/components/static/Header.astro
@@ -8,9 +8,17 @@ interface Props {
   trackerSlug?: string;
   globeEnabled?: boolean;
   statusLabel?: string;
+  dayCount?: string | number;
+  headline?: string;
+  geoPath?: string[];
+  region?: string;
+  country?: string;
+  state?: string;
+  city?: string;
+  neighborhood?: string;
 }
 
-const { meta, navSections, trackerSlug, globeEnabled = true, statusLabel = 'ACTIVE TRACKER' } = Astro.props;
+const { meta, navSections, trackerSlug, globeEnabled = true, statusLabel = 'ACTIVE TRACKER', dayCount, headline, geoPath, region, country, state, city, neighborhood } = Astro.props;
 
 // Fallback for backward compat
 const sections = navSections ?? (await import('../../lib/constants')).NAV_SECTIONS;
@@ -18,14 +26,48 @@ const base = import.meta.env.BASE_URL;
 const basePath = base.endsWith('/') ? base : `${base}/`;
 const globeHref = trackerSlug ? `${basePath}${trackerSlug}/globe/` : `${basePath}globe/`;
 const aboutHref = trackerSlug ? `${basePath}${trackerSlug}/about/` : `${basePath}about/`;
+
+// Build geo breadcrumb segments
+const regionPrefix = region || 'global';
+const geoSegments: { label: string; href: string }[] = [];
+if (geoPath && geoPath.length > 0) {
+  const labels = [country || geoPath[0], state, city, neighborhood].filter(Boolean) as string[];
+  for (let i = 0; i < geoPath.length; i++) {
+    const pathSlice = geoPath.slice(0, i + 1).join('/');
+    geoSegments.push({
+      label: labels[i] || geoPath[i],
+      href: `${basePath}geo/${regionPrefix}/${pathSlice}/`,
+    });
+  }
+}
+
+/** Strip HTML tags for safe display */
+const cleanText = (s: string) =>
+  s.replace(/<[^>]+>/g, ' ').replace(/&amp;/g, '&').replace(/&middot;/g, '\u00B7').replace(/\s{2,}/g, ' ').trim();
+const cleanHeadline = headline ? cleanText(headline) : '';
 ---
-<header class="site-header">
+<header class="site-header compact-header">
   <div class="header-inner">
     <div class="header-left">
       <a class="home-link" href={basePath} title="Watchboard Home">WB</a>
       <span class="header-sep">&middot;</span>
       <span class="live-dot"></span>
-      <span class="header-title"><strong>{statusLabel}</strong> &mdash; {meta.operationName}</span>
+      <div class="header-identity">
+        <span class="header-title">
+          <strong>{meta.operationName}</strong>
+          {dayCount && <span class="header-daycount">Day {dayCount}</span>}
+        </span>
+        {geoSegments.length > 0 && (
+          <nav class="header-geo" aria-label="Geographic location">
+            {geoSegments.map((seg, i) => (
+              <>
+                {i > 0 && <span class="geo-sep">›</span>}
+                <a href={seg.href} class="geo-link">{seg.label}</a>
+              </>
+            ))}
+          </nav>
+        )}
+      </div>
       <span class="freshness-indicator" data-updated={meta.lastUpdated} aria-live="polite">
         <span class="freshness-text">{meta.lastUpdated ? `Updated ${new Date(meta.lastUpdated).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}` : 'Last update time unknown'}</span>
       </span>
@@ -39,6 +81,11 @@ const aboutHref = trackerSlug ? `${basePath}${trackerSlug}/about/` : `${basePath
       <a class="nav-btn about-nav-btn" href={aboutHref}>About</a>
     </nav>
   </div>
+  {cleanHeadline && (
+    <div class="header-headline-bar">
+      <span class="header-headline-text" title={cleanHeadline}>{cleanHeadline}</span>
+    </div>
+  )}
 </header>
 
 <script>

--- a/src/components/static/HeroKpiCombo.astro
+++ b/src/components/static/HeroKpiCombo.astro
@@ -2,50 +2,20 @@
 import type { KpiItem } from '../../lib/schemas';
 
 interface Props {
-  meta: {
-    dateline: string;
-    heroHeadline: string;
-    heroSubtitle: string;
-    lastUpdated?: string;
-    operationName?: string;
-    dayCount?: string | number;
-  };
   kpis: KpiItem[];
 }
 
-const { meta, kpis } = Astro.props;
-
-/** Strip HTML tags and decode common entities for safe text display */
-const cleanText = (s: string) =>
-  s.replace(/<[^>]+>/g, ' ')
-   .replace(/&amp;/g, '&')
-   .replace(/&lt;/g, '<')
-   .replace(/&gt;/g, '>')
-   .replace(/&quot;/g, '"')
-   .replace(/&#39;/g, "'")
-   .replace(/&middot;/g, '\u00B7')
-   .replace(/\s{2,}/g, ' ')
-   .trim();
+const { kpis } = Astro.props;
 ---
-<div class="hero-kpi-combo">
-  <div class="hero-kpi-left">
-    <div class="hero-kpi-dateline">
-      <span class="hero-kpi-dateline-dash">&mdash;&mdash;</span>
-      {meta.dateline} &mdash; SITUATION REPORT
-    </div>
-    <h1 class="hero-kpi-headline" title={cleanText(meta.heroHeadline)}>
-      {cleanText(meta.heroHeadline)}
-    </h1>
-  </div>
-  <div class="hero-kpi-divider"></div>
-  <div class="hero-kpi-right">
+<div class="kpi-ticker" role="region" aria-label="Key metrics">
+  <div class="kpi-ticker-track">
     {kpis.slice(0, 7).map(k => (
-      <div class="hero-kpi-item">
-        <span class="hero-kpi-label">{k.label}</span>
-        <span class={`hero-kpi-value ${k.color}`}>
+      <div class="kpi-ticker-item">
+        <span class="kpi-ticker-label">{k.label}</span>
+        <span class={`kpi-ticker-value ${k.color}`}>
           {k.value}
           {k.trend && k.trend !== 'stable' && (
-            <span class={`hero-kpi-trend ${k.trend}`}>
+            <span class={`kpi-ticker-trend ${k.trend}`}>
               {k.trend === 'up' ? '\u25B2' : '\u25BC'}
             </span>
           )}

--- a/src/pages/[tracker]/index.astro
+++ b/src/pages/[tracker]/index.astro
@@ -9,7 +9,7 @@ import PoliticalGrid from '../../components/static/PoliticalGrid.astro';
 import SourceLegend from '../../components/static/SourceLegend.astro';
 import EmbedModal from '../../components/static/EmbedModal.astro';
 import Footer from '../../components/static/Footer.astro';
-import GeoBreadcrumb from '../../components/static/GeoBreadcrumb.astro';
+// GeoBreadcrumb is now integrated into the Header component
 
 import TimelineSection from '../../components/islands/TimelineSection';
 import IntelMapLoader from '../../components/islands/IntelMapLoader';
@@ -94,30 +94,15 @@ const faqSchema = {
 
   <!-- Desktop layout -->
   <div class="desktop-layout">
-    <Header meta={data.meta} navSections={config.navSections} trackerSlug={config.slug} globeEnabled={config.globe?.enabled} statusLabel={statusLabel} />
+    <Header meta={data.meta} navSections={config.navSections} trackerSlug={config.slug} globeEnabled={config.globe?.enabled} statusLabel={statusLabel} dayCount={data.meta.dayCount} headline={data.meta.heroHeadline} geoPath={config.geoPath} region={config.region} country={config.country ? countryName(config.country) : undefined} state={config.state} city={config.city} neighborhood={config.neighborhood} />
     <main id="main-content">
-      <GeoBreadcrumb
-        geoPath={config.geoPath}
-        region={config.region}
-        country={config.country ? countryName(config.country) : undefined}
-        state={config.state}
-        city={config.city}
-        neighborhood={config.neighborhood}
-      />
+      <HeroKpiCombo kpis={data.kpis} />
 
-      <!-- SEO intro section -->
-      <div class="tracker-intro">
+      <!-- SEO-only intro (visually hidden, crawlable) -->
+      <div class="sr-only">
         <p>{config.description}</p>
-        {latestDigest && (
-          <p class="tracker-latest-update">Latest: {latestDigest.summary?.slice(0, 150)}{(latestDigest.summary?.length ?? 0) > 150 ? '...' : ''}</p>
-        )}
-        <span class="tracker-meta-line">
-          Last updated {data.meta.lastUpdated ? new Date(data.meta.lastUpdated).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : 'recently'}
-          &middot; {eventCount} events tracked since {config.startDate}
-        </span>
+        <span>Last updated {data.meta.lastUpdated ? new Date(data.meta.lastUpdated).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : 'recently'} &middot; {eventCount} events tracked since {config.startDate}</span>
       </div>
-
-      <HeroKpiCombo meta={data.meta} kpis={data.kpis} />
 
       <!-- Server-rendered event previews for SEO crawlability -->
       <div class="seo-event-previews">
@@ -185,26 +170,16 @@ const faqSchema = {
 </BaseLayout>
 
 <style>
-  .tracker-intro {
-    max-width: 900px;
-    margin: 0 auto;
-    padding: 0.75rem 1rem;
-  }
-  .tracker-intro p {
-    font-family: 'DM Sans', sans-serif;
-    font-size: 0.82rem;
-    color: var(--text-secondary);
-    line-height: 1.6;
-    margin: 0 0 0.3rem;
-  }
-  .tracker-latest-update {
-    font-style: italic;
-    opacity: 0.8;
-  }
-  .tracker-meta-line {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.65rem;
-    color: var(--text-muted);
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .seo-event-previews {

--- a/src/pages/es/[tracker]/index.astro
+++ b/src/pages/es/[tracker]/index.astro
@@ -57,9 +57,9 @@ const statusLabel = `${temporalLabel} ${domainLabel}`;
 >
   <!-- Desktop layout -->
   <div class="desktop-layout">
-    <Header meta={data.meta} navSections={config.navSections} trackerSlug={config.slug} globeEnabled={config.globe?.enabled} statusLabel={statusLabel} />
+    <Header meta={data.meta} navSections={config.navSections} trackerSlug={config.slug} globeEnabled={config.globe?.enabled} statusLabel={statusLabel} dayCount={data.meta.dayCount} headline={data.meta.heroHeadline} />
     <main id="main-content">
-      <HeroKpiCombo meta={data.meta} kpis={data.kpis} />
+      <HeroKpiCombo kpis={data.kpis} />
 
       <div class="theater-layout">
         {config.sections.includes('map') && (

--- a/src/pages/fr/[tracker]/index.astro
+++ b/src/pages/fr/[tracker]/index.astro
@@ -57,9 +57,9 @@ const statusLabel = `${temporalLabel} ${domainLabel}`;
 >
   <!-- Desktop layout -->
   <div class="desktop-layout">
-    <Header meta={data.meta} navSections={config.navSections} trackerSlug={config.slug} globeEnabled={config.globe?.enabled} statusLabel={statusLabel} />
+    <Header meta={data.meta} navSections={config.navSections} trackerSlug={config.slug} globeEnabled={config.globe?.enabled} statusLabel={statusLabel} dayCount={data.meta.dayCount} headline={data.meta.heroHeadline} />
     <main id="main-content">
-      <HeroKpiCombo meta={data.meta} kpis={data.kpis} />
+      <HeroKpiCombo kpis={data.kpis} />
 
       <div class="theater-layout">
         {config.sections.includes('map') && (

--- a/src/pages/pt/[tracker]/index.astro
+++ b/src/pages/pt/[tracker]/index.astro
@@ -57,9 +57,9 @@ const statusLabel = `${temporalLabel} ${domainLabel}`;
 >
   <!-- Desktop layout -->
   <div class="desktop-layout">
-    <Header meta={data.meta} navSections={config.navSections} trackerSlug={config.slug} globeEnabled={config.globe?.enabled} statusLabel={statusLabel} />
+    <Header meta={data.meta} navSections={config.navSections} trackerSlug={config.slug} globeEnabled={config.globe?.enabled} statusLabel={statusLabel} dayCount={data.meta.dayCount} headline={data.meta.heroHeadline} />
     <main id="main-content">
-      <HeroKpiCombo meta={data.meta} kpis={data.kpis} />
+      <HeroKpiCombo kpis={data.kpis} />
 
       <div class="theater-layout">
         {config.sections.includes('map') && (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -160,13 +160,61 @@ body::before {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 56px;
+  height: 48px;
 }
 
 .header-left {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.header-identity {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.header-daycount {
+  font-weight: 400;
+  color: var(--accent-amber);
+  margin-left: 0.4rem;
+  font-size: 0.62rem;
+}
+
+.header-geo {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 0.58rem;
+  line-height: 1;
+  margin-top: 1px;
+}
+.header-geo .geo-sep { color: var(--text-muted); font-size: 0.5rem; }
+.header-geo .geo-link {
+  color: var(--accent-blue, #58a6ff);
+  text-decoration: none;
+  transition: opacity 0.15s;
+}
+.header-geo .geo-link:hover { opacity: 0.8; text-decoration: underline; }
+
+.header-headline-bar {
+  max-width: 1600px;
+  margin: 0 auto;
+  padding: 0 0 4px;
+  overflow: hidden;
+}
+.header-headline-text {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
 }
 
 .home-link {
@@ -333,18 +381,31 @@ body::before {
   .header-inner {
     position: relative;
     padding: 0 0.75rem;
+    height: 40px;
   }
 
   .site-header {
-    padding: 0 0.75rem;
+    padding: 0 0.5rem;
   }
 
   .header-title {
-    font-size: 0.6rem;
+    font-size: 0.58rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 60vw;
+    max-width: 55vw;
+  }
+
+  .header-geo {
+    display: none;
+  }
+
+  .header-headline-bar {
+    padding: 0 0.5rem 2px;
+  }
+
+  .header-headline-text {
+    font-size: 0.72rem;
   }
 }
 
@@ -506,69 +567,33 @@ body::before {
 }
 
 /* ─── HERO + KPI COMBO ─── */
-.hero-kpi-combo {
-  display: flex;
-  align-items: center;
-  padding: 8px 20px;
+/* ─── KPI TICKER ─── */
+.kpi-ticker {
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border);
-  gap: 16px;
-  min-height: 50px;
-}
-
-.hero-kpi-left {
-  flex: 1;
-  min-width: 0;
   overflow: hidden;
 }
 
-.hero-kpi-dateline {
-  font-size: 0.55rem;
-  color: var(--accent-red);
-  font-family: 'JetBrains Mono', monospace;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  margin-bottom: 2px;
-}
-
-.hero-kpi-dateline-dash {
-  color: var(--accent-red);
-  margin-right: 0.5rem;
-}
-
-.hero-kpi-headline {
-  font-family: 'Cormorant Garamond', serif;
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--text-primary);
-  line-height: 1.2;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.hero-kpi-divider {
-  width: 1px;
-  height: 32px;
-  background: var(--border);
-  flex-shrink: 0;
-}
-
-.hero-kpi-right {
+.kpi-ticker-track {
   display: flex;
-  gap: 14px;
   align-items: baseline;
-  flex-shrink: 0;
+  gap: 16px;
+  padding: 6px 20px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
+.kpi-ticker-track::-webkit-scrollbar { display: none; }
 
-.hero-kpi-item {
-  text-align: center;
+.kpi-ticker-item {
   display: flex;
   flex-direction: column;
   align-items: center;
+  text-align: center;
+  flex-shrink: 0;
 }
 
-.hero-kpi-label {
+.kpi-ticker-label {
   font-size: 0.42rem;
   color: var(--text-muted);
   font-family: 'JetBrains Mono', monospace;
@@ -577,30 +602,35 @@ body::before {
   white-space: nowrap;
 }
 
-.hero-kpi-value {
+.kpi-ticker-value {
   font-family: 'Cormorant Garamond', serif;
-  font-size: 1.15rem;
+  font-size: 1.1rem;
   font-weight: 700;
   line-height: 1;
   white-space: nowrap;
 }
 
-.hero-kpi-value.red { color: var(--accent-red); }
-.hero-kpi-value.amber { color: var(--accent-amber); }
-.hero-kpi-value.blue { color: var(--accent-blue); }
-.hero-kpi-value.green { color: var(--accent-green); }
+.kpi-ticker-value.red { color: var(--accent-red); }
+.kpi-ticker-value.amber { color: var(--accent-amber); }
+.kpi-ticker-value.blue { color: var(--accent-blue); }
+.kpi-ticker-value.green { color: var(--accent-green); }
 
-.hero-kpi-trend { font-size: 0.55rem; margin-left: 2px; }
-.hero-kpi-trend.up { color: var(--accent-red); }
-.hero-kpi-trend.down { color: var(--accent-green); }
+.kpi-ticker-trend { font-size: 0.55rem; margin-left: 2px; }
+.kpi-ticker-trend.up { color: var(--accent-red); }
+.kpi-ticker-trend.down { color: var(--accent-green); }
 
 @media (max-width: 1024px) {
-  .hero-kpi-right { gap: 10px; }
-  .hero-kpi-value { font-size: 1rem; }
+  .kpi-ticker-value { font-size: 1rem; }
+  .kpi-ticker-track { gap: 12px; }
 }
 
 @media (max-width: 768px) {
-  .hero-kpi-combo { display: none; }
+  .kpi-ticker-track {
+    gap: 10px;
+    padding: 4px 12px;
+  }
+  .kpi-ticker-value { font-size: 0.9rem; }
+  .kpi-ticker-label { font-size: 0.38rem; }
 }
 
 /* ─── LATEST EVENTS ─── */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -160,61 +160,13 @@ body::before {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 48px;
+  height: 56px;
 }
 
 .header-left {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  min-width: 0;
-}
-
-.header-identity {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-}
-
-.header-daycount {
-  font-weight: 400;
-  color: var(--accent-amber);
-  margin-left: 0.4rem;
-  font-size: 0.62rem;
-}
-
-.header-geo {
-  display: flex;
-  align-items: center;
-  gap: 3px;
-  font-family: 'DM Sans', sans-serif;
-  font-size: 0.58rem;
-  line-height: 1;
-  margin-top: 1px;
-}
-.header-geo .geo-sep { color: var(--text-muted); font-size: 0.5rem; }
-.header-geo .geo-link {
-  color: var(--accent-blue, #58a6ff);
-  text-decoration: none;
-  transition: opacity 0.15s;
-}
-.header-geo .geo-link:hover { opacity: 0.8; text-decoration: underline; }
-
-.header-headline-bar {
-  max-width: 1600px;
-  margin: 0 auto;
-  padding: 0 0 4px;
-  overflow: hidden;
-}
-.header-headline-text {
-  font-family: 'Cormorant Garamond', serif;
-  font-size: 0.82rem;
-  font-weight: 600;
-  color: var(--text-secondary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: block;
+  gap: 0.6rem;
 }
 
 .home-link {
@@ -381,31 +333,18 @@ body::before {
   .header-inner {
     position: relative;
     padding: 0 0.75rem;
-    height: 40px;
   }
 
   .site-header {
-    padding: 0 0.5rem;
+    padding: 0 0.75rem;
   }
 
   .header-title {
-    font-size: 0.58rem;
+    font-size: 0.6rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 55vw;
-  }
-
-  .header-geo {
-    display: none;
-  }
-
-  .header-headline-bar {
-    padding: 0 0.5rem 2px;
-  }
-
-  .header-headline-text {
-    font-size: 0.72rem;
+    max-width: 60vw;
   }
 }
 
@@ -567,33 +506,69 @@ body::before {
 }
 
 /* ─── HERO + KPI COMBO ─── */
-/* ─── KPI TICKER ─── */
-.kpi-ticker {
+.hero-kpi-combo {
+  display: flex;
+  align-items: center;
+  padding: 8px 20px;
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border);
+  gap: 16px;
+  min-height: 50px;
+}
+
+.hero-kpi-left {
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
 }
 
-.kpi-ticker-track {
-  display: flex;
-  align-items: baseline;
-  gap: 16px;
-  padding: 6px 20px;
-  overflow-x: auto;
-  scrollbar-width: none;
-  -ms-overflow-style: none;
+.hero-kpi-dateline {
+  font-size: 0.55rem;
+  color: var(--accent-red);
+  font-family: 'JetBrains Mono', monospace;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: 2px;
 }
-.kpi-ticker-track::-webkit-scrollbar { display: none; }
 
-.kpi-ticker-item {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
+.hero-kpi-dateline-dash {
+  color: var(--accent-red);
+  margin-right: 0.5rem;
+}
+
+.hero-kpi-headline {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hero-kpi-divider {
+  width: 1px;
+  height: 32px;
+  background: var(--border);
   flex-shrink: 0;
 }
 
-.kpi-ticker-label {
+.hero-kpi-right {
+  display: flex;
+  gap: 14px;
+  align-items: baseline;
+  flex-shrink: 0;
+}
+
+.hero-kpi-item {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.hero-kpi-label {
   font-size: 0.42rem;
   color: var(--text-muted);
   font-family: 'JetBrains Mono', monospace;
@@ -602,35 +577,30 @@ body::before {
   white-space: nowrap;
 }
 
-.kpi-ticker-value {
+.hero-kpi-value {
   font-family: 'Cormorant Garamond', serif;
-  font-size: 1.1rem;
+  font-size: 1.15rem;
   font-weight: 700;
   line-height: 1;
   white-space: nowrap;
 }
 
-.kpi-ticker-value.red { color: var(--accent-red); }
-.kpi-ticker-value.amber { color: var(--accent-amber); }
-.kpi-ticker-value.blue { color: var(--accent-blue); }
-.kpi-ticker-value.green { color: var(--accent-green); }
+.hero-kpi-value.red { color: var(--accent-red); }
+.hero-kpi-value.amber { color: var(--accent-amber); }
+.hero-kpi-value.blue { color: var(--accent-blue); }
+.hero-kpi-value.green { color: var(--accent-green); }
 
-.kpi-ticker-trend { font-size: 0.55rem; margin-left: 2px; }
-.kpi-ticker-trend.up { color: var(--accent-red); }
-.kpi-ticker-trend.down { color: var(--accent-green); }
+.hero-kpi-trend { font-size: 0.55rem; margin-left: 2px; }
+.hero-kpi-trend.up { color: var(--accent-red); }
+.hero-kpi-trend.down { color: var(--accent-green); }
 
 @media (max-width: 1024px) {
-  .kpi-ticker-value { font-size: 1rem; }
-  .kpi-ticker-track { gap: 12px; }
+  .hero-kpi-right { gap: 10px; }
+  .hero-kpi-value { font-size: 1rem; }
 }
 
 @media (max-width: 768px) {
-  .kpi-ticker-track {
-    gap: 10px;
-    padding: 4px 12px;
-  }
-  .kpi-ticker-value { font-size: 0.9rem; }
-  .kpi-ticker-label { font-size: 0.38rem; }
+  .hero-kpi-combo { display: none; }
 }
 
 /* ─── LATEST EVENTS ─── */


### PR DESCRIPTION
Redesigns tracker 2D pages to feel like an app instead of a content page.

**Changes:**
- Header integrates headline as subtitle (no separate hero)
- HeroKpiCombo → compact horizontal KPI strip
- tracker-intro section removed (description moved to about page)
- Map visible within first viewport on mobile
- Desktop layout preserved
- i18n pages (es/fr/pt) updated

**Goal:** User sees data (map, KPIs, events) immediately, not a wall of text.