### PR TITLE
fix: add clickable Telegram + Bluesky links

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,10 @@ npm start
 
 ### Telegram
 
-Automated breaking news channel — an hourly scan detects new high-priority events across all trackers and posts them to Telegram in real time.
+### Bluesky
+Daily intelligence briefs and breaking news — follow [@watchboard.bsky.social](https://bsky.app/profile/watchboard.bsky.social).
+
+Automated breaking news channel — join [@watchboard_dev](https://t.me/watchboard_dev) for real-time updates.
 
 ### Bluesky
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -132,14 +132,14 @@ const basePath = base.endsWith('/') ? base : `${base}/`;
             <div class="dist-icon">✉️</div>
             <div class="dist-body">
               <strong>Telegram Channel</strong>
-              <p>Automated breaking news posts triggered by an hourly scan. High-priority events across all trackers are pushed to Telegram in real time.</p>
+              <p>Automated breaking news posts triggered by an hourly scan. High-priority events pushed in real time. <a href="https://t.me/watchboard_dev" target="_blank" rel="noopener noreferrer">Join @watchboard_dev →</a></p>
             </div>
           </div>
           <div class="dist-item">
             <div class="dist-icon">🥋</div>
             <div class="dist-body">
               <strong>Bluesky</strong>
-              <p>Automated social posting from the curated social queue. Breaking news, daily digests, and analysis threads published on Bluesky.</p>
+              <p>Automated social posting from the curated social queue. Breaking news, daily digests, and video briefs. <a href="https://bsky.app/profile/watchboard.bsky.social" target="_blank" rel="noopener noreferrer">Follow @watchboard.bsky.social →</a></p>
             </div>
           </div>
           <div class="dist-item">


### PR DESCRIPTION
About page and README mentioned Telegram/Bluesky but had no actual links. Added:
- t.me/watchboard_dev
- bsky.app/profile/watchboard.bsky.social