### PR TITLE
fix(bluesky): use service auth token for video upload

### DIFF
--- a/scripts/bluesky-post.ts
+++ b/scripts/bluesky-post.ts
@@ -21,8 +21,8 @@ import {
   type QueueEntry, type HistoryEntry,
 } from './social-types.js';
 import { BskyAgent, RichText } from '@atproto/api';
-import { readFileSync, existsSync } from 'fs';
-import { join } from 'path';
+import { readFileSync, existsSync, statSync } from 'fs';
+import { join, basename } from 'path';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -242,6 +242,115 @@ async function postSkeet(
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// ── Video posting ────────────────────────────────────────────────────────────
+
+const VIDEO_MAX_BYTES = 50 * 1024 * 1024; // 50MB
+const VIDEO_POLL_INTERVAL_MS = 3000;
+const VIDEO_POLL_MAX_ATTEMPTS = 60;
+
+/**
+ * Upload and post a video to Bluesky using service auth for video.bsky.app.
+ * Handles: service auth token → upload → job polling → post creation.
+ */
+export async function postWithVideo(
+  agent: BskyAgent,
+  videoPath: string,
+  text: string,
+  altText?: string,
+): Promise<{ uri: string; cid: string } | null> {
+  const fileSize = statSync(videoPath).size;
+  if (fileSize > VIDEO_MAX_BYTES) {
+    console.warn(`[bluesky] Video too large (${(fileSize / 1024 / 1024).toFixed(1)}MB > 50MB)`);
+    return null;
+  }
+
+  const did = agent.session?.did;
+  if (!did) {
+    console.warn('[bluesky] No active session — cannot upload video');
+    return null;
+  }
+
+  // Service auth token (session accessJwt is rejected by video.bsky.app)
+  const serviceAuth = await agent.com.atproto.server.getServiceAuth({
+    aud: 'did:web:video.bsky.app',
+    lxm: 'app.bsky.video.uploadVideo',
+    exp: Math.floor(Date.now() / 1000) + 60 * 30,
+  });
+  const videoToken = serviceAuth.data.token;
+
+  const videoBuffer = readFileSync(videoPath);
+  const filename = basename(videoPath);
+  const uploadUrl = `https://video.bsky.app/xrpc/app.bsky.video.uploadVideo?did=${encodeURIComponent(did)}&name=${encodeURIComponent(filename)}`;
+
+  console.log(`[bluesky] Uploading video (${(fileSize / 1024 / 1024).toFixed(1)}MB)...`);
+  const uploadRes = await fetch(uploadUrl, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${videoToken}`,
+      'Content-Type': 'video/mp4',
+    },
+    body: videoBuffer,
+  });
+
+  if (!uploadRes.ok) {
+    const body = await uploadRes.text().catch(() => '');
+    console.warn(`[bluesky] Video upload failed (${uploadRes.status}): ${body}`);
+    return null;
+  }
+
+  const uploadData = await uploadRes.json() as { jobId: string };
+  if (!uploadData.jobId) {
+    console.warn('[bluesky] Video upload response missing jobId');
+    return null;
+  }
+
+  console.log(`[bluesky] Video uploaded, polling job ${uploadData.jobId}...`);
+
+  // Poll for processing completion
+  let blobRef: unknown = null;
+  for (let attempt = 0; attempt < VIDEO_POLL_MAX_ATTEMPTS; attempt++) {
+    await sleep(VIDEO_POLL_INTERVAL_MS);
+    try {
+      const statusUrl = `https://video.bsky.app/xrpc/app.bsky.video.getJobStatus?jobId=${encodeURIComponent(uploadData.jobId)}`;
+      const statusRes = await fetch(statusUrl, {
+        headers: { 'Authorization': `Bearer ${videoToken}` },
+      });
+      if (!statusRes.ok) continue;
+
+      const statusData = await statusRes.json() as { jobStatus: { state: string; blob?: unknown; error?: string; message?: string } };
+      const state = statusData.jobStatus?.state;
+
+      if (state === 'JOB_STATE_COMPLETED') {
+        blobRef = statusData.jobStatus.blob;
+        break;
+      }
+      if (state === 'JOB_STATE_FAILED') {
+        console.warn(`[bluesky] Video processing failed: ${statusData.jobStatus.error || statusData.jobStatus.message}`);
+        return null;
+      }
+      if (attempt % 5 === 0) {
+        console.log(`[bluesky] Processing... (${attempt + 1}/${VIDEO_POLL_MAX_ATTEMPTS}, state: ${state})`);
+      }
+    } catch (err) {
+      console.warn(`[bluesky] Poll error (attempt ${attempt + 1}):`, err);
+    }
+  }
+
+  if (!blobRef) {
+    console.warn('[bluesky] Video processing timed out');
+    return null;
+  }
+
+  const embed = {
+    $type: 'app.bsky.embed.video',
+    video: blobRef,
+    alt: altText ?? '',
+    aspectRatio: { width: 1920, height: 1080 },
+  };
+
+  return postSkeet(agent, truncateToGraphemes(text, BLUESKY_MAX_GRAPHEMES), { embed });
 }
 
 // ── RSS parsing (for --from-rss mode) ─────────────────────────────────────────

