### PR TITLE
fix(push): always include image with OG fallback

### DIFF
--- a/worker/handlers/cron.ts
+++ b/worker/handlers/cron.ts
@@ -162,9 +162,10 @@ export async function handleCron(env: Env): Promise<Response> {
       url: item.link,
       tag: `${slug}-${item.category}-${new Date().toISOString().slice(0, 10)}`,
     };
-    if (item.image) {
-      notificationPayload.image = item.image;
-    }
+    // Image fallback chain: event thumbnail → tracker OG image → site OG card
+    const imageUrl = item.image
+      || `https://watchboard.dev/og/${slug}.png`;
+    notificationPayload.image = imageUrl;
     const payload = JSON.stringify(notificationPayload);
 
     for (const subKey of subKeys) {


### PR DESCRIPTION
Notifications should never be image-less.

**Fallback chain:**
1. Event thumbnail from JSON API (when available)
2. Tracker OG image (`/og/{slug}.png`) — always exists, auto-generated at build time

This ensures every push notification has a visual, even for events without media thumbnails.