### PR TITLE
fix(quality): enforce source URLs and improve fact card images

### DIFF
--- a/.github/workflows/hourly-scan.yml
+++ b/.github/workflows/hourly-scan.yml
@@ -308,6 +308,7 @@ jobs:
             - If adding map-lines with cat "strike" or "retaliation": weaponType AND time are REQUIRED
             - Map coordinates must be within tracker's coordValidation bounds
             - Merge by ID — never remove existing items, only append
+            - Every source MUST include a `url` field with the direct article URL (not a homepage)
             - Every event MUST have a non-empty `media` array
             - Each media item MUST have `type`, `url`, and `thumbnail` fields
 

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -317,6 +317,11 @@ jobs:
             - Merge-by-ID: never remove existing entries, only add new or update existing
             - Every entry needs an `id` field (kebab-case, descriptive)
             - Tag sources with tier (1-4) and pole (western/middle_eastern/eastern/international)
+            - EVERY source MUST include a `url` field with the direct article URL. This is MANDATORY, not optional.
+            - The URL should be the actual article you read, not a generic homepage (e.g., https://www.reuters.com/world/... not https://www.reuters.com/)
+            - If you cite 'Reuters' as a source, you MUST have the specific Reuters article URL
+            - If you cannot find a specific article URL for a source, search for it — do not leave url empty
+            - Sources without URLs are considered unverified and reduce tracker quality
             - OSINT confirmation: 1 Tier-1 or 2+ Tier-2 sources = confirmed
             - BACKFILL: Check for missing days between latest event file and today, create event files for each gap day
             - Update meta.json lastUpdated with the EXACT current UTC time (use new Date().toISOString()), NOT a rounded or hardcoded time like "06:00:00Z"
@@ -781,6 +786,38 @@ jobs:
             }
           }
           main();
+          "
+
+      - name: Audit source URLs
+        if: steps.build_check.outputs.build_ok == 'true'
+        continue-on-error: true
+        run: |
+          node -e "
+          const fs = require('fs');
+          const path = require('path');
+          let totalSources = 0;
+          let sourcesWithUrl = 0;
+          for (const slug of fs.readdirSync('trackers')) {
+            const evDir = path.join('trackers', slug, 'data', 'events');
+            if (!fs.existsSync(evDir)) continue;
+            for (const f of fs.readdirSync(evDir).filter(f => f.endsWith('.json'))) {
+              let events;
+              try { events = JSON.parse(fs.readFileSync(path.join(evDir, f), 'utf8')); } catch { continue; }
+              if (!Array.isArray(events)) continue;
+              for (const ev of events) {
+                for (const s of ev.sources || []) {
+                  totalSources++;
+                  if (s.url) sourcesWithUrl++;
+                }
+              }
+            }
+          }
+          const pct = totalSources > 0 ? Math.round(sourcesWithUrl * 100 / totalSources) : 0;
+          console.log('');
+          console.log('Source URL audit:');
+          console.log('  Sources with URL: ' + sourcesWithUrl + '/' + totalSources + ' (' + pct + '%)');
+          if (pct < 50) console.warn('  ⚠️ Source URL coverage below 50% — consider backfilling');
+          else console.log('  ✓ Coverage acceptable');
           "
 
       - name: Backfill missing digests

--- a/src/components/islands/MapFactCards.tsx
+++ b/src/components/islands/MapFactCards.tsx
@@ -44,7 +44,7 @@ function cardHtml(card: FactCard): string {
 }
 
 const CARD_H_NO_THUMB = 52;
-const CARD_H_THUMB = 118;
+const CARD_H_THUMB = 138;
 const CONNECTOR_H = 20;
 
 // ────────────────────────────────────────────

--- a/src/components/islands/useFactCards.ts
+++ b/src/components/islands/useFactCards.ts
@@ -84,9 +84,23 @@ export function buildFactCards(
     );
 
     // Try to find a matching event for thumbnail
-    const matchingEvent = events.find(
-      e => e.resolvedDate === currentDate && e.title?.toUpperCase().includes(pt.label.toUpperCase().substring(0, 8)),
-    );
+    // Multi-strategy thumbnail matching: exact label → word overlap → any event with media
+    const labelUpper = pt.label.toUpperCase();
+    const labelWords = labelUpper.split(/\s+/).filter(w => w.length > 2);
+    const dayEvents = events.filter(e => e.resolvedDate === currentDate);
+
+    const matchingEvent =
+      // Strategy 1: label substring match (original)
+      dayEvents.find(e => e.title?.toUpperCase().includes(labelUpper.substring(0, 8))) ||
+      // Strategy 2: word overlap (>= 2 shared words)
+      dayEvents.find(e => {
+        if (!e.title) return false;
+        const titleWords = e.title.toUpperCase().split(/\s+/).filter(w => w.length > 2);
+        const overlap = labelWords.filter(w => titleWords.includes(w)).length;
+        return overlap >= 2;
+      }) ||
+      // Strategy 3: first event from that date with a thumbnail
+      dayEvents.find(e => e.media?.some(m => m.thumbnail));
 
     const utcTime = matchingLine?.time
       ? `${matchingLine.time} UTC`

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -9,7 +9,7 @@ export const PoleSchema = z.enum(['western', 'middle_eastern', 'eastern', 'inter
 export const SourceSchema = z.object({
   name: z.string(),
   tier: TierSchema,
-  url: z.string().optional(),
+  url: z.string().optional(), // TODO: make required once existing data is backfilled
   pole: PoleSchema.optional(),
 });
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3278,9 +3278,9 @@ body::before {
 
 .fact-card-thumb {
   width: 100%;
-  height: 60px;
+  height: 80px;
   object-fit: cover;
-  border-radius: 4px;
+  border-radius: 4px 4px 0 0;
   margin-top: 6px;
   opacity: 0.85;
   border: 1px solid rgba(255, 255, 255, 0.05);


### PR DESCRIPTION
**Source URL enforcement:**
- Nightly + hourly prompts now REQUIRE source URLs (not just name/tier)
- Schema has TODO for future hard enforcement
- New audit step reports source URL coverage percentage
- Warns if coverage drops below 50%

**Fact card images:**
- Improved thumbnail matching: 3-strategy fallback instead of fragile 8-char substring
- Thumbnails now 80px tall, full width, cover-fit with rounded top corners

**Why:** 71% of source citations had no URL — sources like 'Reuters' or 'Al Jazeera' cited without a link can't be verified by readers.