### PR TITLE
fix(i18n): externalize ~75 strings from static pages

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -8,11 +8,11 @@ const basePath = base.endsWith('/') ? base : `${base}/`;
   <main id="main-content">
     <div class="not-found">
       <div class="not-found-code">404</div>
-      <h1 class="not-found-title">Page Not Found</h1>
-      <p class="not-found-desc">The page you're looking for doesn't exist or has been moved.</p>
+      <h1 class="not-found-title" data-i18n data-es="Página no encontrada" data-fr="Page non trouvée" data-pt="Página não encontrada">Page Not Found</h1>
+      <p class="not-found-desc" data-i18n data-es="La página que buscas no existe o ha sido movida." data-fr="La page que vous recherchez n'existe pas ou a été déplacée." data-pt="A página que você procura não existe ou foi movida.">The page you're looking for doesn't exist or has been moved.</p>
       <div class="not-found-actions">
-        <a href={basePath} class="not-found-btn primary">← Back to Watchboard</a>
-        <a href={`${basePath}search/`} class="not-found-btn secondary">Search Trackers</a>
+        <a href={basePath} class="not-found-btn primary" data-i18n data-es="← Volver a Watchboard" data-fr="← Retour à Watchboard" data-pt="← Voltar ao Watchboard">← Back to Watchboard</a>
+        <a href={`${basePath}search/`} class="not-found-btn secondary" data-i18n data-es="Buscar rastreadores" data-fr="Rechercher des trackers" data-pt="Pesquisar rastreadores">Search Trackers</a>
       </div>
     </div>
   </main>

