### PR TITLE
fix(translate): increase timeout from 30 to 90 minutes

### DIFF
--- a/.github/workflows/translate-data.yml
+++ b/.github/workflows/translate-data.yml
@@ -30,7 +30,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule' ||
       github.event.workflow_run.conclusion == 'success'
-    timeout-minutes: 30
+    timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
30 minutes is not enough to translate all 51 trackers. Previous runs were cancelled at the timeout.