### PR TITLE
fix(ci): quote if-expression in weekly-digest workflow

### DIFF
--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -149,7 +149,7 @@ jobs:
         run: npx tsx scripts/newsletter-generate.ts
 
       - name: Trigger newsletter send
-        if: ${{ secrets.NEWSLETTER_SECRET != '' }}
+        if: "${{ secrets.NEWSLETTER_SECRET != '' }}"
         env:
           NEWSLETTER_SECRET: ${{ secrets.NEWSLETTER_SECRET }}
         run: |


### PR DESCRIPTION
The unquoted `${{ }}` expression in the `if:` condition caused YAML parsing failures whenever the workflow file was modified in a push. GitHub validates workflow files on push even when the workflow isn't triggered by push events, and unquoted expressions fail that validation.

This caused all those `weekly-digest.yml` failures with 0 jobs after the distribution PR merges.

Fix: wrap the expression in quotes.