### PR TITLE
fix(ci): prevent ghost failures on push for schedule-only workflows

### DIFF
--- a/.github/workflows/post-social-queue.yml
+++ b/.github/workflows/post-social-queue.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 8,13,18,22 * * *'
   workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/post-social-queue.yml'
 
 permissions:
   contents: write
@@ -11,6 +14,7 @@ permissions:
 jobs:
   post:
     runs-on: ubuntu-latest
+    if: github.event_name != 'push'
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 16 * * 0'  # Sundays at 16:00 UTC
   workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/weekly-digest.yml'
 
 permissions:
   contents: write
@@ -11,6 +14,7 @@ permissions:
 jobs:
   digest:
     runs-on: ubuntu-latest
+    if: github.event_name != 'push'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
GitHub creates a 0-job 'validation run' when a workflow file is modified in a push, even if the workflow doesn't have `push` as a trigger. This results in red X failures in the Actions tab that are pure noise.

**Fix:** Add `push` trigger scoped to the workflow file itself + job-level `if: github.event_name != 'push'` guard. Result:
- Push that modifies the file → workflow triggers → job is **skipped** → ✅ green
- Schedule/dispatch → no guard hit → job runs normally

Applied to:
- `weekly-digest.yml` (was showing ~10 ghost failures from tonight's merges)
- `post-social-queue.yml` (preemptive, same pattern)