### PR TITLE
fix(video): bulletproof pipeline with graceful fallbacks

### DIFF
--- a/.github/workflows/daily-video.yml
+++ b/.github/workflows/daily-video.yml
@@ -34,10 +34,18 @@ jobs:
       - name: Render video
         run: cd video && npx tsx render.ts
 
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
       - name: Generate narration with Polly
+        continue-on-error: true
         env:
           AWS_REGION: us-east-1
         run: |
+          if ! command -v aws &>/dev/null; then
+            echo "AWS CLI not available — skipping narration"
+            exit 0
+          fi
           DATE=$(date -u +%Y-%m-%d)
           # Extract tracker names from breaking data
           TRACKERS=$(node -e "const d=require('./video/src/data/breaking.json'); console.log(d.trackers.map(t=>t.name).join('. '))")

--- a/video/render.ts
+++ b/video/render.ts
@@ -4,13 +4,15 @@
  * Usage: cd video && npx tsx render.ts
  *
  * Fetches breaking data, bundles the Remotion project, and renders to MP4.
+ * Every step has graceful fallbacks so we always produce SOMETHING.
  */
 import { execSync } from 'node:child_process';
-import { readFileSync, existsSync, mkdirSync } from 'node:fs';
+import { readFileSync, existsSync, mkdirSync, readdirSync, copyFileSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { bundle } from '@remotion/bundler';
 import { renderMedia, selectComposition } from '@remotion/renderer';
 import type { BreakingData } from './src/data/types.js';
+import { SAMPLE_DATA } from './src/data/types.js';
 import { calculateDuration } from './src/Video.js';
 
 const ROOT_DIR = resolve(import.meta.dirname ?? '.');
@@ -18,7 +20,13 @@ const DATA_PATH = resolve(ROOT_DIR, 'src/data/breaking.json');
 const OUTPUT_DIR = resolve(ROOT_DIR, 'output');
 const ENTRY_POINT = resolve(ROOT_DIR, 'src/Root.tsx');
 const NARRATION_PATH = resolve(ROOT_DIR, 'src/assets/narration.mp3');
-const EARTH_TEXTURE_PATH = resolve(ROOT_DIR, '../public/textures/earth-night-lights-nasa.jpg');
+
+// Earth texture candidates in priority order
+const EARTH_TEXTURE_CANDIDATES = [
+  resolve(ROOT_DIR, '../public/textures/earth-night-lights-nasa.jpg'),
+  resolve(ROOT_DIR, '../public/textures/earth-dark-blend-4k.webp'),
+  resolve(ROOT_DIR, '../public/textures/earth-dark-threejs.jpg'),
+];
 
 async function downloadThumbnail(url: string): Promise<Buffer | null> {
   const headers = {
@@ -47,31 +55,46 @@ async function downloadThumbnail(url: string): Promise<Buffer | null> {
 async function main(): Promise<void> {
   console.log('=== Watchboard Video Renderer ===\n');
 
-  // Step 1: Fetch breaking data
+  // Step 1: Fetch breaking data (with fallback to sample data)
   console.log('[1/4] Fetching breaking data...');
-  execSync('npx tsx src/data/fetch-breaking.ts', {
-    cwd: ROOT_DIR,
-    stdio: 'inherit',
-  });
-
-  if (!existsSync(DATA_PATH)) {
-    console.error('ERROR: Breaking data not found at', DATA_PATH);
-    process.exit(1);
+  let data: BreakingData;
+  try {
+    execSync('npx tsx src/data/fetch-breaking.ts', {
+      cwd: ROOT_DIR,
+      stdio: 'inherit',
+    });
+    data = JSON.parse(readFileSync(DATA_PATH, 'utf-8'));
+  } catch (err) {
+    console.warn('  Failed to fetch breaking data — using sample data:', (err as Error).message);
+    data = SAMPLE_DATA;
   }
 
-  const data: BreakingData = JSON.parse(readFileSync(DATA_PATH, 'utf-8'));
+  // Validate data has usable trackers
+  if (!data.trackers || data.trackers.length === 0) {
+    console.warn('  No trackers in data — using sample data');
+    data = SAMPLE_DATA;
+  }
 
   // Download tracker thumbnails for Remotion (can't fetch external URLs during render)
   console.log('  Downloading tracker thumbnails...');
+  const thumbnailDeadline = Date.now() + 30_000; // 30s total budget
   for (const tracker of data.trackers) {
-    for (const url of tracker.thumbnailUrls) {
-      const buf = await downloadThumbnail(url);
-      if (buf && buf.length > 5000) {
-        const ct = url.endsWith('.png') ? 'image/png' : url.endsWith('.webp') ? 'image/webp' : 'image/jpeg';
-        tracker.thumbnailBase64 = `data:${ct};base64,${buf.toString('base64')}`;
-        console.log(`    ${tracker.name}: thumbnail downloaded (${(buf.length / 1024).toFixed(0)} KB)`);
-        break;
+    if (Date.now() > thumbnailDeadline) {
+      console.warn('  Thumbnail download budget exhausted — skipping remaining');
+      break;
+    }
+    try {
+      for (const url of tracker.thumbnailUrls) {
+        const buf = await downloadThumbnail(url);
+        if (buf && buf.length > 5000) {
+          const ct = url.endsWith('.png') ? 'image/png' : url.endsWith('.webp') ? 'image/webp' : 'image/jpeg';
+          tracker.thumbnailBase64 = `data:${ct};base64,${buf.toString('base64')}`;
+          console.log(`    ${tracker.name}: thumbnail downloaded (${(buf.length / 1024).toFixed(0)} KB)`);
+          break;
+        }
       }
+    } catch (err) {
+      console.warn(`    ${tracker.name}: thumbnail download error — skipping:`, (err as Error).message);
     }
     if (!tracker.thumbnailBase64) {
       console.log(`    ${tracker.name}: no thumbnail found, will use globe`);
@@ -79,19 +102,48 @@ async function main(): Promise<void> {
   }
 
   // Load GeoJSON for globe rendering
-  const GEO_PATH = resolve(ROOT_DIR, '../public/geo/countries-110m.json');
-  const geoData = JSON.parse(readFileSync(GEO_PATH, 'utf-8'));
-  const geoFeatures = geoData.features;
+  let geoFeatures: unknown[] = [];
+  try {
+    const GEO_PATH = resolve(ROOT_DIR, '../public/geo/countries-110m.json');
+    const geoData = JSON.parse(readFileSync(GEO_PATH, 'utf-8'));
+    geoFeatures = geoData.features;
+  } catch (err) {
+    console.warn('  GeoJSON load failed — globe will render without countries:', (err as Error).message);
+  }
 
-  // Load earth night-lights texture as base64 data URL
+  // Load earth night-lights texture as base64 data URL (try multiple candidates)
   let earthTexture = '';
-  if (existsSync(EARTH_TEXTURE_PATH)) {
-    const texBuf = readFileSync(EARTH_TEXTURE_PATH);
-    const ext = EARTH_TEXTURE_PATH.endsWith('.webp') ? 'webp' : EARTH_TEXTURE_PATH.endsWith('.png') ? 'png' : 'jpeg';
-    earthTexture = `data:image/${ext};base64,${texBuf.toString('base64')}`;
-    console.log(`  Earth texture: ${(texBuf.length / 1024).toFixed(0)} KB loaded`);
-  } else {
-    console.warn('  Earth texture not found — falling back to polygon rendering');
+  try {
+    for (const texPath of EARTH_TEXTURE_CANDIDATES) {
+      if (existsSync(texPath)) {
+        const texBuf = readFileSync(texPath);
+        const ext = texPath.endsWith('.webp') ? 'webp' : texPath.endsWith('.png') ? 'png' : 'jpeg';
+        earthTexture = `data:image/${ext};base64,${texBuf.toString('base64')}`;
+        console.log(`  Earth texture: ${texPath.split('/').pop()} (${(texBuf.length / 1024).toFixed(0)} KB)`);
+        break;
+      }
+    }
+    if (!earthTexture) {
+      console.warn('  No earth texture found — globe will use polygon fallback');
+    }
+  } catch (err) {
+    console.warn('  Earth texture load failed — globe will use polygon fallback:', (err as Error).message);
+  }
+
+  // Music rotation: pick a track based on day-of-year
+  const musicDir = resolve(ROOT_DIR, 'music');
+  try {
+    if (existsSync(musicDir)) {
+      const musicFiles = readdirSync(musicDir).filter(f => f.endsWith('.mp3'));
+      if (musicFiles.length > 0) {
+        const dayOfYear = Math.floor((Date.now() - new Date(new Date().getFullYear(), 0, 0).getTime()) / 86400000);
+        const selectedMusic = musicFiles[dayOfYear % musicFiles.length];
+        copyFileSync(resolve(musicDir, selectedMusic), resolve(ROOT_DIR, 'public/bg-music.mp3'));
+        console.log(`  Music: ${selectedMusic}`);
+      }
+    }
+  } catch (err) {
+    console.warn('  Music rotation failed — using existing track:', (err as Error).message);
   }
 
   const trackerCount = Math.min(data.trackers.length, 3);
@@ -118,18 +170,36 @@ async function main(): Promise<void> {
   // Override duration based on actual tracker count
   composition.durationInFrames = durationInFrames;
 
-  // Step 4: Render
+  // Step 4: Render (with retry)
   if (!existsSync(OUTPUT_DIR)) mkdirSync(OUTPUT_DIR, { recursive: true });
   const outputPath = resolve(OUTPUT_DIR, `watchboard-${data.date}.mp4`);
 
   console.log(`[4/4] Rendering to ${outputPath}...`);
-  await renderMedia({
-    composition,
-    serveUrl: bundled,
-    codec: 'h264',
-    outputLocation: outputPath,
-    inputProps: { data, geoFeatures, earthTexture },
-  });
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      await renderMedia({
+        composition,
+        serveUrl: bundled,
+        codec: 'h264',
+        outputLocation: outputPath,
+        inputProps: { data, geoFeatures, earthTexture },
+      });
+      break;
+    } catch (err) {
+      if (attempt === 0) {
+        console.warn('  Render failed, retrying...', (err as Error).message);
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  // Output validation
+  const outputStat = statSync(outputPath);
+  if (outputStat.size < 100_000) {
+    throw new Error(`Output too small (${outputStat.size} bytes) — render likely failed`);
+  }
+  console.log(`  Output: ${(outputStat.size / 1024 / 1024).toFixed(1)} MB`);
 
   // Step 5 (optional): Merge narration audio via ffmpeg
   if (existsSync(NARRATION_PATH)) {

--- a/video/src/components/CanvasGlobe.tsx
+++ b/video/src/components/CanvasGlobe.tsx
@@ -622,91 +622,101 @@ export const CanvasGlobe: React.FC<CanvasGlobeProps> = ({
     const cy = height / 2;
     const radius = Math.min(width, height) * 0.46;
 
-    // Compute globe center via smooth interpolation
-    const { lon: rawLon, lat: centerLat } = computeGlobeCenter(
-      trackers,
-      activeTrackerIndex,
-      globalFrame,
-    );
-
-    // Normalize centerLon to [-180, 180]
-    const centerLon = ((rawLon % 360) + 540) % 360 - 180;
-
-    // Clear
-    ctx.clearRect(0, 0, width, height);
-
-    const hasTexture = textureRef.current !== null;
-
-    // 1. Atmosphere glow (drawn before/behind the sphere)
-    drawAtmosphere(ctx, cx, cy, radius);
-
-    if (hasTexture) {
-      // Texture-mapped rendering path
-      // Clip to globe circle
-      ctx.save();
-      ctx.beginPath();
-      ctx.arc(cx, cy, radius, 0, Math.PI * 2);
-      ctx.clip();
-
-      drawTexturedSphere(
-        ctx,
-        cx,
-        cy,
-        radius,
-        centerLon,
-        centerLat,
-        textureRef.current!.data,
-        textureRef.current!.width,
-        textureRef.current!.height,
+    try {
+      // Compute globe center via smooth interpolation
+      const { lon: rawLon, lat: centerLat } = computeGlobeCenter(
+        trackers,
+        activeTrackerIndex,
+        globalFrame,
       );
 
-      ctx.restore();
-    } else {
-      // Fallback: polygon rendering (ocean + grid + countries)
-      drawOcean(ctx, cx, cy, radius);
+      // Normalize centerLon to [-180, 180]
+      const centerLon = ((rawLon % 360) + 540) % 360 - 180;
 
-      ctx.save();
-      ctx.beginPath();
-      ctx.arc(cx, cy, radius, 0, Math.PI * 2);
-      ctx.clip();
+      // Clear
+      ctx.clearRect(0, 0, width, height);
 
-      drawGridLines(ctx, centerLon, centerLat, radius, cx, cy);
+      const hasTexture = textureRef.current !== null;
 
-      if (geoFeatures.length > 0) {
-        drawCountries(ctx, geoFeatures, centerLon, centerLat, radius, cx, cy);
+      // 1. Atmosphere glow (drawn before/behind the sphere)
+      drawAtmosphere(ctx, cx, cy, radius);
+
+      if (hasTexture) {
+        // Texture-mapped rendering path
+        // Clip to globe circle
+        ctx.save();
+        ctx.beginPath();
+        ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+        ctx.clip();
+
+        drawTexturedSphere(
+          ctx,
+          cx,
+          cy,
+          radius,
+          centerLon,
+          centerLat,
+          textureRef.current!.data,
+          textureRef.current!.width,
+          textureRef.current!.height,
+        );
+
+        ctx.restore();
+      } else {
+        // Fallback: polygon rendering (ocean + grid + countries)
+        drawOcean(ctx, cx, cy, radius);
+
+        ctx.save();
+        ctx.beginPath();
+        ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+        ctx.clip();
+
+        drawGridLines(ctx, centerLon, centerLat, radius, cx, cy);
+
+        if (geoFeatures.length > 0) {
+          drawCountries(ctx, geoFeatures, centerLon, centerLat, radius, cx, cy);
+        }
+
+        ctx.restore();
       }
 
-      ctx.restore();
-    }
+      // Rim highlight — bright blue edge like Cesium atmosphere
+      ctx.beginPath();
+      ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+      ctx.strokeStyle = 'rgba(60, 160, 230, 0.35)';
+      ctx.lineWidth = 2.5;
+      ctx.stroke();
+      // Second softer outer rim
+      ctx.beginPath();
+      ctx.arc(cx, cy, radius + 3, 0, Math.PI * 2);
+      ctx.strokeStyle = 'rgba(40, 120, 200, 0.12)';
+      ctx.lineWidth = 4;
+      ctx.stroke();
 
-    // Rim highlight — bright blue edge like Cesium atmosphere
-    ctx.beginPath();
-    ctx.arc(cx, cy, radius, 0, Math.PI * 2);
-    ctx.strokeStyle = 'rgba(60, 160, 230, 0.35)';
-    ctx.lineWidth = 2.5;
-    ctx.stroke();
-    // Second softer outer rim
-    ctx.beginPath();
-    ctx.arc(cx, cy, radius + 3, 0, Math.PI * 2);
-    ctx.strokeStyle = 'rgba(40, 120, 200, 0.12)';
-    ctx.lineWidth = 4;
-    ctx.stroke();
-
-    // 5. Pulsing dot at active tracker location (always on top)
-    if (activeTrackerIndex >= 0 && activeTrackerIndex < trackers.length) {
-      const target = trackers[activeTrackerIndex];
-      drawPulsingDot(
-        ctx,
-        centerLon,
-        centerLat,
-        target.mapCenter[0],
-        target.mapCenter[1],
-        radius,
-        cx,
-        cy,
-        globalFrame,
-        accentColor,
-      );
+      // 5. Pulsing dot at active tracker location (always on top)
+      if (activeTrackerIndex >= 0 && activeTrackerIndex < trackers.length) {
+        const target = trackers[activeTrackerIndex];
+        drawPulsingDot(
+          ctx,
+          centerLon,
+          centerLat,
+          target.mapCenter[0],
+          target.mapCenter[1],
+          radius,
+          cx,
+          cy,
+          globalFrame,
+          accentColor,
+        );
+      }
+    } catch (err) {
+      console.warn('Globe render error:', err);
+      // Ultimate fallback: draw a simple dark circle
+      ctx.clearRect(0, 0, width, height);
+      ctx.beginPath();
+      ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+      ctx.fillStyle = '#0d1117';
+      ctx.fill();
     }
   }, [globalFrame, width, height, geoFeatures, trackers, activeTrackerIndex, accentColor, dpr, earthTexture]);
 

--- a/video/src/components/TrackerSlide.tsx
+++ b/video/src/components/TrackerSlide.tsx
@@ -122,9 +122,15 @@ export const TrackerSlide: React.FC<TrackerSlideProps> = ({
   const imageScale = interpolate(imageSpring, [0, 1], [0.85, 1]);
   const imageY = interpolate(imageSpring, [0, 1], [20, 0]);
 
-  const displayName = stripEmoji(tracker.name).toUpperCase();
-  const displayHeadline = smartTruncate(tracker.headline, 150);
-  const kpiDisplay = `${tracker.kpiPrefix ?? ''}${tracker.kpiValue}${tracker.kpiSuffix ?? ''}`;
+  // Safe defaults for all tracker fields
+  const safeName = tracker.name || tracker.slug || 'Unknown';
+  const safeHeadline = tracker.headline || tracker.name || 'Breaking news update';
+  const safeKpiValue = tracker.kpiValue ?? '—';
+  const safeKpiLabel = tracker.kpiLabel || 'STATUS';
+
+  const displayName = stripEmoji(safeName).toUpperCase();
+  const displayHeadline = smartTruncate(safeHeadline, 150);
+  const kpiDisplay = `${tracker.kpiPrefix ?? ''}${safeKpiValue}${tracker.kpiSuffix ?? ''}`;
 
   // Determine chevron direction from kpiPrefix or kpiSuffix
   const hasUpTrend = (tracker.kpiPrefix ?? '').includes('+') || (tracker.kpiPrefix ?? '').includes('\u2191');
@@ -271,7 +277,7 @@ export const TrackerSlide: React.FC<TrackerSlideProps> = ({
               marginBottom: 6,
             }}
           >
-            {tracker.kpiLabel}
+            {safeKpiLabel}
           </div>
 
           <div


### PR DESCRIPTION
Every step in the video pipeline now handles failures gracefully:

- **Data**: sample fallback if API/fetch fails
- **Thumbnails**: 30s budget, per-tracker try/catch
- **Earth texture**: cascading candidates (NASA → 4K → JPG → polygon fallback)
- **Music**: daily rotation from music/ directory
- **Render**: retry once on failure + output size validation
- **Globe**: try/catch draws dark circle on error
- **Text**: safe defaults for all tracker fields
- **CI**: ffmpeg installed for ffprobe, Polly optional (checks aws CLI)

The video pipeline will ALWAYS produce an output, even if everything goes wrong.