--- a/scripts/post-video-social.ts
+++ b/scripts/post-video-social.ts
@@ -205,9 +205,30 @@ function createBlueskyAdapter(): SocialPlatform {
 }
 
 function buildBlueskyPostText(meta: VideoMeta): string {
-  const headlines = meta.trackers.map(t => t.headline).join('\n');
-  const raw = `\ud83d\udcca Watchboard Daily Brief \u2014 ${meta.date}\n\n${headlines}\n\n\ud83d\udd17 watchboard.dev`;
-  return truncateToGraphemes(raw, BLUESKY_MAX_GRAPHEMES);
+  const header = `\ud83d\udcca ${meta.date}`;
+  const footer = `\ud83d\udd17 watchboard.dev`;
+  const skeleton = `${header}\n\n\n\n${footer}`;
+  const skeletonLen = graphemeLength(skeleton);
+
+  // Budget for headlines: total limit minus skeleton
+  let headlineBudget = BLUESKY_MAX_GRAPHEMES - skeletonLen;
+  const lines: string[] = [];
+
+  for (const t of meta.trackers) {
+    const line = `\u2022 ${t.name}: ${t.headline}`;
+    const lineLen = graphemeLength(line) + 1; // +1 for newline
+    if (lineLen > headlineBudget) {
+      // Try to fit a truncated version
+      if (headlineBudget > 10) {
+        lines.push(truncateToGraphemes(line, headlineBudget - 1));
+      }
+      break;
+    }
+    lines.push(line);
+    headlineBudget -= lineLen;
+  }
+
+  return `${header}\n\n${lines.join('\n')}\n\n${footer}`;
 }
 
 async function uploadAndProcessVideo(
@@ -233,11 +254,19 @@ async function uploadAndProcessVideo(
     const filename = basename(videoPath);
     console.log(`[bluesky] Uploading video (${(fileSize / 1024 / 1024).toFixed(1)}MB)...`);
 
+    // Get service auth token for video.bsky.app (session accessJwt is rejected with 401)
+    const serviceAuth = await agent.com.atproto.server.getServiceAuth({
+      aud: 'did:web:video.bsky.app',
+      lxm: 'app.bsky.video.uploadVideo',
+      exp: Math.floor(Date.now() / 1000) + 60 * 30, // 30 min expiry
+    });
+    const videoToken = serviceAuth.data.token;
+
     const uploadUrl = `https://video.bsky.app/xrpc/app.bsky.video.uploadVideo?did=${encodeURIComponent(did)}&name=${encodeURIComponent(filename)}`;
     const uploadRes = await fetch(uploadUrl, {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${accessJwt}`,
+        'Authorization': `Bearer ${videoToken}`,
         'Content-Type': 'video/mp4',
       },
       body: videoBuffer,
@@ -258,8 +287,8 @@ async function uploadAndProcessVideo(
 
     console.log(`[bluesky] Video uploaded, processing job ${jobId}...`);
 
-    // Poll for processing completion
-    const blobRef = await pollVideoJob(accessJwt, jobId);
+    // Poll for processing completion (use service auth token, not session JWT)
+    const blobRef = await pollVideoJob(videoToken, jobId);
     if (!blobRef) return null;
 
     return {
@@ -275,7 +304,7 @@ async function uploadAndProcessVideo(
 }
 
 async function pollVideoJob(
-  accessJwt: string,
+  videoToken: string,
   jobId: string,
 ): Promise<unknown | null> {
   for (let attempt = 0; attempt < POLL_MAX_ATTEMPTS; attempt++) {
@@ -284,7 +313,7 @@ async function pollVideoJob(
     try {
       const statusUrl = `https://video.bsky.app/xrpc/app.bsky.video.getJobStatus?jobId=${encodeURIComponent(jobId)}`;
       const statusRes = await fetch(statusUrl, {
-        headers: { 'Authorization': `Bearer ${accessJwt}` },
+        headers: { 'Authorization': `Bearer ${videoToken}` },
       });
 
       if (!statusRes.ok) {


### PR DESCRIPTION
Video upload was failing with 401 'invalid token' because we used the session JWT instead of a service auth token.

**Fix:** Call `com.atproto.server.getServiceAuth` with `aud: 'did:web:video.bsky.app'` to get the correct token for the video service.

Also:
- Text truncation fixed to fit 300 grapheme Bluesky limit
- Added `postWithVideo()` to `bluesky-post.ts` for reuse