### PR TITLE
fix(sw): bust stale JS cache after black screen fix

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Watchboard Service Worker
 // Strategy: cache-first for static assets, network-first for HTML, stale-while-revalidate for data JSON
-const CACHE_VERSION = 'wb-v1';
+const CACHE_VERSION = 'wb-v2';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const HTML_CACHE = `${CACHE_VERSION}-html`;
 const DATA_CACHE = `${CACHE_VERSION}-data`;


### PR DESCRIPTION
Users with cached (broken) JS from the seenSlugs bug (#53→#64) will never get the fix because the service worker serves cache-first for .js files.

Bump `CACHE_VERSION` from `wb-v1` to `wb-v2` to force all clients to purge old caches on next visit.