### PR TITLE
feat(stories): revert tap to pause + dynamic camera zoom per tracker

### DIFF
--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -337,7 +337,33 @@ export default function CommandCenter({
   const handleStoryTrackerChange = useCallback((slug: string) => {
     const tracker = trackers.find(t => t.slug === slug);
     if (tracker?.mapCenter) {
-      globeRef.current?.flyTo?.(tracker.mapCenter.lat, tracker.mapCenter.lon, 2.0, 1200);
+      // Dynamic zoom based on tracker scope
+      const region = tracker.region;
+      const domain = tracker.domain;
+      let altitude = 2.0; // default
+      let duration = 1800; // ms
+
+      // Country-level trackers: zoom closer
+      if (tracker.country && !tracker.aggregate) {
+        altitude = 1.2;
+        duration = 2200;
+      }
+      // Regional conflicts: medium zoom
+      if (region === 'middle-east' || region === 'southeast-asia') {
+        altitude = 1.5;
+        duration = 2000;
+      }
+      // Global/multi-region trackers: wide view
+      if (domain === 'economy' || domain === 'science' || region === 'global' || tracker.aggregate) {
+        altitude = 3.0;
+        duration = 2500;
+      }
+      // Historical trackers: slower, more cinematic
+      if (tracker.temporal === 'historical') {
+        duration = 3000;
+      }
+
+      globeRef.current?.flyTo?.(tracker.mapCenter.lat, tracker.mapCenter.lon, altitude, duration);
       globeRef.current?.setAutoRotate?.(false);
     }
   }, [trackers]);

--- a/src/components/islands/CommandCenter/MobileStoryCarousel.tsx
+++ b/src/components/islands/CommandCenter/MobileStoryCarousel.tsx
@@ -121,8 +121,6 @@ export default function MobileStoryCarousel({ trackers, basePath, followedSlugs 
 
   const touchStartY = useRef<number | null>(null);
   const touchStartX = useRef<number | null>(null);
-  const lastTapTime = useRef<number>(0);
-  const tapTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const circlesRef = useRef<HTMLDivElement>(null);
   const pauseTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -243,30 +241,16 @@ export default function MobileStoryCarousel({ trackers, basePath, followedSlugs 
   }, [clearPauseTimer]);
 
   const handleCardTap = useCallback(() => {
-    const now = Date.now();
-    const DOUBLE_TAP_MS = 300;
-
-    if (now - lastTapTime.current < DOUBLE_TAP_MS) {
-      // Double tap → open tracker
-      if (tapTimer.current) clearTimeout(tapTimer.current);
-      haptic();
-      window.location.href = `${basePath}${eligible[currentIndex]?.slug}/`;
-      return;
+    if (paused) {
+      handleResume();
+    } else {
+      handlePause();
     }
-
-    lastTapTime.current = now;
-
-    // Single tap → advance to next story (delayed to detect double tap)
-    if (tapTimer.current) clearTimeout(tapTimer.current);
-    tapTimer.current = setTimeout(() => {
-      goNext();
-      haptic();
-    }, DOUBLE_TAP_MS);
-  }, [basePath, eligible, currentIndex, goNext]);
+  }, [paused, handlePause, handleResume]);
 
   // Cleanup
   useEffect(() => {
-    return () => { clearPauseTimer(); if (tapTimer.current) clearTimeout(tapTimer.current); };
+    return () => { clearPauseTimer(); };
   }, [clearPauseTimer]);
 
   // Swipe detection: horizontal (#5) + vertical (existing)
@@ -421,10 +405,16 @@ export default function MobileStoryCarousel({ trackers, basePath, followedSlugs 
 
         {/* Swipe hint */}
         <div className="story-swipe-hint">
-          {t('story.tapNext', locale)}
+          {paused ? t('story.tapToResume', locale) : t('story.swipeHint', locale)}
         </div>
 
-        {/* Touch zones removed — single tap advances, double tap opens */}
+        {/* Touch zones (hidden when paused to allow full card tap) */}
+        {!paused && (
+          <>
+            <div className="story-touch-left" onClick={(e) => { e.stopPropagation(); goPrev(); }} />
+            <div className="story-touch-right" onClick={(e) => { e.stopPropagation(); goNext(); }} />
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
**Tap behavior reverted:**
- Single tap → pause/resume (like Instagram, as originally designed)
- Touch zones restored for left/right navigation
- Double-tap removed — 'Read more →' link is the entry to the tracker

**Dynamic camera movements:**
The globe now zooms to different altitudes based on the tracker:
- 🎯 Country-level (Gaza, Ukraine, etc.): close zoom (1.2x) — 2.2s fly
- 🌍 Regional (Middle East, SE Asia): medium (1.5x) — 2.0s fly
- 🌐 Global/economy/science: wide view (3.0x) — 2.5s fly
- 📜 Historical: slower, more cinematic transitions (3.0s)

Makes the story transitions feel like a news broadcast — camera flies to each conflict zone at the appropriate scale.