### PR TITLE
fix(ci): use job-level env for secrets in weekly-digest

### DIFF
--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -15,6 +15,8 @@ jobs:
   digest:
     runs-on: ubuntu-latest
     if: github.event_name != 'push'
+    env:
+      NEWSLETTER_SECRET: ${{ secrets.NEWSLETTER_SECRET }}
     steps:
       - uses: actions/checkout@v4
 
@@ -153,9 +155,7 @@ jobs:
         run: npx tsx scripts/newsletter-generate.ts
 
       - name: Trigger newsletter send
-        if: "${{ secrets.NEWSLETTER_SECRET != '' }}"
-        env:
-          NEWSLETTER_SECRET: ${{ secrets.NEWSLETTER_SECRET }}
+        if: env.NEWSLETTER_SECRET != ''
         run: |
           NEWSLETTER_HTML=$(cat dist/newsletter/latest.html)
           SUBJECT="Watchboard Weekly Digest — $(date -u +%Y-%m-%d)"


### PR DESCRIPTION
Root cause of all the weekly-digest workflow failures: `secrets` context is **not available** in step-level `if:` expressions. GitHub Actions only allows `env`, `github`, `inputs`, `job`, `matrix`, `needs`, `runner`, `steps`, `strategy`, `vars` in that context.

**Fix:** Move `NEWSLETTER_SECRET` to job-level `env:` (where `secrets` IS available), then reference it as `env.NEWSLETTER_SECRET` in the step `if:`.

Validated with `actionlint` — zero errors.