### PR TITLE
feat: ingesta pipeline fix + images everywhere

### DIFF
--- a/.github/workflows/hourly-scan.yml
+++ b/.github/workflows/hourly-scan.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     outputs:
-      has_actions: ${{ steps.triage.outputs.has_actions || steps.triage-defaults.outputs.has_actions || 'false' }}
-      plan_json: ${{ steps.triage.outputs.plan_json || steps.triage-defaults.outputs.plan_json || '[]' }}
+      has_actions: ${{ steps.freshness.outputs.has_actions || steps.triage.outputs.has_actions || steps.triage-defaults.outputs.has_actions || 'false' }}
+      plan_json: ${{ steps.freshness.outputs.plan_json || steps.triage.outputs.plan_json || steps.triage-defaults.outputs.plan_json || '[]' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -135,6 +135,74 @@ jobs:
             echo "has_actions=false" >> "$GITHUB_OUTPUT"
             echo "plan_json=[]" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Freshness check — inject stale trackers
+        id: freshness
+        run: |
+          node -e "
+            const fs = require('fs');
+            const path = require('path');
+            const NOW = Date.now();
+            const STALE_MS = 36 * 60 * 60 * 1000; // 36 hours
+
+            // Read existing plan (from triage or empty)
+            let plan = [];
+            try {
+              const raw = fs.readFileSync('/tmp/hourly-action-plan.json', 'utf8');
+              const parsed = JSON.parse(raw);
+              plan = parsed.updates || [];
+            } catch {}
+            const alreadyTracked = new Set(plan.map(u => u.tracker));
+
+            const staleAdded = [];
+            for (const slug of fs.readdirSync('trackers')) {
+              const configPath = path.join('trackers', slug, 'tracker.json');
+              if (!fs.existsSync(configPath)) continue;
+              const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+
+              // Only active, non-historical trackers
+              if (config.status !== 'active') continue;
+              if (config.temporal === 'historical') continue;
+              if (alreadyTracked.has(slug)) continue;
+
+              // Check lastUpdated from meta.json
+              const metaPath = path.join('trackers', slug, 'data', 'meta.json');
+              if (!fs.existsSync(metaPath)) continue;
+              const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+              const lastUpdated = meta.lastUpdated ? new Date(meta.lastUpdated).getTime() : 0;
+              const ageDays = ((NOW - lastUpdated) / 86400000).toFixed(1);
+
+              if (NOW - lastUpdated > STALE_MS) {
+                staleAdded.push(slug);
+                console.log('Stale tracker: ' + slug + ' (last updated ' + ageDays + 'd ago)');
+              }
+            }
+
+            if (staleAdded.length === 0) {
+              console.log('No stale trackers found');
+              process.exit(0);
+            }
+
+            // Read current triage output or parse from GITHUB_OUTPUT
+            let hasActions = '${{ steps.triage.outputs.has_actions }}' === 'true';
+            let entries = [];
+            try {
+              entries = JSON.parse('${{ steps.triage.outputs.plan_json }}');
+            } catch { entries = []; }
+
+            for (const slug of staleAdded) {
+              entries.push({ type: 'update', tracker: slug, data: JSON.stringify({
+                tracker: slug,
+                events: [{ summary: 'Freshness refresh — no updates in 36+ hours', sources: [], timestamp: new Date().toISOString() }]
+              })});
+            }
+
+            // Write updated outputs
+            const outputFile = process.env.GITHUB_OUTPUT;
+            fs.appendFileSync(outputFile, 'has_actions=true\n');
+            fs.appendFileSync(outputFile, 'plan_json=' + JSON.stringify(entries) + '\n');
+            console.log('Added ' + staleAdded.length + ' stale trackers to plan: ' + staleAdded.join(', '));
+          "
 
       - name: Commit state
         env:

--- a/.github/workflows/hourly-scan.yml
+++ b/.github/workflows/hourly-scan.yml
@@ -118,7 +118,8 @@ jobs:
         run: |
           if [ -f /tmp/hourly-action-plan.json ]; then
             node -e "
-              const plan = JSON.parse(require('fs').readFileSync('/tmp/hourly-action-plan.json','utf8'));
+              const fs = require('fs');
+              const plan = JSON.parse(fs.readFileSync('/tmp/hourly-action-plan.json','utf8'));
               const hasActions = plan.updates.length > 0 || plan.newTrackers.length > 0;
               console.log('has_actions=' + hasActions);
 
@@ -130,10 +131,12 @@ jobs:
                 entries.push({ type: 'new_tracker', tracker: nt.suggestedSlug, data: JSON.stringify(nt) });
               }
               console.log('plan_json=' + JSON.stringify(entries));
+              fs.writeFileSync('/tmp/triage-plan.json', JSON.stringify(entries));
             " >> "$GITHUB_OUTPUT"
           else
             echo "has_actions=false" >> "$GITHUB_OUTPUT"
             echo "plan_json=[]" >> "$GITHUB_OUTPUT"
+            echo "[]" > /tmp/triage-plan.json
           fi
 
       - name: Freshness check — inject stale trackers
@@ -187,7 +190,8 @@ jobs:
             let hasActions = '${{ steps.triage.outputs.has_actions }}' === 'true';
             let entries = [];
             try {
-              entries = JSON.parse('${{ steps.triage.outputs.plan_json }}');
+              const raw = fs.readFileSync('/tmp/triage-plan.json', 'utf8');
+              entries = JSON.parse(raw);
             } catch { entries = []; }
 
             for (const slug of staleAdded) {
@@ -222,8 +226,16 @@ jobs:
             done
           fi
 
+      - name: Ensure action plan artifact exists
+        if: steps.freshness.outputs.has_actions == 'true' || steps.triage.outputs.has_actions == 'true'
+        run: |
+          if [ ! -f /tmp/hourly-action-plan.json ]; then
+            echo '{"updates":[],"newTrackers":[],"scannedAt":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","candidateCount":0,"discardedCount":0}' > /tmp/hourly-action-plan.json
+            echo "Created default hourly-action-plan.json for freshness-only run"
+          fi
+
       - name: Upload action plan
-        if: steps.triage.outputs.has_actions == 'true'
+        if: steps.freshness.outputs.has_actions == 'true' || steps.triage.outputs.has_actions == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: hourly-action-plan

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -88,7 +88,7 @@ jobs:
                 LAST_EPOCH=$(date -d "$LAST_RUN" +%s 2>/dev/null || echo 0)
                 ELAPSED_DAYS=$(( (NOW_EPOCH - LAST_EPOCH) / 86400 ))
                 if [ "$ELAPSED_DAYS" -lt "$INTERVAL" ]; then
-                  echo "Skipping $SLUG: updated ${ELAPSED_DAYS}d ago, interval is ${INTERVAL}d"
+                  echo "Skipping $SLUG: updated ${ELAPSED_DAYS}d ago, interval is ${INTERVAL}d (escalation policy, last run: $LAST_RUN)"
                   continue
                 fi
               fi
@@ -275,14 +275,17 @@ jobs:
             - Add map-points.json entries for new locations
             - Validate coordinates within tracker's coordValidation bounds
 
-            STEP 3.5 — EVENT MEDIA (for each new or updated event):
-            For significant events, add a `media` array with 1-2 items:
-            - Search for news article URLs with photos covering the event
-            - Add media items: { "type": "image", "url": "<article-url>", "caption": "<brief description>", "source": "<outlet-name>", "thumbnail": "<direct-image-url-if-available>" }
+            STEP 3.5 — EVENT MEDIA (MANDATORY for each new or updated event):
+            Every event MUST have a `media` array with at least 1 item containing a thumbnail URL.
+            For each event:
+            - Search for a news article or image URL covering the event
+            - Add media items: { "type": "image", "url": "<article-url>", "caption": "<brief description>", "source": "<outlet-name>", "thumbnail": "<direct-image-url>" }
+            - ALWAYS search for and include a `thumbnail` URL (the direct og:image or photo URL from the article)
             - Prefer Tier 1-2 sources (Reuters, AP, BBC, CNN, Al Jazeera) for image reliability
-            - The `url` field can be the article URL; `thumbnail` should be the direct og:image URL if findable
-            - If no good image source exists, omit the media array entirely (don't add empty arrays)
+            - The `url` field should be the article URL; `thumbnail` MUST be the direct image URL
+            - If you absolutely cannot find any image after searching multiple sources, use the article URL as thumbnail
             - NEVER fabricate or guess image URLs — only use URLs you verified exist
+            - Do NOT skip media — trackers without images look broken in the UI
 
             STEP 4 — UPDATE LOG:
             After updating, write trackers/${{ matrix.slug }}/data/update-log.json with:

--- a/public/sw.js
+++ b/public/sw.js
@@ -147,17 +147,24 @@ self.addEventListener('push', event => {
     };
   }
 
-  const { title, body, icon, url, tag, tracker } = payload;
+  const { title, body, icon, image, url, tag, tracker } = payload;
+
+  const notificationOptions = {
+    body: body || '',
+    icon: icon || '/icons/icon-192.png',
+    badge: '/icons/icon-192.png',
+    tag: tag || `wb-${tracker || 'update'}-${Date.now()}`,
+    data: { url: url || '/' },
+    vibrate: [200, 100, 200],
+  };
+
+  // Add image if available (shows large image in notification on supported platforms)
+  if (image) {
+    notificationOptions.image = image;
+  }
 
   event.waitUntil(
-    self.registration.showNotification(title || 'Watchboard', {
-      body: body || '',
-      icon: icon || '/icons/icon-192.png',
-      badge: '/icons/icon-192.png',
-      tag: tag || `wb-${tracker || 'update'}-${Date.now()}`,
-      data: { url: url || '/' },
-      vibrate: [200, 100, 200],
-    })
+    self.registration.showNotification(title || 'Watchboard', notificationOptions)
   );
 });
 

--- a/src/components/islands/CesiumGlobe/GlobeMobileSheet.tsx
+++ b/src/components/islands/CesiumGlobe/GlobeMobileSheet.tsx
@@ -613,6 +613,7 @@ function MissionCompact({
 function MobileEventCard({ event, isActive }: { event: FlatEvent; isActive: boolean }) {
   const [expanded, setExpanded] = useState(false);
   const thumb = event.media?.find(m => m.thumbnail)?.thumbnail;
+  const [imgFailed, setImgFailed] = useState(false);
 
   return (
     <div className={`mobile-event-card${isActive ? ' active' : ''}`}>
@@ -620,13 +621,13 @@ function MobileEventCard({ event, isActive }: { event: FlatEvent; isActive: bool
         className="mobile-event-card-header"
         onClick={() => setExpanded(prev => !prev)}
       >
-        {thumb ? (
+        {thumb && !imgFailed ? (
           <img
             className="mobile-event-card-thumb"
             src={thumb}
             alt=""
             referrerPolicy="no-referrer"
-            onError={e => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
+            onError={() => setImgFailed(true)}
           />
         ) : (
           <span

--- a/src/components/islands/CesiumGlobe/GlobeMobileSheet.tsx
+++ b/src/components/islands/CesiumGlobe/GlobeMobileSheet.tsx
@@ -612,6 +612,7 @@ function MissionCompact({
 /** Compact mobile event card */
 function MobileEventCard({ event, isActive }: { event: FlatEvent; isActive: boolean }) {
   const [expanded, setExpanded] = useState(false);
+  const thumb = event.media?.find(m => m.thumbnail)?.thumbnail;
 
   return (
     <div className={`mobile-event-card${isActive ? ' active' : ''}`}>
@@ -619,10 +620,20 @@ function MobileEventCard({ event, isActive }: { event: FlatEvent; isActive: bool
         className="mobile-event-card-header"
         onClick={() => setExpanded(prev => !prev)}
       >
-        <span
-          className="mobile-event-type-dot"
-          style={{ background: TYPE_COLORS[event.type] || '#888' }}
-        />
+        {thumb ? (
+          <img
+            className="mobile-event-card-thumb"
+            src={thumb}
+            alt=""
+            referrerPolicy="no-referrer"
+            onError={e => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
+          />
+        ) : (
+          <span
+            className="mobile-event-type-dot"
+            style={{ background: TYPE_COLORS[event.type] || '#888' }}
+          />
+        )}
         <span className="mobile-event-title">{event.title}</span>
         <span className="mobile-event-expand">{expanded ? '\u2212' : '+'}</span>
       </button>

--- a/src/components/islands/mobile/MobileFeedTab.tsx
+++ b/src/components/islands/mobile/MobileFeedTab.tsx
@@ -147,23 +147,46 @@ export default function MobileFeedTab({ heroSubtitle, events }: Props) {
                 {dayEvents.length} event{dayEvents.length !== 1 ? 's' : ''}
               </span>
             </div>
-            {dayEvents.map(ev => (
-              <button
-                key={ev.id}
-                className="mtab-event-card"
-                style={{ borderLeftColor: eventTypeColor(ev.type) }}
-                onClick={() => handleEventTap(ev)}
-                aria-label={ev.title}
-              >
-                <div className="mtab-event-header">
-                  <span className="mtab-event-type">{ev.type}</span>
-                  <span className="mtab-event-time" suppressHydrationWarning>
-                    {relativeTime(ev.resolvedDate)}
-                  </span>
-                </div>
-                <div className="mtab-event-title">{ev.title}</div>
-              </button>
-            ))}
+            {dayEvents.map(ev => {
+              const thumb = ev.media?.find(m => m.thumbnail)?.thumbnail;
+              return (
+                <button
+                  key={ev.id}
+                  className="mtab-event-card"
+                  style={{ borderLeftColor: eventTypeColor(ev.type) }}
+                  onClick={() => handleEventTap(ev)}
+                  aria-label={ev.title}
+                >
+                  <div className="mtab-event-card-row">
+                    {thumb ? (
+                      <img
+                        className="mtab-event-thumb"
+                        src={thumb}
+                        alt=""
+                        referrerPolicy="no-referrer"
+                        onError={e => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
+                      />
+                    ) : (
+                      <div
+                        className="mtab-event-thumb-fallback"
+                        style={{ borderColor: eventTypeColor(ev.type) }}
+                      >
+                        <span className="mtab-event-thumb-icon">{ev.type.charAt(0).toUpperCase()}</span>
+                      </div>
+                    )}
+                    <div className="mtab-event-card-content">
+                      <div className="mtab-event-header">
+                        <span className="mtab-event-type">{ev.type}</span>
+                        <span className="mtab-event-time" suppressHydrationWarning>
+                          {relativeTime(ev.resolvedDate)}
+                        </span>
+                      </div>
+                      <div className="mtab-event-title">{ev.title}</div>
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
           </div>
         );
       })}

--- a/src/components/islands/mobile/MobileFeedTab.tsx
+++ b/src/components/islands/mobile/MobileFeedTab.tsx
@@ -147,46 +147,9 @@ export default function MobileFeedTab({ heroSubtitle, events }: Props) {
                 {dayEvents.length} event{dayEvents.length !== 1 ? 's' : ''}
               </span>
             </div>
-            {dayEvents.map(ev => {
-              const thumb = ev.media?.find(m => m.thumbnail)?.thumbnail;
-              return (
-                <button
-                  key={ev.id}
-                  className="mtab-event-card"
-                  style={{ borderLeftColor: eventTypeColor(ev.type) }}
-                  onClick={() => handleEventTap(ev)}
-                  aria-label={ev.title}
-                >
-                  <div className="mtab-event-card-row">
-                    {thumb ? (
-                      <img
-                        className="mtab-event-thumb"
-                        src={thumb}
-                        alt=""
-                        referrerPolicy="no-referrer"
-                        onError={e => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
-                      />
-                    ) : (
-                      <div
-                        className="mtab-event-thumb-fallback"
-                        style={{ borderColor: eventTypeColor(ev.type) }}
-                      >
-                        <span className="mtab-event-thumb-icon">{ev.type.charAt(0).toUpperCase()}</span>
-                      </div>
-                    )}
-                    <div className="mtab-event-card-content">
-                      <div className="mtab-event-header">
-                        <span className="mtab-event-type">{ev.type}</span>
-                        <span className="mtab-event-time" suppressHydrationWarning>
-                          {relativeTime(ev.resolvedDate)}
-                        </span>
-                      </div>
-                      <div className="mtab-event-title">{ev.title}</div>
-                    </div>
-                  </div>
-                </button>
-              );
-            })}
+            {dayEvents.map(ev => (
+              <FeedEventCard key={ev.id} event={ev} onTap={handleEventTap} />
+            ))}
           </div>
         );
       })}
@@ -263,5 +226,47 @@ export default function MobileFeedTab({ heroSubtitle, events }: Props) {
         </div>
       )}
     </div>
+  );
+}
+
+function FeedEventCard({ event: ev, onTap }: { event: FlatEvent; onTap: (ev: FlatEvent) => void }) {
+  const thumb = ev.media?.find(m => m.thumbnail)?.thumbnail;
+  const [imgFailed, setImgFailed] = useState(false);
+
+  return (
+    <button
+      className="mtab-event-card"
+      style={{ borderLeftColor: eventTypeColor(ev.type) }}
+      onClick={() => onTap(ev)}
+      aria-label={ev.title}
+    >
+      <div className="mtab-event-card-row">
+        {thumb && !imgFailed ? (
+          <img
+            className="mtab-event-thumb"
+            src={thumb}
+            alt=""
+            referrerPolicy="no-referrer"
+            onError={() => setImgFailed(true)}
+          />
+        ) : (
+          <div
+            className="mtab-event-thumb-fallback"
+            style={{ borderColor: eventTypeColor(ev.type) }}
+          >
+            <span className="mtab-event-thumb-icon">{ev.type.charAt(0).toUpperCase()}</span>
+          </div>
+        )}
+        <div className="mtab-event-card-content">
+          <div className="mtab-event-header">
+            <span className="mtab-event-type">{ev.type}</span>
+            <span className="mtab-event-time" suppressHydrationWarning>
+              {relativeTime(ev.resolvedDate)}
+            </span>
+          </div>
+          <div className="mtab-event-title">{ev.title}</div>
+        </div>
+      </div>
+    </button>
   );
 }

--- a/src/components/islands/mobile/MobileMapTab.tsx
+++ b/src/components/islands/mobile/MobileMapTab.tsx
@@ -172,7 +172,20 @@ export default function MobileMapTab({
       {/* Floating latest event card (#6) */}
       {latestEvent && !cardDismissed && (
         <div className="mtab-map-event-card">
-          <div className="mtab-map-event-dot" style={{ background: eventTypeColor(latestEvent.type) }} />
+          {(() => {
+            const thumb = latestEvent.media?.find(m => m.thumbnail)?.thumbnail;
+            return thumb ? (
+              <img
+                className="mtab-map-event-thumb"
+                src={thumb}
+                alt=""
+                referrerPolicy="no-referrer"
+                onError={e => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
+              />
+            ) : (
+              <div className="mtab-map-event-dot" style={{ background: eventTypeColor(latestEvent.type) }} />
+            );
+          })()}
           <div className="mtab-map-event-body">
             <div className="mtab-map-event-type">{latestEvent.type}</div>
             <div className="mtab-map-event-title">{latestEvent.title}</div>

--- a/src/components/islands/mobile/MobileMapTab.tsx
+++ b/src/components/islands/mobile/MobileMapTab.tsx
@@ -1,5 +1,5 @@
 // src/components/islands/mobile/MobileMapTab.tsx
-import { useState, useMemo, useCallback, lazy, Suspense, Component, type ReactNode } from 'react';
+import { useState, useMemo, useCallback, lazy, Suspense, Component, type ReactNode, type CSSProperties } from 'react';
 import IntelMap from '../IntelMap';
 import { eventTypeColor } from '../../../lib/event-utils';
 import type { MapPoint, MapLine, KpiItem, Meta } from '../../../lib/schemas';
@@ -171,34 +171,40 @@ export default function MobileMapTab({
 
       {/* Floating latest event card (#6) */}
       {latestEvent && !cardDismissed && (
-        <div className="mtab-map-event-card">
-          {(() => {
-            const thumb = latestEvent.media?.find(m => m.thumbnail)?.thumbnail;
-            return thumb ? (
-              <img
-                className="mtab-map-event-thumb"
-                src={thumb}
-                alt=""
-                referrerPolicy="no-referrer"
-                onError={e => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
-              />
-            ) : (
-              <div className="mtab-map-event-dot" style={{ background: eventTypeColor(latestEvent.type) }} />
-            );
-          })()}
-          <div className="mtab-map-event-body">
-            <div className="mtab-map-event-type">{latestEvent.type}</div>
-            <div className="mtab-map-event-title">{latestEvent.title}</div>
-          </div>
-          <button
-            className="mtab-map-event-dismiss"
-            onClick={() => setCardDismissed(true)}
-            aria-label="Dismiss"
-          >
-            ✕
-          </button>
-        </div>
+        <MapEventCard event={latestEvent} onDismiss={() => setCardDismissed(true)} />
       )}
+    </div>
+  );
+}
+
+function MapEventCard({ event, onDismiss }: { event: FlatEvent; onDismiss: () => void }) {
+  const thumb = event.media?.find(m => m.thumbnail)?.thumbnail;
+  const [imgFailed, setImgFailed] = useState(false);
+
+  return (
+    <div className="mtab-map-event-card">
+      {thumb && !imgFailed ? (
+        <img
+          className="mtab-map-event-thumb"
+          src={thumb}
+          alt=""
+          referrerPolicy="no-referrer"
+          onError={() => setImgFailed(true)}
+        />
+      ) : (
+        <div className="mtab-map-event-dot" style={{ background: eventTypeColor(event.type) }} />
+      )}
+      <div className="mtab-map-event-body">
+        <div className="mtab-map-event-type">{event.type}</div>
+        <div className="mtab-map-event-title">{event.title}</div>
+      </div>
+      <button
+        className="mtab-map-event-dismiss"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+      >
+        ✕
+      </button>
     </div>
   );
 }

--- a/src/styles/mobile-tabs.css
+++ b/src/styles/mobile-tabs.css
@@ -938,6 +938,64 @@
   letter-spacing: 0.5px;
 }
 
+/* ─── Event card thumbnail layout ─── */
+.mtab-event-card-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.mtab-event-card-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.mtab-event-thumb {
+  width: 60px;
+  height: 60px;
+  object-fit: cover;
+  border-radius: 6px;
+  flex-shrink: 0;
+}
+
+.mtab-event-thumb-fallback {
+  width: 60px;
+  height: 60px;
+  border-radius: 6px;
+  flex-shrink: 0;
+  background: linear-gradient(135deg, rgba(255,255,255,0.06) 0%, rgba(255,255,255,0.02) 100%);
+  border: 1px solid rgba(255,255,255,0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mtab-event-thumb-icon {
+  font-size: 1.1rem;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--text-muted);
+  opacity: 0.7;
+}
+
+/* ─── Map tab floating card thumbnail ─── */
+.mtab-map-event-thumb {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border-radius: 6px;
+  flex-shrink: 0;
+}
+
+/* ─── Globe mobile sheet event card thumbnail ─── */
+.mobile-event-card-thumb {
+  width: 60px;
+  height: 60px;
+  object-fit: cover;
+  border-radius: 6px;
+  flex-shrink: 0;
+}
+
 /* ─── Bottom sheet (#3) ─── */
 .mtab-sheet-backdrop {
   position: fixed;

--- a/trackers/afghanistan-pakistan-war/tracker.json
+++ b/trackers/afghanistan-pakistan-war/tracker.json
@@ -233,12 +233,12 @@
     },
     "updatePolicy": {
       "escalation": [
-        3,
+        1,
+        1,
         3,
         7,
         14,
-        30,
-        60
+        30
       ],
       "quietThreshold": 0
     }

--- a/trackers/artemis-2/tracker.json
+++ b/trackers/artemis-2/tracker.json
@@ -199,12 +199,12 @@
     },
     "updatePolicy": {
       "escalation": [
-        3,
+        1,
+        1,
         3,
         7,
         14,
-        30,
-        60
+        30
       ],
       "quietThreshold": 0
     }

--- a/trackers/bad-bunny/tracker.json
+++ b/trackers/bad-bunny/tracker.json
@@ -145,12 +145,12 @@
     },
     "updatePolicy": {
       "escalation": [
-        3,
+        1,
+        1,
         3,
         7,
         14,
-        30,
-        60
+        30
       ],
       "quietThreshold": 0
     }

--- a/trackers/bts/tracker.json
+++ b/trackers/bts/tracker.json
@@ -146,12 +146,12 @@
     },
     "updatePolicy": {
       "escalation": [
-        3,
+        1,
+        1,
         3,
         7,
         14,
-        30,
-        60
+        30
       ],
       "quietThreshold": 0
     }

--- a/trackers/china-tech-revolution/tracker.json
+++ b/trackers/china-tech-revolution/tracker.json
@@ -194,12 +194,12 @@
     },
     "updatePolicy": {
       "escalation": [
-        3,
+        1,
+        1,
         3,
         7,
         14,
-        30,
-        60
+        30
       ],
       "quietThreshold": 0
     }

--- a/trackers/global-recession-risk/tracker.json
+++ b/trackers/global-recession-risk/tracker.json
@@ -165,12 +165,12 @@
     },
     "updatePolicy": {
       "escalation": [
-        3,
+        1,
+        1,
         3,
         7,
         14,
-        30,
-        60
+        30
       ],
       "quietThreshold": 0
     }

--- a/trackers/haiti-collapse/tracker.json
+++ b/trackers/haiti-collapse/tracker.json
@@ -198,12 +198,12 @@
     },
     "updatePolicy": {
       "escalation": [
-        3,
+        1,
+        1,
         3,
         7,
         14,
-        30,
-        60
+        30
       ],
       "quietThreshold": 0
     }

--- a/trackers/ice-history/tracker.json
+++ b/trackers/ice-history/tracker.json
@@ -191,12 +191,12 @@
     },
     "updatePolicy": {
       "escalation": [
-        3,
+        1,
+        1,
         3,
         7,
         14,
-        30,
-        60
+        30
       ],
       "quietThreshold": 0
     }

--- a/trackers/india-pakistan-conflict/tracker.json
+++ b/trackers/india-pakistan-conflict/tracker.json
@@ -229,12 +229,12 @@
     },
     "updatePolicy": {
       "escalation": [
-        3,
+        1,
+        1,
         3,
         7,
         14,
-        30,
-        60
+        30
       ],
       "quietThreshold": 0
     }

--- a/trackers/myanmar-civil-war/tracker.json
+++ b/trackers/myanmar-civil-war/tracker.json
@@ -226,12 +226,12 @@
     },
     "updatePolicy": {
       "escalation": [
-        3,
+        1,
+        1,
         3,
         7,
         14,
-        30,
-        60
+        30
       ],
       "quietThreshold": 0
     }

--- a/trackers/nato-us-tensions/tracker.json
+++ b/trackers/nato-us-tensions/tracker.json
@@ -186,12 +186,12 @@
     },
     "updatePolicy": {
       "escalation": [
-        3,
+        1,
+        1,
         3,
         7,
         14,
-        30,
-        60
+        30
       ],
       "quietThreshold": 0
     }

--- a/trackers/october-7-attack/tracker.json
+++ b/trackers/october-7-attack/tracker.json
@@ -239,12 +239,12 @@
     },
     "updatePolicy": {
       "escalation": [
-        3,
+        1,
+        1,
         3,
         7,
         14,
-        30,
-        60
+        30
       ],
       "quietThreshold": 0
     }

--- a/trackers/sahel-insurgency/tracker.json
+++ b/trackers/sahel-insurgency/tracker.json
@@ -230,12 +230,12 @@
     },
     "updatePolicy": {
       "escalation": [
-        3,
+        1,
+        1,
         3,
         7,
         14,
-        30,
-        60
+        30
       ],
       "quietThreshold": 0
     }

--- a/trackers/sheinbaum-presidency/tracker.json
+++ b/trackers/sheinbaum-presidency/tracker.json
@@ -183,12 +183,12 @@
     },
     "updatePolicy": {
       "escalation": [
-        3,
+        1,
+        1,
         3,
         7,
         14,
-        30,
-        60
+        30
       ],
       "quietThreshold": 0
     }

--- a/trackers/somalia-conflict/tracker.json
+++ b/trackers/somalia-conflict/tracker.json
@@ -233,12 +233,12 @@
     },
     "updatePolicy": {
       "escalation": [
-        3,
+        1,
+        1,
         3,
         7,
         14,
-        30,
-        60
+        30
       ],
       "quietThreshold": 0
     }

--- a/trackers/southeast-asia-escalation/tracker.json
+++ b/trackers/southeast-asia-escalation/tracker.json
@@ -233,12 +233,12 @@
     },
     "updatePolicy": {
       "escalation": [
-        3,
+        1,
+        1,
         3,
         7,
         14,
-        30,
-        60
+        30
       ],
       "quietThreshold": 0
     }

--- a/trackers/spacex-history/tracker.json
+++ b/trackers/spacex-history/tracker.json
@@ -181,12 +181,12 @@
     },
     "updatePolicy": {
       "escalation": [
-        3,
+        1,
+        1,
         3,
         7,
         14,
-        30,
-        60
+        30
       ],
       "quietThreshold": 0
     }

--- a/worker/handlers/cron.ts
+++ b/worker/handlers/cron.ts
@@ -36,24 +36,33 @@ function parseRssItems(xml: string): RssItem[] {
   return items;
 }
 
+function decodeXmlEntities(url: string): string {
+  return url
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'");
+}
+
 function extractImageUrl(description: string, fullItemXml?: string): string | null {
   // 1. Check for media:content or media:thumbnail in the raw XML
   if (fullItemXml) {
     const mediaMatch = fullItemXml.match(/<media:(?:content|thumbnail)[^>]+url=["']([^"']+)["']/i);
-    if (mediaMatch) return mediaMatch[1];
+    if (mediaMatch) return decodeXmlEntities(mediaMatch[1]);
   }
 
   // 2. Check for <img> tag in description
   const imgMatch = description.match(/<img[^>]+src=["']([^"']+)["']/i);
-  if (imgMatch) return imgMatch[1];
+  if (imgMatch) return decodeXmlEntities(imgMatch[1]);
 
   // 3. Check for <enclosure> with image type in raw XML
   if (fullItemXml) {
     const enclosureMatch = fullItemXml.match(/<enclosure[^>]+type=["']image\/[^"']+["'][^>]+url=["']([^"']+)["']/i);
-    if (enclosureMatch) return enclosureMatch[1];
+    if (enclosureMatch) return decodeXmlEntities(enclosureMatch[1]);
     // Also try url before type
     const enclosureMatch2 = fullItemXml.match(/<enclosure[^>]+url=["']([^"']+)["'][^>]+type=["']image\/[^"']+["']/i);
-    if (enclosureMatch2) return enclosureMatch2[1];
+    if (enclosureMatch2) return decodeXmlEntities(enclosureMatch2[1]);
   }
 
   return null;

--- a/worker/handlers/cron.ts
+++ b/worker/handlers/cron.ts
@@ -8,6 +8,7 @@ interface RssItem {
   description: string;
   category: string;
   pubDate: string;
+  image: string | null;
 }
 
 function parseRssItems(xml: string): RssItem[] {
@@ -20,16 +21,42 @@ function parseRssItems(xml: string): RssItem[] {
       const m = content.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`));
       return m ? m[1].replace(/<!\\[CDATA\\[|\\]\\]>/g, '').trim() : '';
     };
+    const rawDescription = get('description');
+    const imageUrl = extractImageUrl(rawDescription, content);
     items.push({
       title: get('title'),
       link: get('link'),
       guid: get('guid'),
-      description: get('description').slice(0, 200),
+      description: rawDescription.slice(0, 200),
       category: get('category') || 'daily',
       pubDate: get('pubDate'),
+      image: imageUrl,
     });
   }
   return items;
+}
+
+function extractImageUrl(description: string, fullItemXml?: string): string | null {
+  // 1. Check for media:content or media:thumbnail in the raw XML
+  if (fullItemXml) {
+    const mediaMatch = fullItemXml.match(/<media:(?:content|thumbnail)[^>]+url=["']([^"']+)["']/i);
+    if (mediaMatch) return mediaMatch[1];
+  }
+
+  // 2. Check for <img> tag in description
+  const imgMatch = description.match(/<img[^>]+src=["']([^"']+)["']/i);
+  if (imgMatch) return imgMatch[1];
+
+  // 3. Check for <enclosure> with image type in raw XML
+  if (fullItemXml) {
+    const enclosureMatch = fullItemXml.match(/<enclosure[^>]+type=["']image\/[^"']+["'][^>]+url=["']([^"']+)["']/i);
+    if (enclosureMatch) return enclosureMatch[1];
+    // Also try url before type
+    const enclosureMatch2 = fullItemXml.match(/<enclosure[^>]+url=["']([^"']+)["'][^>]+type=["']image\/[^"']+["']/i);
+    if (enclosureMatch2) return enclosureMatch2[1];
+  }
+
+  return null;
 }
 
 function extractTrackerSlug(link: string): string | null {
@@ -76,13 +103,17 @@ export async function handleCron(env: Env): Promise<Response> {
     if (!subKeys?.length) continue;
 
     const isBreaking = item.category === 'breaking';
-    const payload = JSON.stringify({
+    const notificationPayload: Record<string, string> = {
       title: isBreaking ? `⚡ ${item.title}` : `🔴 ${item.title}`,
       body: item.description,
       icon: '/icons/icon-192.png',
       url: item.link,
       tag: `${slug}-${item.category}-${new Date().toISOString().slice(0, 10)}`,
-    });
+    };
+    if (item.image) {
+      notificationPayload.image = item.image;
+    }
+    const payload = JSON.stringify(notificationPayload);
 
     for (const subKey of subKeys) {
       const sub = await env.PUSH_SUBSCRIPTIONS.get(subKey, 'json') as {


### PR DESCRIPTION
Comprehensive fix for stale trackers and missing images.

**Ingesta Pipeline:**
- 17 tracker escalation policies: [3,3,7,14,30,60] → [1,1,3,7,14,30] (daily minimum)
- Hourly scan: freshness check injects stale trackers (>36h) as updates
- Nightly prompt: MANDATORY thumbnail capture for every event
- Better skip logging with escalation context

**Mobile UI Images:**
- MobileFeedTab: 60x60 thumbnails on event cards with gradient fallback
- MobileMapTab: 48x48 thumbnails on map event overlay
- GlobeMobileSheet: 60x60 thumbnails in intel feed
- All imgs: referrerPolicy=no-referrer + onError hide

**Push Notifications:**
- Cron extracts images from RSS (media:content, img tags, enclosures)
- Push payload includes image field for rich notifications

3 parallel subagent commits.