### PR TITLE
fix(mobile): clean up cramped navbar on mobile devices

### DIFF
--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -434,50 +434,26 @@ export default function CommandCenter({
         <div style={styles.overlayNavBadges}>
           {isMobile ? (
             <>
-              <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '0.55rem', color: 'var(--accent-green)' }}>
+              <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '0.5rem', color: 'var(--accent-green)' }}>
                 ● {liveCount} {t('cc.live', locale)}
               </span>
-              <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '0.55rem', color: 'var(--text-muted, #8b949e)' }}>
+              <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '0.5rem', color: 'var(--text-muted, #8b949e)' }}>
                 {historicalCount} {t('cc.hist', locale)}
               </span>
-              <a
-                href="https://github.com/ArtemioPadilla/watchboard"
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{ color: 'var(--text-muted, #8b949e)', opacity: 0.7, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', minWidth: '44px', minHeight: '44px' }}
-                title="View on GitHub"
-                aria-label="View on GitHub"
-              >
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-              </a>
-              <a
-                href="https://github.com/sponsors/ArtemioPadilla"
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{ color: 'var(--accent-pink, #f778ba)', opacity: 0.8, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: '2px', fontFamily: "'JetBrains Mono', monospace", fontSize: '0.5rem', fontWeight: 600, textDecoration: 'none', minWidth: '44px', minHeight: '44px' }}
-                title="Support this project"
-                aria-label="Support this project"
-              >
-                ♥ Support
-              </a>
               <button
                 type="button"
                 onClick={handleToggleLocale}
                 style={{
-                  display: 'inline-flex', alignItems: 'center', gap: 2,
-                  padding: '2px 5px', border: '1px solid rgba(255,255,255,0.15)', borderRadius: 3,
+                  display: 'inline-flex', alignItems: 'center', gap: 3,
+                  padding: '2px 6px', border: '1px solid rgba(255,255,255,0.15)', borderRadius: 3,
                   background: 'transparent', cursor: 'pointer',
-                  fontFamily: "'JetBrains Mono', monospace", fontSize: '0.48rem',
+                  fontFamily: "'JetBrains Mono', monospace", fontSize: '0.5rem',
                   fontWeight: 600, color: '#e6edf3', letterSpacing: '0.04em',
                 }}
                 title="Change language"
+                aria-label={`Language: ${locale.toUpperCase()}. Tap to change.`}
               >
-                {SUPPORTED_LOCALES.map((loc, i) => (
-                  <span key={loc}>
-                    {i > 0 && <span style={{ opacity: 0.3 }}>/</span>}
-                    <span style={{ opacity: locale === loc ? 1 : 0.4 }}>{loc.toUpperCase()}</span>
-                  </span>
-                ))}
+                🌐{locale.toUpperCase()}
               </button>
             </>
           ) : (
@@ -493,7 +469,10 @@ export default function CommandCenter({
         </div>
       </div>
 
-      <div className="cc-globe" style={sidebarCollapsed && !isMobile ? styles.globeExpanded : styles.globe} role="region" aria-label="Globe visualization">
+      <div className="cc-globe" style={{
+        ...(sidebarCollapsed && !isMobile ? styles.globeExpanded : styles.globe),
+        ...(isMobile ? { paddingTop: '2.5rem' } : {}),
+      }} role="region" aria-label="Globe visualization">
         <Suspense fallback={
           <div style={styles.globeLoading}>
             <div style={styles.globePlaceholder}>


### PR DESCRIPTION
The mobile navbar had too many elements crammed in one line (live/hist counts, GitHub, Support, EN/ES/FR/PT language switcher).

**Changes:**
- Remove GitHub and Support links from mobile nav (available in sidebar)
- Language switcher shows only current locale as compact button (🌐 ES) instead of full EN/ES/FR/PT
- Still cycles through all 4 languages on tap
- Fixed globe z-index to not be clipped by navbar