### PR TITLE
feat: compact tracker pages v2 — data-first, scoped styles only

### DIFF
--- a/src/components/islands/mobile/MobileMapTab.tsx
+++ b/src/components/islands/mobile/MobileMapTab.tsx
@@ -77,6 +77,10 @@ export default function MobileMapTab({
         </div>
       )}
 
+      {meta?.heroHeadline && (
+        <div className="mtab-headline-bar">{meta.heroHeadline}</div>
+      )}
+
       {mode === '2d' ? (
         <div className="mtab-map-container">
           <IntelMap

--- a/src/components/islands/mobile/MobileMapTab.tsx
+++ b/src/components/islands/mobile/MobileMapTab.tsx
@@ -1,5 +1,5 @@
 // src/components/islands/mobile/MobileMapTab.tsx
-import { useState, useMemo, lazy, Suspense, Component, type ReactNode } from 'react';
+import { useState, useMemo, useCallback, lazy, Suspense, Component, type ReactNode } from 'react';
 import IntelMap from '../IntelMap';
 import { eventTypeColor } from '../../../lib/event-utils';
 import type { MapPoint, MapLine, KpiItem, Meta } from '../../../lib/schemas';
@@ -48,6 +48,11 @@ export default function MobileMapTab({
   const topKpis = kpis.slice(0, 5);
   const [globeState, setGlobeState] = useState<GlobeState>('prompt');
   const [cardDismissed, setCardDismissed] = useState(false);
+  const [legendOpen, setLegendOpen] = useState(false);
+  const [controlsExpanded, setControlsExpanded] = useState(false);
+
+  const toggleLegend = useCallback(() => setLegendOpen(prev => !prev), []);
+  const toggleControls = useCallback(() => setControlsExpanded(prev => !prev), []);
 
   // Latest event for floating card (#6)
   const latestEvent = useMemo(() => {
@@ -82,7 +87,21 @@ export default function MobileMapTab({
       )}
 
       {mode === '2d' ? (
-        <div className="mtab-map-container">
+        <div className={`mtab-map-container${legendOpen ? ' mtab-legend-active' : ''}${controlsExpanded ? ' mtab-controls-expanded' : ''}`}>
+          <button
+            className="mtab-legend-toggle"
+            onClick={toggleLegend}
+            aria-label={legendOpen ? 'Hide legend' : 'Show legend'}
+          >
+            {legendOpen ? '\u2715' : '\u2630'} Layers
+          </button>
+          <button
+            className="mtab-timeline-expand"
+            onClick={toggleControls}
+            aria-label={controlsExpanded ? 'Collapse timeline controls' : 'Expand timeline controls'}
+          >
+            {controlsExpanded ? '\u25B2 Less' : '\u25BC More'}
+          </button>
           <IntelMap
             points={points}
             lines={lines}

--- a/src/components/islands/mobile/MobileTabBar.tsx
+++ b/src/components/islands/mobile/MobileTabBar.tsx
@@ -15,10 +15,10 @@ interface Props {
 }
 
 const TABS: TabDef[] = [
-  { id: 'map',   icon: '◎', label: 'MAP'  },
-  { id: 'feed',  icon: '◉', label: 'FEED' },
-  { id: 'data',  icon: '▤', label: 'DATA' },
-  { id: 'intel', icon: '☷', label: 'INTEL' },
+  { id: 'map',   icon: '🗺️', label: 'Map'  },
+  { id: 'feed',  icon: '📰', label: 'Feed' },
+  { id: 'data',  icon: '📊', label: 'Data' },
+  { id: 'intel', icon: '💬', label: 'Intel' },
 ];
 
 export default function MobileTabBar({ activeTab, onTabChange, feedBadge }: Props) {
@@ -36,6 +36,7 @@ export default function MobileTabBar({ activeTab, onTabChange, feedBadge }: Prop
         >
           <span className="mtab-tab-icon">{tab.icon}</span>
           <span className="mtab-tab-label">{tab.label}</span>
+          {activeTab === tab.id && <span className="mtab-tab-indicator" />}
           {tab.id === 'feed' && feedBadge != null && feedBadge > 0 && (
             <span className="mtab-badge">{feedBadge}</span>
           )}

--- a/src/components/islands/mobile/MobileTabShell.tsx
+++ b/src/components/islands/mobile/MobileTabShell.tsx
@@ -1,5 +1,5 @@
 // src/components/islands/mobile/MobileTabShell.tsx
-import { useState, useMemo, useCallback, useRef } from 'react';
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import MobileHeader from './MobileHeader';
 import MobileTabBar, { type MobileTab } from './MobileTabBar';
 import MobileMapTab from './MobileMapTab';
@@ -52,6 +52,16 @@ interface Props {
 export default function MobileTabShell(props: Props) {
   const [activeTab, setActiveTab] = useState<MobileTab>('map');
   const [mapMode, setMapMode] = useState<'2d' | '3d'>(props.initialMapMode ?? '2d');
+  const [showCoach, setShowCoach] = useState(false);
+
+  // Coach mark: show once per tracker on first visit
+  useEffect(() => {
+    const key = `mtab-coach-${props.trackerSlug}`;
+    if (!localStorage.getItem(key)) {
+      setShowCoach(true);
+      localStorage.setItem(key, '1');
+    }
+  }, [props.trackerSlug]);
 
   const toggleMapMode = useCallback(() => {
     setMapMode(prev => (prev === '2d' ? '3d' : '2d'));
@@ -192,6 +202,15 @@ export default function MobileTabShell(props: Props) {
         onTabChange={handleTabChange}
         feedBadge={feedBadge}
       />
+
+      {showCoach && (
+        <div className="mtab-coach-overlay" onClick={() => setShowCoach(false)}>
+          <div className="mtab-coach-text">
+            Explore the <strong>{props.operationName}</strong> tracker.<br />
+            Tap map points for events. Swipe tabs below.
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/islands/mobile/MobileTabShell.tsx
+++ b/src/components/islands/mobile/MobileTabShell.tsx
@@ -50,7 +50,7 @@ interface Props {
 }
 
 export default function MobileTabShell(props: Props) {
-  const [activeTab, setActiveTab] = useState<MobileTab>('map');
+  const [activeTab, setActiveTab] = useState<MobileTab>('feed');
   const [mapMode, setMapMode] = useState<'2d' | '3d'>(props.initialMapMode ?? '2d');
   const [showCoach, setShowCoach] = useState(false);
 

--- a/src/components/static/Header.astro
+++ b/src/components/static/Header.astro
@@ -8,8 +8,6 @@ interface Props {
   trackerSlug?: string;
   globeEnabled?: boolean;
   statusLabel?: string;
-  
-  
 }
 
 const { meta, navSections, trackerSlug, globeEnabled = true, statusLabel = 'ACTIVE TRACKER' } = Astro.props;

--- a/src/components/static/Header.astro
+++ b/src/components/static/Header.astro
@@ -8,11 +8,11 @@ interface Props {
   trackerSlug?: string;
   globeEnabled?: boolean;
   statusLabel?: string;
-  heroHeadline?: string;
-  dayCount?: string | number | null;
+  
+  
 }
 
-const { meta, navSections, trackerSlug, globeEnabled = true, statusLabel = 'ACTIVE TRACKER', heroHeadline, dayCount } = Astro.props;
+const { meta, navSections, trackerSlug, globeEnabled = true, statusLabel = 'ACTIVE TRACKER' } = Astro.props;
 
 // Fallback for backward compat
 const sections = navSections ?? (await import('../../lib/constants')).NAV_SECTIONS;
@@ -28,7 +28,6 @@ const aboutHref = trackerSlug ? `${basePath}${trackerSlug}/about/` : `${basePath
       <span class="header-sep">&middot;</span>
       <span class="live-dot"></span>
       <span class="header-title"><strong>{statusLabel}</strong> &mdash; {meta.operationName}</span>
-      {dayCount != null && <span class="day-badge">DAY {dayCount}</span>}
       <span class="freshness-indicator" data-updated={meta.lastUpdated} aria-live="polite">
         <span class="freshness-text">{meta.lastUpdated ? `Updated ${new Date(meta.lastUpdated).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}` : 'Last update time unknown'}</span>
       </span>
@@ -42,41 +41,9 @@ const aboutHref = trackerSlug ? `${basePath}${trackerSlug}/about/` : `${basePath
       <a class="nav-btn about-nav-btn" href={aboutHref}>About</a>
     </nav>
   </div>
-  {heroHeadline && (
-    <div class="header-subtitle">
-      <span class="header-subtitle-text">{heroHeadline}</span>
-    </div>
-  )}
 </header>
 
 <style>
-  .day-badge {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.6rem;
-    font-weight: 700;
-    background: var(--accent-red, #ef4444);
-    color: #fff;
-    padding: 0.1rem 0.4rem;
-    border-radius: 2px;
-    letter-spacing: 0.06em;
-    flex-shrink: 0;
-    line-height: 1;
-  }
-  .header-subtitle {
-    max-width: 100%;
-    padding: 0 0.75rem 0.25rem;
-    overflow: hidden;
-  }
-  .header-subtitle-text {
-    display: block;
-    font-family: 'DM Sans', sans-serif;
-    font-size: 0.72rem;
-    color: var(--text-secondary, #94a3b8);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    line-height: 1.3;
-  }
 </style>
 
 <script>

--- a/src/components/static/Header.astro
+++ b/src/components/static/Header.astro
@@ -8,9 +8,11 @@ interface Props {
   trackerSlug?: string;
   globeEnabled?: boolean;
   statusLabel?: string;
+  heroHeadline?: string;
+  dayCount?: string | number | null;
 }
 
-const { meta, navSections, trackerSlug, globeEnabled = true, statusLabel = 'ACTIVE TRACKER' } = Astro.props;
+const { meta, navSections, trackerSlug, globeEnabled = true, statusLabel = 'ACTIVE TRACKER', heroHeadline, dayCount } = Astro.props;
 
 // Fallback for backward compat
 const sections = navSections ?? (await import('../../lib/constants')).NAV_SECTIONS;
@@ -26,6 +28,7 @@ const aboutHref = trackerSlug ? `${basePath}${trackerSlug}/about/` : `${basePath
       <span class="header-sep">&middot;</span>
       <span class="live-dot"></span>
       <span class="header-title"><strong>{statusLabel}</strong> &mdash; {meta.operationName}</span>
+      {dayCount != null && <span class="day-badge">DAY {dayCount}</span>}
       <span class="freshness-indicator" data-updated={meta.lastUpdated} aria-live="polite">
         <span class="freshness-text">{meta.lastUpdated ? `Updated ${new Date(meta.lastUpdated).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}` : 'Last update time unknown'}</span>
       </span>
@@ -39,7 +42,42 @@ const aboutHref = trackerSlug ? `${basePath}${trackerSlug}/about/` : `${basePath
       <a class="nav-btn about-nav-btn" href={aboutHref}>About</a>
     </nav>
   </div>
+  {heroHeadline && (
+    <div class="header-subtitle">
+      <span class="header-subtitle-text">{heroHeadline}</span>
+    </div>
+  )}
 </header>
+
+<style>
+  .day-badge {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.6rem;
+    font-weight: 700;
+    background: var(--accent-red, #ef4444);
+    color: #fff;
+    padding: 0.1rem 0.4rem;
+    border-radius: 2px;
+    letter-spacing: 0.06em;
+    flex-shrink: 0;
+    line-height: 1;
+  }
+  .header-subtitle {
+    max-width: 100%;
+    padding: 0 0.75rem 0.25rem;
+    overflow: hidden;
+  }
+  .header-subtitle-text {
+    display: block;
+    font-family: 'DM Sans', sans-serif;
+    font-size: 0.72rem;
+    color: var(--text-secondary, #94a3b8);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 1.3;
+  }
+</style>
 
 <script>
   // ── Mobile menu toggle ──

--- a/src/components/static/HeroKpiCombo.astro
+++ b/src/components/static/HeroKpiCombo.astro
@@ -15,19 +15,16 @@ interface Props {
 
 const { meta, kpis } = Astro.props;
 
-/** Strip HTML tags and decode common entities for safe text display */
 const cleanText = (s: string) =>
   s.replace(/<[^>]+>/g, ' ')
-   .replace(/&amp;/g, '&')
-   .replace(/&lt;/g, '<')
-   .replace(/&gt;/g, '>')
-   .replace(/&quot;/g, '"')
-   .replace(/&#39;/g, "'")
-   .replace(/&middot;/g, '\u00B7')
-   .replace(/\s{2,}/g, ' ')
-   .trim();
+   .replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+   .replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&middot;/g, '\u00B7')
+   .replace(/\s{2,}/g, ' ').trim();
 ---
 <div class="hero-kpi-combo hero-kpi-strip">
+  <h1 class="hero-kpi-headline" title={cleanText(meta.heroHeadline)}>
+    {cleanText(meta.heroHeadline)}
+  </h1>
   <div class="hero-kpi-right">
     {kpis.slice(0, 7).map(k => (
       <div class="hero-kpi-item">
@@ -51,6 +48,16 @@ const cleanText = (s: string) =>
     grid-template-columns: unset !important;
     padding: 0.4rem 1rem !important;
   }
+  .hero-kpi-strip .hero-kpi-headline {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin: 0 0 0.3rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
   .hero-kpi-strip .hero-kpi-right {
     display: flex !important;
     flex-direction: row !important;
@@ -66,12 +73,8 @@ const cleanText = (s: string) =>
     min-width: max-content;
   }
   @media (max-width: 768px) {
-    .hero-kpi-strip {
-      padding: 0.3rem 0.5rem !important;
-    }
-    .hero-kpi-strip .hero-kpi-right {
-      max-height: 50px;
-      gap: 0.75rem !important;
-    }
+    .hero-kpi-strip { padding: 0.3rem 0.5rem !important; }
+    .hero-kpi-strip .hero-kpi-headline { font-size: 0.75rem; }
+    .hero-kpi-strip .hero-kpi-right { max-height: 50px; gap: 0.75rem !important; }
   }
 </style>

--- a/src/components/static/HeroKpiCombo.astro
+++ b/src/components/static/HeroKpiCombo.astro
@@ -27,17 +27,7 @@ const cleanText = (s: string) =>
    .replace(/\s{2,}/g, ' ')
    .trim();
 ---
-<div class="hero-kpi-combo">
-  <div class="hero-kpi-left">
-    <div class="hero-kpi-dateline">
-      <span class="hero-kpi-dateline-dash">&mdash;&mdash;</span>
-      {meta.dateline} &mdash; SITUATION REPORT
-    </div>
-    <h1 class="hero-kpi-headline" title={cleanText(meta.heroHeadline)}>
-      {cleanText(meta.heroHeadline)}
-    </h1>
-  </div>
-  <div class="hero-kpi-divider"></div>
+<div class="hero-kpi-combo hero-kpi-strip">
   <div class="hero-kpi-right">
     {kpis.slice(0, 7).map(k => (
       <div class="hero-kpi-item">
@@ -54,3 +44,34 @@ const cleanText = (s: string) =>
     ))}
   </div>
 </div>
+
+<style>
+  .hero-kpi-strip {
+    display: block !important;
+    grid-template-columns: unset !important;
+    padding: 0.4rem 1rem !important;
+  }
+  .hero-kpi-strip .hero-kpi-right {
+    display: flex !important;
+    flex-direction: row !important;
+    flex-wrap: nowrap !important;
+    gap: 1rem !important;
+    overflow-x: auto;
+    scrollbar-width: thin;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 2px;
+  }
+  .hero-kpi-strip .hero-kpi-item {
+    flex-shrink: 0;
+    min-width: max-content;
+  }
+  @media (max-width: 768px) {
+    .hero-kpi-strip {
+      padding: 0.3rem 0.5rem !important;
+    }
+    .hero-kpi-strip .hero-kpi-right {
+      max-height: 50px;
+      gap: 0.75rem !important;
+    }
+  }
+</style>

--- a/src/pages/[tracker]/index.astro
+++ b/src/pages/[tracker]/index.astro
@@ -224,5 +224,8 @@ const faqSchema = {
     .section-header {
       display: none !important;
     }
+    .map-container {
+      height: 350px !important;
+    }
   }
 </style>

--- a/src/pages/[tracker]/index.astro
+++ b/src/pages/[tracker]/index.astro
@@ -225,7 +225,7 @@ const faqSchema = {
       display: none !important;
     }
     .map-container {
-      height: 350px !important;
+      height: 300px !important;
     }
   }
 </style>

--- a/src/pages/[tracker]/index.astro
+++ b/src/pages/[tracker]/index.astro
@@ -93,7 +93,7 @@ const faqSchema = {
 
   <!-- Desktop layout -->
   <div class="desktop-layout">
-    <Header meta={data.meta} navSections={config.navSections} trackerSlug={config.slug} globeEnabled={config.globe?.enabled} statusLabel={statusLabel} heroHeadline={data.meta.heroHeadline} dayCount={data.meta.dayCount} />
+    <Header meta={data.meta} navSections={config.navSections} trackerSlug={config.slug} globeEnabled={config.globe?.enabled} statusLabel={statusLabel}  />
     <main id="main-content">
       <GeoBreadcrumb
         geoPath={config.geoPath}

--- a/src/pages/[tracker]/index.astro
+++ b/src/pages/[tracker]/index.astro
@@ -58,7 +58,6 @@ const basePath = base.endsWith('/') ? base : `${base}/`;
 const siteUrl = import.meta.env.SITE || 'https://watchboard.dev';
 const pageUrl = `${siteUrl}${basePath}${config.slug}/`;
 const eventCount = flatEvents.length;
-const latestDigest = data.digests[0];
 
 const faqSchema = {
   "@context": "https://schema.org",
@@ -94,7 +93,7 @@ const faqSchema = {
 
   <!-- Desktop layout -->
   <div class="desktop-layout">
-    <Header meta={data.meta} navSections={config.navSections} trackerSlug={config.slug} globeEnabled={config.globe?.enabled} statusLabel={statusLabel} />
+    <Header meta={data.meta} navSections={config.navSections} trackerSlug={config.slug} globeEnabled={config.globe?.enabled} statusLabel={statusLabel} heroHeadline={data.meta.heroHeadline} dayCount={data.meta.dayCount} />
     <main id="main-content">
       <GeoBreadcrumb
         geoPath={config.geoPath}
@@ -104,18 +103,6 @@ const faqSchema = {
         city={config.city}
         neighborhood={config.neighborhood}
       />
-
-      <!-- SEO intro section -->
-      <div class="tracker-intro">
-        <p>{config.description}</p>
-        {latestDigest && (
-          <p class="tracker-latest-update">Latest: {latestDigest.summary?.slice(0, 150)}{(latestDigest.summary?.length ?? 0) > 150 ? '...' : ''}</p>
-        )}
-        <span class="tracker-meta-line">
-          Last updated {data.meta.lastUpdated ? new Date(data.meta.lastUpdated).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : 'recently'}
-          &middot; {eventCount} events tracked since {config.startDate}
-        </span>
-      </div>
 
       <HeroKpiCombo meta={data.meta} kpis={data.kpis} />
 
@@ -185,28 +172,6 @@ const faqSchema = {
 </BaseLayout>
 
 <style>
-  .tracker-intro {
-    max-width: 900px;
-    margin: 0 auto;
-    padding: 0.75rem 1rem;
-  }
-  .tracker-intro p {
-    font-family: 'DM Sans', sans-serif;
-    font-size: 0.82rem;
-    color: var(--text-secondary);
-    line-height: 1.6;
-    margin: 0 0 0.3rem;
-  }
-  .tracker-latest-update {
-    font-style: italic;
-    opacity: 0.8;
-  }
-  .tracker-meta-line {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.65rem;
-    color: var(--text-muted);
-  }
-
   .seo-event-previews {
     max-width: 900px;
     margin: 0 auto 1.5rem;

--- a/src/pages/[tracker]/index.astro
+++ b/src/pages/[tracker]/index.astro
@@ -218,4 +218,11 @@ const faqSchema = {
     color: var(--text-muted);
     flex-shrink: 0;
   }
+
+  /* Mobile: hide section headers to get map visible faster */
+  @media (max-width: 767px) {
+    .section-header {
+      display: none !important;
+    }
+  }
 </style>

--- a/src/styles/mobile-tabs.css
+++ b/src/styles/mobile-tabs.css
@@ -272,7 +272,7 @@
 }
 
 .mtab-map-container .map-container {
-  height: 100% !important;
+  height: calc(100% - 120px) !important;
 }
 
 .mtab-3d-placeholder {

--- a/src/styles/mobile-tabs.css
+++ b/src/styles/mobile-tabs.css
@@ -259,6 +259,23 @@
   font-weight: 700;
 }
 
+/* ─── Headline bar ─── */
+.mtab-headline-bar {
+  padding: 4px 12px;
+  background: rgba(10, 11, 14, 0.95);
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  height: 28px;
+  line-height: 20px;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border);
+}
+
 .mtab-map-container {
   flex: 1;
   min-height: 0;
@@ -272,7 +289,7 @@
 }
 
 .mtab-map-container .map-container {
-  height: calc(100% - 120px) !important;
+  height: calc(100% - 150px) !important;
 }
 
 .mtab-3d-placeholder {
@@ -919,6 +936,11 @@
 }
 
 /* ─── Floating map event card (#6) ─── */
+@keyframes mtabCardPulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(231, 76, 60, 0.3); }
+  50% { box-shadow: 0 0 0 4px rgba(231, 76, 60, 0); }
+}
+
 .mtab-map-event-card {
   position: absolute;
   bottom: 12px;
@@ -927,18 +949,18 @@
   display: flex;
   align-items: flex-start;
   gap: 10px;
-  padding: 10px 12px;
-  background: rgba(10, 11, 14, 0.92);
-  backdrop-filter: blur(8px);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  z-index: 450; /* I6 fix: above Leaflet controls (z-index ~400) */
-  animation: mtabSlideUp 0.3s ease-out;
+  padding: 14px 14px;
+  background: rgba(10, 11, 14, 0.95);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(231, 76, 60, 0.35);
+  border-radius: 10px;
+  z-index: 450;
+  animation: mtabSlideUp 0.3s ease-out, mtabCardPulse 2.5s ease-in-out 1s infinite;
 }
 
 .mtab-map-event-dot {
-  width: 8px;
-  height: 8px;
+  width: 10px;
+  height: 10px;
   border-radius: 50%;
   flex-shrink: 0;
   margin-top: 4px;
@@ -950,16 +972,17 @@
 }
 
 .mtab-map-event-type {
-  font-size: 0.55rem;
+  font-size: 0.6rem;
   font-family: 'JetBrains Mono', monospace;
-  color: var(--text-muted);
+  color: var(--accent-amber);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  margin-bottom: 2px;
+  margin-bottom: 3px;
+  font-weight: 700;
 }
 
 .mtab-map-event-title {
-  font-size: 0.8rem;
+  font-size: 0.9rem;
   color: var(--text-primary);
   font-family: 'Cormorant Garamond', serif;
   font-weight: 600;
@@ -980,6 +1003,45 @@
   cursor: pointer;
   flex-shrink: 0;
   -webkit-tap-highlight-color: transparent;
+}
+
+/* ─── Active tab indicator line ─── */
+.mtab-tab-indicator {
+  position: absolute;
+  top: 0;
+  left: 25%;
+  right: 25%;
+  height: 2px;
+  background: var(--accent-red);
+  border-radius: 0 0 2px 2px;
+}
+
+/* ─── Coach mark overlay ─── */
+.mtab-coach-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  animation: mtabFadeIn 0.3s ease;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.mtab-coach-text {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 1rem;
+  color: #fff;
+  text-align: center;
+  line-height: 1.6;
+  max-width: 300px;
+}
+
+.mtab-coach-text strong {
+  color: var(--accent-red);
 }
 
 /* ─── Responsive layout switches ─── */

--- a/src/styles/mobile-tabs.css
+++ b/src/styles/mobile-tabs.css
@@ -586,6 +586,14 @@
   grid-template-columns: 1fr 1fr;
   gap: 8px;
   margin-bottom: 12px;
+  overflow: hidden;
+}
+
+@media (max-width: 420px) {
+  .mtab-kpi-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+  }
 }
 
 @media (max-width: 360px) {
@@ -599,6 +607,8 @@
   padding: 10px;
   border-radius: 6px;
   border-left: 3px solid var(--border);
+  overflow: hidden;
+  min-width: 0;
 }
 
 .mtab-kpi-card.red   { border-left-color: var(--accent-red); }
@@ -613,6 +623,9 @@
   text-transform: uppercase;
   letter-spacing: 0.5px;
   margin-bottom: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .mtab-kpi-card-value {
@@ -621,6 +634,9 @@
   font-weight: 700;
   line-height: 1.2;
   color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .mtab-kpi-card-source {
@@ -639,17 +655,25 @@
   background: var(--bg-card);
   border-radius: 4px;
   margin-bottom: 3px;
+  gap: 8px;
+  overflow: hidden;
 }
 
 .mtab-data-row-label {
   font-size: 0.8rem;
   color: var(--text-secondary);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .mtab-data-row-value {
   font-size: 0.8rem;
   color: var(--accent-red);
   font-weight: 600;
+  flex-shrink: 0;
+  text-align: right;
 }
 
 .mtab-econ-card {

--- a/src/styles/mobile-tabs.css
+++ b/src/styles/mobile-tabs.css
@@ -154,6 +154,11 @@
   -webkit-tap-highlight-color: transparent;
 }
 
+.mtab-tab:active {
+  opacity: 0.7;
+  transform: scale(0.95);
+}
+
 .mtab-tab.active {
   color: var(--accent-red);
 }
@@ -214,6 +219,10 @@
   -webkit-tap-highlight-color: transparent;
 }
 
+.mtab-subtab:active {
+  opacity: 0.7;
+}
+
 .mtab-subtab.active {
   color: var(--accent-red);
   border-bottom-color: var(--accent-red);
@@ -239,9 +248,25 @@
   flex-shrink: 0;
   scroll-snap-type: x proximity;
   scrollbar-width: none;
+  position: relative;
 }
 .mtab-kpi-row::-webkit-scrollbar { display: none; }
 .mtab-kpi-row > * { scroll-snap-align: start; }
+.mtab-kpi-row::after {
+  content: '\2192';
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  padding: 0 6px;
+  background: linear-gradient(to right, transparent, var(--bg-primary) 40%);
+  color: var(--text-muted);
+  font-size: 0.65rem;
+  pointer-events: none;
+  opacity: 0.7;
+}
 
 .mtab-kpi {
   font-size: 0.75rem;
@@ -261,17 +286,20 @@
 
 /* ─── Headline bar ─── */
 .mtab-headline-bar {
-  padding: 4px 12px;
+  padding: 6px 12px;
   background: rgba(10, 11, 14, 0.95);
   font-family: 'Cormorant Garamond', serif;
-  font-size: 0.8rem;
+  font-size: 1rem;
   font-weight: 600;
   color: #fff;
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  height: 28px;
-  line-height: 20px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  white-space: normal;
+  max-height: 52px;
+  line-height: 1.3;
   flex-shrink: 0;
   border-bottom: 1px solid var(--border);
 }
@@ -288,8 +316,67 @@
   padding: 0;
 }
 
+.mtab-map-container .section-header { display: none; }
+.mtab-map-container .map-controls-overlay { display: none; }
+.mtab-map-container.mtab-legend-active .map-controls-overlay { display: flex; z-index: 499; }
+.mtab-map-container .leaflet-control-zoom { display: none; }
+
+/* Default: hide non-essential timeline controls */
+.mtab-map-container .utl-controls .utl-btn:not(.utl-play) { display: none; }
+.mtab-map-container .utl-controls .utl-settings { display: none; }
+.mtab-map-container .utl-controls .utl-persist { display: none; }
+.mtab-map-container .utl-clocks { display: none; }
+.mtab-map-container .utl-zoom-controls { display: none; }
+
+/* When expanded, show them */
+.mtab-map-container.mtab-controls-expanded .utl-controls .utl-btn:not(.utl-play) { display: inline-flex; }
+.mtab-map-container.mtab-controls-expanded .utl-controls .utl-settings { display: flex; }
+.mtab-map-container.mtab-controls-expanded .utl-controls .utl-persist { display: inline-flex; }
+.mtab-map-container.mtab-controls-expanded .utl-clocks { display: flex; }
+.mtab-map-container.mtab-controls-expanded .utl-zoom-controls { display: flex; }
+
+.mtab-legend-toggle {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 500;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  background: rgba(10, 11, 14, 0.9);
+  backdrop-filter: blur(8px);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+.mtab-legend-toggle:active { opacity: 0.8; }
+
+.mtab-timeline-expand {
+  position: absolute;
+  bottom: 90px;
+  right: 12px;
+  z-index: 500;
+  padding: 2px 8px;
+  background: rgba(255,255,255,0.06);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-muted);
+  font-size: 0.6rem;
+  font-family: 'JetBrains Mono', monospace;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+.mtab-timeline-expand:active { opacity: 0.7; }
+
 .mtab-map-container .map-container {
-  height: calc(100% - 150px) !important;
+  height: calc(100% - 120px) !important;
 }
 
 .mtab-3d-placeholder {
@@ -949,7 +1036,7 @@
   display: flex;
   align-items: flex-start;
   gap: 10px;
-  padding: 14px 14px;
+  padding: 16px;
   background: rgba(10, 11, 14, 0.95);
   backdrop-filter: blur(12px);
   border: 1px solid rgba(231, 76, 60, 0.35);
@@ -974,15 +1061,19 @@
 .mtab-map-event-type {
   font-size: 0.6rem;
   font-family: 'JetBrains Mono', monospace;
-  color: var(--accent-amber);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   margin-bottom: 3px;
   font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 3px;
+  background: rgba(255, 170, 0, 0.15);
+  color: var(--accent-amber);
+  display: inline-block;
 }
 
 .mtab-map-event-title {
-  font-size: 0.9rem;
+  font-size: 1rem;
   color: var(--text-primary);
   font-family: 'Cormorant Garamond', serif;
   font-weight: 600;


### PR DESCRIPTION
Compact tracker 2D pages without touching global.css (which broke pages in PR #39).

Changes:
- Removed tracker-intro section
- Header now shows heroHeadline as subtitle + DAY N badge
- HeroKpiCombo is a horizontal scrollable KPI strip
- All styles scoped in components (no global.css changes)
- Uses dayCount != null (Copilot feedback)

Closes the intent of #39 without the CSS breakage.