--- a/src/pages/briefing/[date].astro
+++ b/src/pages/briefing/[date].astro
@@ -156,18 +156,18 @@ const newsArticleSchema = {
       <nav class="breadcrumb" aria-label="Breadcrumb">
         <a href={`${basePath}`}>Watchboard</a>
         <span class="sep">/</span>
-        <a href={`${basePath}briefing/`}>Briefings</a>
+        <a href={`${basePath}briefing/`} data-i18n data-es="Informes" data-fr="Briefings" data-pt="Briefings">Briefings</a>
         <span class="sep">/</span>
         <span class="current">{date}</span>
       </nav>
 
       <!-- Header -->
       <header class="briefing-header">
-        <div class="briefing-label">DAILY BRIEFING</div>
+        <div class="briefing-label" data-i18n data-es="INFORME DIARIO" data-fr="BRIEFING QUOTIDIEN" data-pt="BRIEFING DIÁRIO">DAILY BRIEFING</div>
         <h1 class="briefing-date">{displayDate}</h1>
         <p class="briefing-stats">
-          <span class="stat-num">{totalEvents}</span> event{totalEvents !== 1 ? 's' : ''} across
-          <span class="stat-num">{trackerCount}</span> tracker{trackerCount !== 1 ? 's' : ''}
+          <span class="stat-num">{totalEvents}</span> <span data-i18n data-es={`${totalEvents !== 1 ? 'eventos' : 'evento'} en`} data-fr={`${totalEvents !== 1 ? 'événements' : 'événement'} dans`} data-pt={`${totalEvents !== 1 ? 'eventos' : 'evento'} em`}>event{totalEvents !== 1 ? 's' : ''} across</span>
+          <span class="stat-num">{trackerCount}</span> <span data-i18n data-es={trackerCount !== 1 ? 'rastreadores' : 'rastreador'} data-fr={trackerCount !== 1 ? 'trackers' : 'tracker'} data-pt={trackerCount !== 1 ? 'rastreadores' : 'rastreador'}>tracker{trackerCount !== 1 ? 's' : ''}</span>
         </p>
       </header>
 
@@ -177,7 +177,7 @@ const newsArticleSchema = {
           <a href={`${basePath}briefing/${prevDate}/`} class="day-nav-btn prev" rel="prev">
             <span class="nav-arrow">&larr;</span>
             <span class="nav-label">
-              <span class="nav-hint">Previous</span>
+              <span class="nav-hint" data-i18n data-es="Anterior" data-fr="Précédent" data-pt="Anterior">Previous</span>
               <span class="nav-date">{formatDateShort(prevDate)}</span>
             </span>
           </a>
@@ -185,17 +185,17 @@ const newsArticleSchema = {
           <span class="day-nav-btn prev disabled" aria-disabled="true">
             <span class="nav-arrow">&larr;</span>
             <span class="nav-label">
-              <span class="nav-hint">Previous</span>
+              <span class="nav-hint" data-i18n data-es="Anterior" data-fr="Précédent" data-pt="Anterior">Previous</span>
             </span>
           </span>
         )}
 
-        <a href={`${basePath}briefing/`} class="day-nav-index">All Briefings</a>
+        <a href={`${basePath}briefing/`} class="day-nav-index" data-i18n data-es="Todos los informes" data-fr="Tous les briefings" data-pt="Todos os briefings">All Briefings</a>
 
         {nextDate ? (
           <a href={`${basePath}briefing/${nextDate}/`} class="day-nav-btn next" rel="next">
             <span class="nav-label">
-              <span class="nav-hint">Next</span>
+              <span class="nav-hint" data-i18n data-es="Siguiente" data-fr="Suivant" data-pt="Próximo">Next</span>
               <span class="nav-date">{formatDateShort(nextDate)}</span>
             </span>
             <span class="nav-arrow">&rarr;</span>
@@ -203,7 +203,7 @@ const newsArticleSchema = {
         ) : (
           <span class="day-nav-btn next disabled" aria-disabled="true">
             <span class="nav-label">
-              <span class="nav-hint">Next</span>
+              <span class="nav-hint" data-i18n data-es="Siguiente" data-fr="Suivant" data-pt="Próximo">Next</span>
             </span>
             <span class="nav-arrow">&rarr;</span>
           </span>
@@ -219,7 +219,7 @@ const newsArticleSchema = {
                 <a href={`${basePath}${group.config.slug}/`} class="group-name">
                   {group.config.name}
                 </a>
-                <span class="group-count">
+                <span class="group-count" data-i18n data-es={`${group.events.length} ${group.events.length !== 1 ? 'eventos' : 'evento'}`} data-fr={`${group.events.length} ${group.events.length !== 1 ? 'événements' : 'événement'}`} data-pt={`${group.events.length} ${group.events.length !== 1 ? 'eventos' : 'evento'}`}>
                   {group.events.length} event{group.events.length !== 1 ? 's' : ''}
                 </span>
               </div>
@@ -254,8 +254,8 @@ const newsArticleSchema = {
 
       <!-- Footer nav -->
       <footer class="briefing-footer">
-        <a href={`${basePath}briefing/`} class="footer-link">&larr; All Briefings</a>
-        <a href={`${basePath}`} class="footer-link">Watchboard Home</a>
+        <a href={`${basePath}briefing/`} class="footer-link" data-i18n data-es="← Todos los informes" data-fr="← Tous les briefings" data-pt="← Todos os briefings">&larr; All Briefings</a>
+        <a href={`${basePath}`} class="footer-link" data-i18n data-es="Inicio de Watchboard" data-fr="Accueil Watchboard" data-pt="Início do Watchboard">Watchboard Home</a>
       </footer>
 
     </div>

--- a/src/pages/briefing/index.astro
+++ b/src/pages/briefing/index.astro
@@ -97,25 +97,25 @@ const collectionPageSchema = {
     <div class="briefing-index">
 
       <!-- Back nav -->
-      <a href={`${basePath}`} class="back-link">&larr; Watchboard</a>
+      <a href={`${basePath}`} class="back-link" data-i18n data-es="← Watchboard" data-fr="← Watchboard" data-pt="← Watchboard">&larr; Watchboard</a>
 
       <!-- Header -->
       <header class="index-header">
-        <div class="index-label">INTELLIGENCE ARCHIVE</div>
-        <h1 class="index-title">Daily Briefings</h1>
-        <p class="index-desc">
+        <div class="index-label" data-i18n data-es="ARCHIVO DE INTELIGENCIA" data-fr="ARCHIVES DU RENSEIGNEMENT" data-pt="ARQUIVO DE INTELIGÊNCIA">INTELLIGENCE ARCHIVE</div>
+        <h1 class="index-title" data-i18n data-es="Informes diarios" data-fr="Briefings quotidiens" data-pt="Briefings diários">Daily Briefings</h1>
+        <p class="index-desc" data-i18n data-es="Resúmenes cruzados de rastreadores agregados cada día en todos los rastreadores activos de Watchboard. Cada informe enlaza a permalinks de eventos individuales con atribución completa de fuentes." data-fr="Résumés inter-trackers agrégés chaque jour sur tous les trackers actifs de Watchboard. Chaque briefing renvoie aux permaliens des événements individuels avec attribution complète des sources." data-pt="Resumos cruzados de rastreadores agregados diariamente em todos os rastreadores ativos do Watchboard. Cada briefing liga a permalinks de eventos individuais com atribuição completa de fontes.">
           Cross-tracker summaries aggregated each day across all active Watchboard trackers.
           Each briefing links to individual event permalinks with full source attribution.
         </p>
         <p class="index-count">
-          <span class="count-num">{totalDates}</span> briefings available
+          <span class="count-num">{totalDates}</span> <span data-i18n data-es="informes disponibles" data-fr="briefings disponibles" data-pt="briefings disponíveis">briefings available</span>
         </p>
       </header>
 
       <!-- Briefing list -->
       {briefings.length === 0 ? (
         <div class="empty-state">
-          <p>No briefings available yet. Events will appear here once trackers have day-level dated events.</p>
+          <p data-i18n data-es="Aún no hay informes disponibles. Los eventos aparecerán aquí una vez que los rastreadores tengan eventos con fecha a nivel de día." data-fr="Aucun briefing disponible pour le moment. Les événements apparaîtront ici une fois que les trackers auront des événements datés au jour." data-pt="Nenhum briefing disponível ainda. Os eventos aparecerão aqui assim que os rastreadores tiverem eventos datados por dia.">No briefings available yet. Events will appear here once trackers have day-level dated events.</p>
         </div>
       ) : (
         <ol class="briefing-list" reversed>
@@ -129,12 +129,12 @@ const collectionPageSchema = {
                 <div class="entry-right">
                   <span class="entry-stat">
                     <span class="stat-val">{entry.eventCount}</span>
-                    <span class="stat-lbl">event{entry.eventCount !== 1 ? 's' : ''}</span>
+                    <span class="stat-lbl" data-i18n data-es={entry.eventCount !== 1 ? 'eventos' : 'evento'} data-fr={entry.eventCount !== 1 ? 'événements' : 'événement'} data-pt={entry.eventCount !== 1 ? 'eventos' : 'evento'}>event{entry.eventCount !== 1 ? 's' : ''}</span>
                   </span>
                   <span class="entry-sep">&middot;</span>
                   <span class="entry-stat">
                     <span class="stat-val">{entry.trackerCount}</span>
-                    <span class="stat-lbl">tracker{entry.trackerCount !== 1 ? 's' : ''}</span>
+                    <span class="stat-lbl" data-i18n data-es={entry.trackerCount !== 1 ? 'rastreadores' : 'rastreador'} data-fr={entry.trackerCount !== 1 ? 'trackers' : 'tracker'} data-pt={entry.trackerCount !== 1 ? 'rastreadores' : 'rastreador'}>tracker{entry.trackerCount !== 1 ? 's' : ''}</span>
                   </span>
                   <span class="entry-arrow">&rarr;</span>
                 </div>
@@ -146,8 +146,8 @@ const collectionPageSchema = {
 
       <!-- Footer -->
       <footer class="index-footer">
-        <a href={`${basePath}`} class="footer-link">&larr; Back to Watchboard</a>
-        <a href={`${basePath}rss.xml`} class="footer-link">RSS Feed</a>
+        <a href={`${basePath}`} class="footer-link" data-i18n data-es="← Volver a Watchboard" data-fr="← Retour à Watchboard" data-pt="← Voltar ao Watchboard">&larr; Back to Watchboard</a>
+        <a href={`${basePath}rss.xml`} class="footer-link" data-i18n data-es="Fuente RSS" data-fr="Flux RSS" data-pt="Feed RSS">RSS Feed</a>
       </footer>
 
     </div>

--- a/src/pages/newsletter.astro
+++ b/src/pages/newsletter.astro
@@ -8,11 +8,11 @@ const pushUrl = 'https://push.watchboard.dev';
 <BaseLayout title="Newsletter — Watchboard" description="Subscribe to the Watchboard weekly intelligence digest delivered to your inbox every Sunday.">
   <main id="main-content">
   <div class="newsletter-page">
-    <a class="newsletter-back" href={`${basePath}`}>&larr; Watchboard</a>
+    <a class="newsletter-back" href={`${basePath}`} data-i18n data-es="← Watchboard" data-fr="← Watchboard" data-pt="← Watchboard">&larr; Watchboard</a>
 
     <article class="newsletter-content">
-      <h1>📰 Weekly Intelligence Digest</h1>
-      <p class="newsletter-subtitle">
+      <h1 data-i18n data-es="📰 Resumen semanal de inteligencia" data-fr="📰 Résumé hebdomadaire du renseignement" data-pt="📰 Resumo semanal de inteligência">📰 Weekly Intelligence Digest</h1>
+      <p class="newsletter-subtitle" data-i18n data-es="Recibe un resumen curado de cada rastreador activo — entregado a tu correo cada domingo. Eventos clave, KPIs actualizados y análisis de titulares en todos los temas." data-fr="Recevez un résumé de chaque tracker actif — livré dans votre boîte mail chaque dimanche. Événements clés, KPIs mis à jour et analyse des gros titres." data-pt="Receba um resumo curado de cada rastreador ativo — entregue no seu e-mail todo domingo. Eventos-chave, KPIs atualizados e análise de manchetes em todos os tópicos.">
         Get a curated summary of every active tracker — delivered to your inbox every Sunday.
         Key events, updated KPIs, and headline analysis across all topics.
       </p>
@@ -20,7 +20,7 @@ const pushUrl = 'https://push.watchboard.dev';
       <div class="newsletter-form-wrapper" id="newsletter-form-wrapper">
         <form id="newsletter-form" class="newsletter-form">
           <div class="form-group">
-            <label for="email">Email address</label>
+            <label for="email" data-i18n data-es="Correo electrónico" data-fr="Adresse e-mail" data-pt="Endereço de e-mail">Email address</label>
             <input
               type="email"
               id="email"
@@ -30,31 +30,31 @@ const pushUrl = 'https://push.watchboard.dev';
               autocomplete="email"
             />
           </div>
-          <button type="submit" class="newsletter-submit" id="newsletter-submit">
+          <button type="submit" class="newsletter-submit" id="newsletter-submit" data-i18n data-es="Suscribirse" data-fr="S'abonner" data-pt="Inscrever-se">
             Subscribe
           </button>
-          <p class="newsletter-note">No spam. Unsubscribe anytime. One email per week.</p>
+          <p class="newsletter-note" data-i18n data-es="Sin spam. Cancela cuando quieras. Un correo por semana." data-fr="Pas de spam. Désabonnement à tout moment. Un e-mail par semaine." data-pt="Sem spam. Cancele quando quiser. Um e-mail por semana.">No spam. Unsubscribe anytime. One email per week.</p>
         </form>
 
         <div id="newsletter-success" class="newsletter-success" style="display:none;">
           <span class="success-icon">✅</span>
-          <h2>You're subscribed!</h2>
-          <p>Look for the first digest in your inbox this Sunday.</p>
+          <h2 data-i18n data-es="¡Estás suscrito!" data-fr="Vous êtes abonné !" data-pt="Você está inscrito!">You're subscribed!</h2>
+          <p data-i18n data-es="Busca el primer resumen en tu correo este domingo." data-fr="Recherchez le premier résumé dans votre boîte mail ce dimanche." data-pt="Procure o primeiro resumo no seu e-mail neste domingo.">Look for the first digest in your inbox this Sunday.</p>
         </div>
 
         <div id="newsletter-error" class="newsletter-error" style="display:none;">
           <span class="error-icon">⚠️</span>
-          <p id="newsletter-error-msg">Something went wrong. Please try again.</p>
+          <p id="newsletter-error-msg" data-i18n data-es="Algo salió mal. Por favor, inténtalo de nuevo." data-fr="Une erreur s'est produite. Veuillez réessayer." data-pt="Algo deu errado. Por favor, tente novamente.">Something went wrong. Please try again.</p>
         </div>
       </div>
 
       <section class="newsletter-preview">
-        <h2>What you'll get</h2>
+        <h2 data-i18n data-es="Lo que recibirás" data-fr="Ce que vous recevrez" data-pt="O que você receberá">What you'll get</h2>
         <ul>
-          <li><strong>Tracker summaries</strong> — headline + top KPIs for every active tracker</li>
-          <li><strong>Weekly digest</strong> — the most important events from the past 7 days</li>
-          <li><strong>Direct links</strong> — jump straight to any tracker for full analysis</li>
-          <li><strong>Dark-themed email</strong> — easy on the eyes, designed for readability</li>
+          <li data-i18n data-es="Resúmenes de rastreadores — titular + KPIs principales para cada rastreador activo" data-fr="Résumés des trackers — titre + KPIs principaux pour chaque tracker actif" data-pt="Resumos dos rastreadores — manchete + KPIs principais para cada rastreador ativo"><strong>Tracker summaries</strong> — headline + top KPIs for every active tracker</li>
+          <li data-i18n data-es="Resumen semanal — los eventos más importantes de los últimos 7 días" data-fr="Résumé hebdomadaire — les événements les plus importants des 7 derniers jours" data-pt="Resumo semanal — os eventos mais importantes dos últimos 7 dias"><strong>Weekly digest</strong> — the most important events from the past 7 days</li>
+          <li data-i18n data-es="Enlaces directos — ve directamente a cualquier rastreador para un análisis completo" data-fr="Liens directs — accédez directement à n'importe quel tracker pour une analyse complète" data-pt="Links diretos — vá direto para qualquer rastreador para análise completa"><strong>Direct links</strong> — jump straight to any tracker for full analysis</li>
+          <li data-i18n data-es="Correo con tema oscuro — fácil para los ojos, diseñado para legibilidad" data-fr="E-mail en thème sombre — agréable à lire, conçu pour la lisibilité" data-pt="E-mail com tema escuro — fácil para os olhos, projetado para legibilidade"><strong>Dark-themed email</strong> — easy on the eyes, designed for readability</li>
         </ul>
       </section>
     </article>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -12,10 +12,10 @@ const pagefindBase = `${basePath}pagefind/`;
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <polyline points="15 18 9 12 15 6"/>
         </svg>
-        Watchboard
+        <span data-i18n data-es="Watchboard" data-fr="Watchboard" data-pt="Watchboard">Watchboard</span>
       </a>
-      <h1 class="search-title">Search All Trackers</h1>
-      <p class="search-subtitle">Full-text search across all tracker events, timelines, and data.</p>
+      <h1 class="search-title" data-i18n data-es="Buscar en todos los rastreadores" data-fr="Rechercher tous les trackers" data-pt="Pesquisar todos os rastreadores">Search All Trackers</h1>
+      <p class="search-subtitle" data-i18n data-es="Búsqueda de texto completo en todos los eventos, líneas de tiempo y datos de los rastreadores." data-fr="Recherche en texte intégral dans tous les événements, chronologies et données des trackers." data-pt="Pesquisa de texto completo em todos os eventos, cronologias e dados dos rastreadores.">Full-text search across all tracker events, timelines, and data.</p>
     </header>
     <div id="search"></div>
   </main>

--- a/src/pages/social.astro
+++ b/src/pages/social.astro
@@ -16,21 +16,21 @@ const basePath = base.endsWith('/') ? base : `${base}/`;
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <polyline points="15 18 9 12 15 6"/>
         </svg>
-        Watchboard
+        <span data-i18n data-es="Watchboard" data-fr="Watchboard" data-pt="Watchboard">Watchboard</span>
       </a>
       <div class="social-title-row">
         <span class="section-num">S</span>
-        <h1 class="social-title">Social Command Center</h1>
+        <h1 class="social-title" data-i18n data-es="Centro de mando social" data-fr="Centre de commande social" data-pt="Central de comando social">Social Command Center</h1>
       </div>
-      <p class="social-subtitle">AI-curated social media queue with LLM judge, budget tracking, and batch approval.</p>
+      <p class="social-subtitle" data-i18n data-es="Cola de redes sociales curada por IA con juez LLM, seguimiento de presupuesto y aprobación por lotes." data-fr="File d'attente de médias sociaux gérée par IA avec juge LLM, suivi du budget et approbation par lots." data-pt="Fila de mídia social curada por IA com juiz LLM, rastreamento de orçamento e aprovação em lote.">AI-curated social media queue with LLM judge, budget tracking, and batch approval.</p>
     </header>
     <SocialCommandCenter client:load basePath={basePath} githubRepo="ArtemioPadilla/watchboard" />
     <footer class="platform-footer">
       <a href={basePath}>Watchboard</a>
       <span>&middot;</span>
-      <a href={`${basePath}about/`}>About</a>
+      <a href={`${basePath}about/`} data-i18n data-es="Acerca de" data-fr="À propos" data-pt="Sobre">About</a>
       <span>&middot;</span>
-      <a href={`${basePath}metrics/`}>Metrics</a>
+      <a href={`${basePath}metrics/`} data-i18n data-es="Métricas" data-fr="Métriques" data-pt="Métricas">Metrics</a>
       <span>&middot;</span>
       <a href={`${basePath}rss.xml`}>RSS</a>
       <span>&middot;</span>


### PR DESCRIPTION
Externalizes user-facing strings from search, 404, newsletter, briefing, and social pages using data-i18n attributes with translations in all 4 languages.