### PR TITLE
chore: sync package-lock.json with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
+        "@atproto/api": "^0.15.0",
         "@cloudflare/workers-types": "^4.20260410.1",
         "@playwright/test": "^1.58.2",
         "@types/leaflet": "^1.9.21",
@@ -259,6 +260,129 @@
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.5.0"
+      }
+    },
+    "node_modules/@atproto/api": {
+      "version": "0.15.27",
+      "resolved": "https://registry.npmjs.org/@atproto/api/-/api-0.15.27.tgz",
+      "integrity": "sha512-ok/WGafh1nz4t8pEQGtAF/32x2E2VDWU4af6BajkO5Gky2jp2q6cv6aB2A5yuvNNcc3XkYMYipsqVHVwLPMF9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/common-web": "^0.4.2",
+        "@atproto/lexicon": "^0.4.12",
+        "@atproto/syntax": "^0.4.0",
+        "@atproto/xrpc": "^0.7.1",
+        "await-lock": "^2.2.2",
+        "multiformats": "^9.9.0",
+        "tlds": "^1.234.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/common-web": {
+      "version": "0.4.20",
+      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.4.20.tgz",
+      "integrity": "sha512-RcsYT28yQgVi/Glb/hHPGpqpzIlKrbMLeldEd7PmmMLWDaJL2j3lb92qytvxjl1yhi2Ssq2TEuMZ2NlWaAbpow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lex-data": "^0.0.15",
+        "@atproto/lex-json": "^0.0.15",
+        "@atproto/syntax": "^0.5.3",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/common-web/node_modules/@atproto/syntax": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.5.3.tgz",
+      "integrity": "sha512-gzhlHOJHm5KXdCc17fXi1fXM81ccs5jJfNgCui84ay9JGvczxegpYHNqdMlv+iBuhtBzFIjgx6ChjRxN/kO8kQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@atproto/lex-data": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.0.15.tgz",
+      "integrity": "sha512-ZsbGiaM5S3CnGrcTMbDGON3bLZzCi/Mx9UvcMREKSRujnF68eHgMiXxJqvykP7+QpOX6tYCK93axZkuJVhtSEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.9.0",
+        "tslib": "^2.8.1",
+        "uint8arrays": "3.0.0",
+        "unicode-segmenter": "^0.14.0"
+      }
+    },
+    "node_modules/@atproto/lex-json": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.0.15.tgz",
+      "integrity": "sha512-kCLdP629H6GhgPjBTpZibUoqlpmW0hnVfZVwcD4s4Jch1KAqY/QcfL24Ih8wrW0Ok1YvtMIhjk98evdTA2OJcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lex-data": "^0.0.15",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@atproto/lexicon": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.4.14.tgz",
+      "integrity": "sha512-jiKpmH1QER3Gvc7JVY5brwrfo+etFoe57tKPQX/SmPwjvUsFnJAow5xLIryuBaJgFAhnTZViXKs41t//pahGHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/common-web": "^0.4.2",
+        "@atproto/syntax": "^0.4.0",
+        "iso-datestring-validator": "^2.2.2",
+        "multiformats": "^9.9.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/syntax": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.4.3.tgz",
+      "integrity": "sha512-YoZUz40YAJr5nPwvCDWgodEOlt5IftZqPJvA0JDWjuZKD8yXddTwSzXSaKQAzGOpuM+/A3uXRtPzJJqlScc+iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@atproto/xrpc": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.7.7.tgz",
+      "integrity": "sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lexicon": "^0.6.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/xrpc/node_modules/@atproto/lexicon": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.6.2.tgz",
+      "integrity": "sha512-p3Ly6hinVZW0ETuAXZMeUGwuMm3g8HvQMQ41yyEE6AL0hAkfeKFaZKos6BdBrr6CjkpbrDZqE8M+5+QOceysMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/common-web": "^0.4.18",
+        "@atproto/syntax": "^0.5.0",
+        "iso-datestring-validator": "^2.2.2",
+        "multiformats": "^9.9.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/xrpc/node_modules/@atproto/syntax": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.5.3.tgz",
+      "integrity": "sha512-gzhlHOJHm5KXdCc17fXi1fXM81ccs5jJfNgCui84ay9JGvczxegpYHNqdMlv+iBuhtBzFIjgx6ChjRxN/kO8kQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3212,6 +3336,13 @@
         "pnpm": ">=10.10.0"
       }
     },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -4901,6 +5032,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/iso-datestring-validator": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/iso-datestring-validator/-/iso-datestring-validator-2.2.2.tgz",
+      "integrity": "sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5926,6 +6064,13 @@
       "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
       "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
       "license": "MIT"
+    },
+    "node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "dev": true,
+      "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -7323,6 +7468,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tlds": {
+      "version": "1.261.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
+      "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tlds": "bin.js"
+      }
+    },
     "node_modules/topojson-client": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
@@ -7481,6 +7636,16 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "license": "MIT"
     },
+    "node_modules/uint8arrays": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
+      "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
     "node_modules/ultrahtml": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.6.0.tgz",
@@ -7497,6 +7662,13 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/unicode-segmenter": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/unicode-segmenter/-/unicode-segmenter-0.14.5.tgz",
+      "integrity": "sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-trie": {


### PR DESCRIPTION
The `@atproto/api` dependency (Bluesky SDK) was added to package.json in PR #44 but the lockfile wasn't updated, causing `npm ci` to fail in CI.

This syncs the lockfile so the deploy workflow passes.