### PR TITLE
feat(stories): unique headline per slide in multi-story trackers

### DIFF
--- a/src/components/islands/CommandCenter/MobileStoryCarousel.tsx
+++ b/src/components/islands/CommandCenter/MobileStoryCarousel.tsx
@@ -418,28 +418,35 @@ export default function MobileStoryCarousel({ trackers, basePath, followedSlugs 
           )}
         </div>
 
-        {/* Content — expanded when paused */}
-        <div className="story-content">
-          {tracker.headline && <p className={`story-headline ${paused ? 'story-headline-expanded' : ''}`}>{tracker.headline}</p>}
-        </div>
-
-        {/* Briefing */}
-        {(tracker.digestSummary || tracker.description) && (
-          <div className={`story-briefing ${paused ? 'story-briefing-expanded' : ''}`}>
-            <div className="story-briefing-label">
-              <span className="story-briefing-dot" />
-              {t('story.briefing', locale)}
-              {tracker.digestSectionsUpdated && tracker.digestSectionsUpdated.length > 0 && (
-                <span className="story-briefing-sections">
-                  {tracker.digestSectionsUpdated.length} {t('story.sectionsUpdated', locale)}
-                </span>
+        {/* Content — expanded when paused; per-slide text for slides 1+ */}
+        {(() => {
+          const currentSlideImage = tracker.eventImages?.[slideIndex];
+          const displayHeadline = (slideIndex > 0 && currentSlideImage?.eventTitle) ? currentSlideImage.eventTitle : tracker.headline;
+          const displayBriefing = (slideIndex > 0 && currentSlideImage?.eventDetail) ? currentSlideImage.eventDetail : (tracker.digestSummary ?? tracker.description);
+          return (
+            <>
+              <div className="story-content">
+                {displayHeadline && <p className={`story-headline ${paused ? 'story-headline-expanded' : ''}`}>{displayHeadline}</p>}
+              </div>
+              {displayBriefing && (
+                <div className={`story-briefing ${paused ? 'story-briefing-expanded' : ''}`}>
+                  <div className="story-briefing-label">
+                    <span className="story-briefing-dot" />
+                    {t('story.briefing', locale)}
+                    {slideIndex === 0 && tracker.digestSectionsUpdated && tracker.digestSectionsUpdated.length > 0 && (
+                      <span className="story-briefing-sections">
+                        {tracker.digestSectionsUpdated.length} {t('story.sectionsUpdated', locale)}
+                      </span>
+                    )}
+                  </div>
+                  <p className="story-briefing-text">
+                    {displayBriefing}
+                  </p>
+                </div>
               )}
-            </div>
-            <p className="story-briefing-text">
-              {tracker.digestSummary ?? tracker.description}
-            </p>
-          </div>
-        )}
+            </>
+          );
+        })()}
 
         {/* KPI strip */}
         {tracker.topKpis.length > 0 && (

--- a/src/lib/tracker-directory-utils.ts
+++ b/src/lib/tracker-directory-utils.ts
@@ -43,7 +43,7 @@ export interface TrackerCardData {
   digestSummary?: string;
   digestSectionsUpdated?: string[];
   latestEventMedia?: { url: string; source: string; tier: number };
-  eventImages?: Array<{ url: string; source: string; tier: number }>;
+  eventImages?: Array<{ url: string; source: string; tier: number; eventTitle?: string; eventDetail?: string }>;
   isBreaking?: boolean;
   recentEventCount?: number;
   avgSourceTier?: number;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -54,7 +54,7 @@ const serializedTrackers = nonDraft.map(t => {
       if (!bestSource) continue;
       const image = evt.media.find(m => m.thumbnail);
       if (image) {
-        eventImages.push({ url: image.thumbnail!, source: image.source || bestSource.name, tier: bestSource.tier });
+        eventImages.push({ url: image.thumbnail!, source: image.source || bestSource.name, tier: bestSource.tier, eventTitle: evt.title, eventDetail: evt.detail?.slice(0, 150) });
       }
     }
     latestEventMedia = eventImages[0];


### PR DESCRIPTION
Each slide now shows its own event title/detail:
- Slide 0: tracker's latest digest headline (main story)
- Slides 1+: individual event titles from the image's source event

Also carries eventTitle + eventDetail in the eventImages array from build time.