### PR TITLE
feat(social): daily video posting to Bluesky with extensible adapter pattern

### DIFF
--- a/.github/workflows/daily-video.yml
+++ b/.github/workflows/daily-video.yml
@@ -79,6 +79,39 @@ jobs:
               "video/output/watchboard-${DATE}-narrated-es.mp4" -y || echo "Merge failed"
           fi
 
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Post to social media
+        continue-on-error: true
+        env:
+          BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
+          BLUESKY_PASSWORD: ${{ secrets.BLUESKY_PASSWORD }}
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          VIDEO="video/output/watchboard-${DATE}.mp4"
+          NARRATED="video/output/watchboard-${DATE}-narrated-en.mp4"
+          # Prefer narrated version if available, fall back to base video
+          if [ -f "$NARRATED" ]; then
+            npx tsx scripts/post-video-social.ts "$NARRATED"
+          elif [ -f "$VIDEO" ]; then
+            npx tsx scripts/post-video-social.ts "$VIDEO"
+          else
+            echo "No video file found — skipping social post"
+          fi
+
+      - name: Commit social post record
+        continue-on-error: true
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          if [ -f "public/_social/video-post-${DATE}.json" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add "public/_social/video-post-${DATE}.json"
+            git diff --cached --quiet || git commit -m "chore(social): video post record ${DATE}"
+            git push || echo "Push failed (non-fatal)"
+          fi
+
       - name: Upload video artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/post-video-social.ts
+++ b/scripts/post-video-social.ts
@@ -1,0 +1,527 @@
+#!/usr/bin/env tsx
+/**
+ * post-video-social.ts
+ *
+ * Posts the daily Watchboard video brief to social platforms.
+ * Extensible adapter architecture — currently auto-publishes to Bluesky,
+ * with stubs for YouTube Shorts and Reddit. Always generates a manual
+ * queue JSON for platforms that require human posting (TikTok, Instagram).
+ *
+ * Usage:
+ *   npx tsx scripts/post-video-social.ts <video-path> [--dry-run]
+ *
+ * Environment:
+ *   BLUESKY_HANDLE    — Bluesky handle (e.g. watchboard.bsky.social)
+ *   BLUESKY_PASSWORD   — App password (not account password)
+ */
+import { BskyAgent, RichText } from '@atproto/api';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync } from 'fs';
+import { join, basename } from 'path';
+import { execSync } from 'child_process';
+import { todayDateString, PATHS } from './social-types.js';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface VideoMeta {
+  date: string;
+  trackers: Array<{ name: string; slug: string; headline: string }>;
+  duration: number;
+  videoPath: string;
+}
+
+interface SocialPlatform {
+  name: string;
+  enabled: boolean;
+  postVideo(videoPath: string, meta: VideoMeta): Promise<{ url: string } | null>;
+}
+
+interface VideoPostRecord {
+  date: string;
+  videoFile: string;
+  narrationFile: string;
+  caption_en: string;
+  caption_es: string;
+  hashtags: string[];
+  platforms: Record<string, 'auto' | 'manual' | 'stub'>;
+  posted: Record<string, { url: string; postedAt: string }>;
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const BLUESKY_MAX_GRAPHEMES = 300;
+const BLUESKY_VIDEO_MAX_BYTES = 50 * 1024 * 1024; // 50MB
+const POLL_INTERVAL_MS = 3000;
+const POLL_MAX_ATTEMPTS = 60; // 3 minutes max
+const PLATFORM_DELAY_MS = 2000;
+
+const ROOT = process.cwd();
+const BREAKING_JSON_PATH = join(ROOT, 'video', 'src', 'data', 'breaking.json');
+const SOCIAL_DIR = PATHS.socialDir;
+
+// ── Text utilities ───────────────────────────────────────────────────────────
+
+function graphemeLength(text: string): number {
+  const segmenter = new Intl.Segmenter();
+  return [...segmenter.segment(text)].length;
+}
+
+function truncateToGraphemes(text: string, maxGraphemes: number): string {
+  const segmenter = new Intl.Segmenter();
+  const segments = [...segmenter.segment(text)];
+  if (segments.length <= maxGraphemes) return text;
+  return segments.slice(0, maxGraphemes - 1).map(s => s.segment).join('') + '\u2026';
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// ── Video metadata ───────────────────────────────────────────────────────────
+
+function loadBreakingData(): { date: string; trackers: Array<{ slug: string; name: string; headline: string }> } {
+  if (!existsSync(BREAKING_JSON_PATH)) {
+    throw new Error(`Breaking data not found at ${BREAKING_JSON_PATH}`);
+  }
+  return JSON.parse(readFileSync(BREAKING_JSON_PATH, 'utf8'));
+}
+
+function getVideoDuration(videoPath: string): number {
+  try {
+    const output = execSync(
+      `ffprobe -v error -show_entries format=duration -of csv=p=0 "${videoPath}"`,
+      { encoding: 'utf8', timeout: 15000 },
+    );
+    return Math.round(parseFloat(output.trim()));
+  } catch {
+    console.warn('[video-social] ffprobe not available or failed — using 0 for duration');
+    return 0;
+  }
+}
+
+function buildVideoMeta(videoPath: string): VideoMeta {
+  const data = loadBreakingData();
+  const duration = getVideoDuration(videoPath);
+  return {
+    date: data.date,
+    trackers: data.trackers.map(t => ({ name: t.name, slug: t.slug, headline: t.headline })),
+    duration,
+    videoPath,
+  };
+}
+
+// ── Caption generation ───────────────────────────────────────────────────────
+
+function buildCaptionEn(meta: VideoMeta): string {
+  const headlines = meta.trackers.map(t => `${t.headline}`).join('\n');
+  return `Watchboard Daily Brief \u2014 ${meta.date}\n\n${headlines}\n\nhttps://watchboard.dev`;
+}
+
+function buildCaptionEs(meta: VideoMeta): string {
+  return `Resumen Diario Watchboard \u2014 ${meta.date}\n\nhttps://watchboard.dev`;
+}
+
+// ── Post record (idempotency file) ───────────────────────────────────────────
+
+function postRecordPath(date: string): string {
+  return join(SOCIAL_DIR, `video-post-${date}.json`);
+}
+
+function loadPostRecord(date: string): VideoPostRecord | null {
+  const p = postRecordPath(date);
+  if (!existsSync(p)) return null;
+  return JSON.parse(readFileSync(p, 'utf8'));
+}
+
+function savePostRecord(record: VideoPostRecord): void {
+  mkdirSync(SOCIAL_DIR, { recursive: true });
+  writeFileSync(postRecordPath(record.date), JSON.stringify(record, null, 2), 'utf8');
+}
+
+function buildInitialRecord(meta: VideoMeta, platforms: SocialPlatform[]): VideoPostRecord {
+  const platformMap: Record<string, 'auto' | 'manual' | 'stub'> = {
+    tiktok: 'manual',
+    instagram: 'manual',
+  };
+  for (const p of platforms) {
+    if (p.enabled) {
+      platformMap[p.name] = 'auto';
+    } else {
+      platformMap[p.name] = 'stub';
+    }
+  }
+
+  const videoFile = basename(meta.videoPath);
+  const narrationFile = videoFile.replace(/\.mp4$/, '-narrated-en.mp4');
+
+  return {
+    date: meta.date,
+    videoFile,
+    narrationFile,
+    caption_en: buildCaptionEn(meta),
+    caption_es: buildCaptionEs(meta),
+    hashtags: ['#OSINT', '#geopolitics', '#Watchboard'],
+    platforms: platformMap,
+    posted: {},
+  };
+}
+
+// ── Bluesky adapter ─────────────────────────────────────────────────────────
+
+function createBlueskyAdapter(): SocialPlatform {
+  const handle = process.env.BLUESKY_HANDLE;
+  const password = process.env.BLUESKY_PASSWORD;
+  const enabled = Boolean(handle && password);
+
+  return {
+    name: 'bluesky',
+    enabled,
+
+    async postVideo(videoPath: string, meta: VideoMeta): Promise<{ url: string } | null> {
+      if (!handle || !password) {
+        console.warn('[bluesky] Missing BLUESKY_HANDLE or BLUESKY_PASSWORD — skipping');
+        return null;
+      }
+
+      const agent = new BskyAgent({ service: 'https://bsky.social' });
+      await agent.login({ identifier: handle, password });
+      console.log(`[bluesky] Logged in as ${handle}`);
+
+      const postText = buildBlueskyPostText(meta);
+      const altText = `Watchboard Daily Intelligence Brief for ${meta.date}. Covers: ${meta.trackers.map(t => t.name).join(', ')}.`;
+
+      // Attempt video upload, fall back to text-only
+      const videoEmbed = await uploadAndProcessVideo(agent, videoPath, altText);
+
+      if (videoEmbed) {
+        return createBlueskyPost(agent, handle, postText, videoEmbed);
+      }
+
+      // Fallback: post with external link card
+      console.warn('[bluesky] Video upload failed — falling back to link card');
+      const linkEmbed = await createLinkCardEmbed(agent, meta);
+      return createBlueskyPost(agent, handle, postText, linkEmbed);
+    },
+  };
+}
+
+function buildBlueskyPostText(meta: VideoMeta): string {
+  const headlines = meta.trackers.map(t => t.headline).join('\n');
+  const raw = `\ud83d\udcca Watchboard Daily Brief \u2014 ${meta.date}\n\n${headlines}\n\n\ud83d\udd17 watchboard.dev`;
+  return truncateToGraphemes(raw, BLUESKY_MAX_GRAPHEMES);
+}
+
+async function uploadAndProcessVideo(
+  agent: BskyAgent,
+  videoPath: string,
+  altText: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const fileSize = statSync(videoPath).size;
+    if (fileSize > BLUESKY_VIDEO_MAX_BYTES) {
+      console.warn(`[bluesky] Video too large (${(fileSize / 1024 / 1024).toFixed(1)}MB > 50MB limit) — skipping video upload`);
+      return null;
+    }
+
+    const videoBuffer = readFileSync(videoPath);
+    const did = agent.session?.did;
+    const accessJwt = agent.session?.accessJwt;
+    if (!did || !accessJwt) {
+      console.warn('[bluesky] No active session — cannot upload video');
+      return null;
+    }
+
+    const filename = basename(videoPath);
+    console.log(`[bluesky] Uploading video (${(fileSize / 1024 / 1024).toFixed(1)}MB)...`);
+
+    const uploadUrl = `https://video.bsky.app/xrpc/app.bsky.video.uploadVideo?did=${encodeURIComponent(did)}&name=${encodeURIComponent(filename)}`;
+    const uploadRes = await fetch(uploadUrl, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessJwt}`,
+        'Content-Type': 'video/mp4',
+      },
+      body: videoBuffer,
+    });
+
+    if (!uploadRes.ok) {
+      const errorBody = await uploadRes.text().catch(() => '');
+      console.warn(`[bluesky] Video upload failed (${uploadRes.status}): ${errorBody}`);
+      return null;
+    }
+
+    const uploadData = await uploadRes.json() as { jobId: string };
+    const jobId = uploadData.jobId;
+    if (!jobId) {
+      console.warn('[bluesky] Video upload response missing jobId');
+      return null;
+    }
+
+    console.log(`[bluesky] Video uploaded, processing job ${jobId}...`);
+
+    // Poll for processing completion
+    const blobRef = await pollVideoJob(accessJwt, jobId);
+    if (!blobRef) return null;
+
+    return {
+      $type: 'app.bsky.embed.video',
+      video: blobRef,
+      alt: altText,
+      aspectRatio: { width: 1920, height: 1080 },
+    };
+  } catch (err) {
+    console.warn('[bluesky] Video upload error:', err);
+    return null;
+  }
+}
+
+async function pollVideoJob(
+  accessJwt: string,
+  jobId: string,
+): Promise<unknown | null> {
+  for (let attempt = 0; attempt < POLL_MAX_ATTEMPTS; attempt++) {
+    await sleep(POLL_INTERVAL_MS);
+
+    try {
+      const statusUrl = `https://video.bsky.app/xrpc/app.bsky.video.getJobStatus?jobId=${encodeURIComponent(jobId)}`;
+      const statusRes = await fetch(statusUrl, {
+        headers: { 'Authorization': `Bearer ${accessJwt}` },
+      });
+
+      if (!statusRes.ok) {
+        console.warn(`[bluesky] Job status check failed (${statusRes.status})`);
+        continue;
+      }
+
+      const statusData = await statusRes.json() as { jobStatus: { state: string; blob?: unknown; error?: string; message?: string } };
+      const state = statusData.jobStatus?.state;
+
+      if (state === 'JOB_STATE_COMPLETED') {
+        console.log('[bluesky] Video processing complete');
+        return statusData.jobStatus.blob;
+      }
+
+      if (state === 'JOB_STATE_FAILED') {
+        const errMsg = statusData.jobStatus.error || statusData.jobStatus.message || 'unknown';
+        console.warn(`[bluesky] Video processing failed: ${errMsg}`);
+        return null;
+      }
+
+      // Still processing
+      if (attempt % 5 === 0) {
+        console.log(`[bluesky] Video processing... (attempt ${attempt + 1}/${POLL_MAX_ATTEMPTS}, state: ${state})`);
+      }
+    } catch (err) {
+      console.warn(`[bluesky] Job status poll error (attempt ${attempt + 1}):`, err);
+    }
+  }
+
+  console.warn('[bluesky] Video processing timed out');
+  return null;
+}
+
+async function createLinkCardEmbed(
+  agent: BskyAgent,
+  meta: VideoMeta,
+): Promise<Record<string, unknown>> {
+  const firstTracker = meta.trackers[0];
+  const embed: Record<string, unknown> = {
+    $type: 'app.bsky.embed.external',
+    external: {
+      uri: 'https://watchboard.dev',
+      title: `Watchboard Daily Brief \u2014 ${meta.date}`,
+      description: firstTracker
+        ? firstTracker.headline.slice(0, 300)
+        : 'Daily intelligence brief from Watchboard',
+    },
+  };
+
+  // Attempt to fetch a thumbnail from breaking data
+  try {
+    const data = loadBreakingData();
+    const trackerWithThumb = data.trackers.find(
+      (t: Record<string, unknown>) => t.thumbnailUrl && typeof t.thumbnailUrl === 'string',
+    );
+    if (trackerWithThumb) {
+      const thumbUrl = (trackerWithThumb as Record<string, unknown>).thumbnailUrl as string;
+      const thumbRes = await fetch(thumbUrl);
+      if (thumbRes.ok) {
+        const thumbBuffer = Buffer.from(await thumbRes.arrayBuffer());
+        if (thumbBuffer.length <= 1_000_000) {
+          const mimeType = thumbRes.headers.get('content-type') ?? 'image/jpeg';
+          const uploaded = await agent.uploadBlob(thumbBuffer, { encoding: mimeType });
+          (embed.external as Record<string, unknown>).thumb = uploaded.data.blob;
+        }
+      }
+    }
+  } catch (err) {
+    console.warn('[bluesky] Thumbnail upload for fallback failed:', err);
+  }
+
+  return embed;
+}
+
+async function createBlueskyPost(
+  agent: BskyAgent,
+  handle: string,
+  text: string,
+  embed: Record<string, unknown> | null,
+): Promise<{ url: string } | null> {
+  try {
+    const rt = new RichText({ text });
+    await rt.detectFacets(agent);
+
+    const record: Record<string, unknown> = {
+      text: rt.text,
+      facets: rt.facets,
+      createdAt: new Date().toISOString(),
+    };
+    if (embed) {
+      record.embed = embed;
+    }
+
+    const result = await agent.post(record);
+    // Convert AT URI to web URL: at://did/app.bsky.feed.post/rkey -> https://bsky.app/profile/handle/post/rkey
+    const rkey = result.uri.split('/').pop();
+    const url = `https://bsky.app/profile/${handle}/post/${rkey}`;
+    console.log(`[bluesky] Video post created: ${url}`);
+    return { url };
+  } catch (err) {
+    console.error('[bluesky] Post creation failed:', err);
+    return null;
+  }
+}
+
+// ── YouTube Shorts stub ──────────────────────────────────────────────────────
+
+function createYouTubeAdapter(): SocialPlatform {
+  return {
+    name: 'youtube',
+    enabled: false,
+    async postVideo(): Promise<{ url: string } | null> {
+      return null;
+    },
+  };
+}
+
+// ── Reddit stub ──────────────────────────────────────────────────────────────
+
+function createRedditAdapter(): SocialPlatform {
+  return {
+    name: 'reddit',
+    enabled: false,
+    async postVideo(): Promise<{ url: string } | null> {
+      return null;
+    },
+  };
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const videoPath = args.find(a => !a.startsWith('--'));
+
+  if (!videoPath) {
+    console.error('Usage: post-video-social.ts <video-path> [--dry-run]');
+    process.exit(1);
+  }
+
+  if (!existsSync(videoPath)) {
+    console.error(`[video-social] Video file not found: ${videoPath}`);
+    process.exit(1);
+  }
+
+  console.log(`[video-social] Video: ${videoPath}`);
+  console.log(`[video-social] Dry run: ${dryRun}`);
+
+  const meta = buildVideoMeta(videoPath);
+  console.log(`[video-social] Date: ${meta.date}, Trackers: ${meta.trackers.length}, Duration: ${meta.duration}s`);
+
+  // Build platform adapters
+  const platforms: SocialPlatform[] = [
+    createBlueskyAdapter(),
+    createYouTubeAdapter(),
+    createRedditAdapter(),
+  ];
+
+  // Load or create the post record for idempotency
+  const existingRecord = loadPostRecord(meta.date);
+  const record = existingRecord ?? buildInitialRecord(meta, platforms);
+
+  // Merge any existing posted entries
+  if (existingRecord) {
+    console.log(`[video-social] Found existing record for ${meta.date}`);
+  }
+
+  if (dryRun) {
+    console.log('\n[DRY RUN] Would post to:');
+    for (const platform of platforms) {
+      const alreadyPosted = record.posted[platform.name];
+      if (alreadyPosted) {
+        console.log(`  ${platform.name}: SKIP (already posted at ${alreadyPosted.postedAt} -> ${alreadyPosted.url})`);
+      } else if (platform.enabled) {
+        console.log(`  ${platform.name}: WOULD POST`);
+      } else {
+        console.log(`  ${platform.name}: DISABLED (stub)`);
+      }
+    }
+    console.log(`\nPost text (Bluesky):`);
+    console.log(`  ${buildBlueskyPostText(meta).replace(/\n/g, '\n  ')}`);
+    console.log(`  (${graphemeLength(buildBlueskyPostText(meta))} graphemes)`);
+    console.log(`\nCaption (EN):`);
+    console.log(`  ${record.caption_en.replace(/\n/g, '\n  ')}`);
+
+    // Still save the record so manual platforms have the queue file
+    savePostRecord(record);
+    console.log(`\n[video-social] Queue file saved: ${postRecordPath(meta.date)}`);
+    return;
+  }
+
+  // Post to each enabled platform
+  for (const platform of platforms) {
+    if (!platform.enabled) {
+      console.log(`[video-social] ${platform.name}: disabled — skipping`);
+      continue;
+    }
+
+    // Idempotency: skip if already posted today
+    if (record.posted[platform.name]) {
+      console.log(`[video-social] ${platform.name}: already posted at ${record.posted[platform.name].postedAt} — skipping`);
+      continue;
+    }
+
+    console.log(`[video-social] ${platform.name}: posting...`);
+    try {
+      const result = await platform.postVideo(videoPath, meta);
+      if (result) {
+        record.posted[platform.name] = {
+          url: result.url,
+          postedAt: new Date().toISOString(),
+        };
+        console.log(`[video-social] ${platform.name}: success -> ${result.url}`);
+      } else {
+        console.warn(`[video-social] ${platform.name}: returned null (no post created)`);
+      }
+    } catch (err) {
+      console.warn(`[video-social] ${platform.name}: failed —`, err);
+    }
+
+    // Rate limit delay between platforms
+    await sleep(PLATFORM_DELAY_MS);
+  }
+
+  // Always save the record (even on partial failure)
+  savePostRecord(record);
+  console.log(`\n[video-social] Record saved: ${postRecordPath(meta.date)}`);
+
+  // Summary
+  const postedCount = Object.keys(record.posted).length;
+  const enabledCount = platforms.filter(p => p.enabled).length;
+  console.log(`[video-social] Done. ${postedCount}/${enabledCount} platforms posted.`);
+}
+
+main().catch(err => {
+  console.error('[video-social] Fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Automated daily video publishing with safety guardrails.

**Bluesky (fully implemented):**
- Video upload via AT Protocol video service
- Job polling with 3min timeout
- Fallback to link card + thumbnail if video upload fails
- Post with daily brief summary + tracker names + watchboard.dev link

**Safety:**
- Max 1 post per platform per day
- Idempotent (checks existing post record)
- 2s delay between platforms
- continue-on-error in workflow

**Manual queue:** Always generates `video-post-YYYY-MM-DD.json` with captions (EN/ES) + hashtags for manual posting on TikTok/Instagram/LinkedIn

**Stubs ready:** YouTube Shorts, Reddit (just flip `enabled: true` + add creds)