### PR TITLE
fix(translate): scheduled translation runs were always skipped

### DIFF
--- a/.github/workflows/translate-data.yml
+++ b/.github/workflows/translate-data.yml
@@ -28,6 +28,7 @@ jobs:
     # Only run on workflow_run if the upstream succeeded, always run on manual dispatch
     if: >-
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
       github.event.workflow_run.conclusion == 'success'
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
The translate-data workflow ran on `schedule` (cron 22:00 UTC daily) but the job's `if` condition only allowed `workflow_dispatch` and `workflow_run` events. Since `schedule` matched neither, every nightly translation was silently skipped.

Added `github.event_name == 'schedule'` to the condition.

This means translations will now run every night at 22:00 UTC (4 PM CDMX), 8 hours after the nightly data update.