### PR TITLE
fix(ci): legacy-peer-deps for video workflow

### DIFF
--- a/.github/workflows/daily-video.yml
+++ b/.github/workflows/daily-video.yml
@@ -26,7 +26,7 @@ jobs:
           cache-dependency-path: video/package-lock.json
 
       - name: Install video dependencies
-        run: cd video && npm ci
+        run: cd video && npm ci --legacy-peer-deps
 
       - name: Ensure browser for Remotion
         run: cd video && npx remotion browser ensure


### PR DESCRIPTION
npm ci fails due to React/three.js peer dep conflict with Remotion. Add --legacy-peer-deps.