### PR TITLE
fix(stories): double-tap on image now opens tracker

### DIFF
--- a/src/components/islands/CommandCenter/MobileStoryCarousel.tsx
+++ b/src/components/islands/CommandCenter/MobileStoryCarousel.tsx
@@ -355,7 +355,7 @@ export default function MobileStoryCarousel({ trackers, basePath, followedSlugs 
         </div>
 
         {/* Image area — carousel when paused, single image otherwise */}
-        <div className="story-image" onClick={paused ? (e: React.MouseEvent) => e.stopPropagation() : undefined}>
+        <div className="story-image">
           {paused && tracker.eventImages && tracker.eventImages.length > 1 ? (
             <div className="story-image-carousel-wrap">
               <ImageCarousel


### PR DESCRIPTION
The `story-image` div had `stopPropagation` when paused, which ate the second tap before it could reach the card's double-tap handler.

Removed the stopPropagation — double-tap now works on the entire card including the image area.