### PR TITLE
feat(home): unified broadcast sync on desktop home

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ playwright-report/
 # Claude Code / Superpowers (local agent config)
 .claude/
 .superpowers/
+
+# Firebase service account keys
+*firebase-adminsdk*.json

--- a/docs/superpowers/plans/2026-04-03-hourly-breaking-news-pipeline.md
+++ b/docs/superpowers/plans/2026-04-03-hourly-breaking-news-pipeline.md
@@ -1,0 +1,1886 @@
+# Hourly Breaking News Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an hourly workflow that detects breaking news via RSS/GDELT, triages with AI, updates tracker data, posts to X immediately, and auto-creates new trackers for out-of-scope events.
+
+**Architecture:** Two-job GitHub Actions workflow. Job 1 (Scan) does deterministic RSS/GDELT polling + URL dedup + 1-2 turn Claude Sonnet triage. Job 2 (Act) is a matrix job that runs per affected tracker: Claude Code action updates data (10-15 turns), validates, posts to X, and writes to an hourly manifest that the nightly pipeline reads for dedup.
+
+**Tech Stack:** TypeScript scripts (tsx), fast-xml-parser (RSS), GDELT v2 API (fetch), twitter-api-v2 (X posting), Zod (validation), Claude Sonnet (triage), Claude Code action (data updates), GitHub Actions
+
+---
+
+## File Map
+
+### New Files
+| File | Responsibility |
+|------|---------------|
+| `scripts/hourly-types.ts` | Types, paths, state I/O utilities for the hourly pipeline |
+| `scripts/hourly-scan.ts` | RSS feed parsing + GDELT API polling + URL dedup + candidate output |
+| `scripts/hourly-triage.ts` | Builds AI triage prompt, calls Claude Sonnet, parses response, assembles action plan |
+| `scripts/hourly-post.ts` | Direct X posting for breaking news (reuses twitter-api-v2 pattern from post-social-queue.ts) |
+| `public/_hourly/state.json` | Rolling URL/headline cache (48h) — bootstrapped empty |
+| `public/_hourly/today-updates.json` | Daily manifest for nightly dedup — bootstrapped empty |
+| `.github/workflows/hourly-scan.yml` | Two-job workflow: Scan + Act |
+| `tests/hourly-scan.test.ts` | Tests for polling, URL dedup, keyword matching |
+| `tests/hourly-triage.test.ts` | Tests for prompt building, response parsing, action plan assembly |
+| `tests/hourly-types.test.ts` | Tests for state I/O, manifest operations, date rollover |
+
+### Modified Files
+| File | Change |
+|------|--------|
+| `src/lib/tracker-config.ts:65-78` | Add `rssFeeds` to AiConfigSchema |
+| `.github/workflows/update-data.yml` | Resolve phase reads hourly manifest; update phase injects hourly event IDs |
+| `social-config.json` | Add `hourly` cost category |
+
+---
+
+### Task 1: Add `rssFeeds` to Tracker Config Schema
+
+**Files:**
+- Modify: `src/lib/tracker-config.ts:65-78`
+
+- [ ] **Step 1: Add rssFeeds field to AiConfigSchema**
+
+In `src/lib/tracker-config.ts`, the `AiConfigSchema` at line 65 currently ends with `backfillTargets`. Add `rssFeeds`:
+
+```typescript
+const AiConfigSchema = z.object({
+  systemPrompt: z.string(),
+  searchContext: z.string(),
+  enabledSections: z.array(z.string()),
+  coordValidation: z.object({
+    lonMin: z.number(),
+    lonMax: z.number(),
+    latMin: z.number(),
+    latMax: z.number(),
+  }).optional(),
+  updateIntervalDays: z.number().int().positive().default(1),
+  updatePolicy: UpdatePolicySchema.optional(),
+  backfillTargets: z.record(z.string(), z.number().int().positive()).optional(),
+  rssFeeds: z.array(z.string().url()).optional(),
+});
+```
+
+- [ ] **Step 2: Verify build still passes**
+
+Run: `npm run build 2>&1 | tail -20`
+Expected: Build succeeds (optional field, no existing tracker.json breaks)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/tracker-config.ts
+git commit -m "feat(config): add optional rssFeeds to AiConfigSchema"
+```
+
+---
+
+### Task 2: Create Hourly Types Module
+
+**Files:**
+- Create: `scripts/hourly-types.ts`
+- Create: `tests/hourly-types.test.ts`
+
+- [ ] **Step 1: Write tests for state I/O and manifest operations**
+
+Create `tests/hourly-types.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+
+// We'll test against a temp directory
+const TMP = join(__dirname, '__hourly_test_tmp__');
+
+describe('hourly-types', () => {
+  beforeEach(() => {
+    mkdirSync(TMP, { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  describe('loadState', () => {
+    it('returns empty state when file does not exist', async () => {
+      const { loadState } = await import('../scripts/hourly-types.js');
+      const state = loadState(join(TMP, 'state.json'));
+      expect(state.seen).toEqual([]);
+      expect(state.lastScan).toBe('');
+    });
+
+    it('loads existing state and prunes entries older than 48h', async () => {
+      const { loadState } = await import('../scripts/hourly-types.js');
+      const now = new Date();
+      const old = new Date(now.getTime() - 49 * 60 * 60 * 1000).toISOString();
+      const recent = new Date(now.getTime() - 1 * 60 * 60 * 1000).toISOString();
+      writeFileSync(join(TMP, 'state.json'), JSON.stringify({
+        lastScan: old,
+        seen: [
+          { url: 'https://old.com', tracker: 'a', eventId: 'e1', ts: old },
+          { url: 'https://new.com', tracker: 'b', eventId: 'e2', ts: recent },
+        ],
+      }));
+      const state = loadState(join(TMP, 'state.json'));
+      expect(state.seen).toHaveLength(1);
+      expect(state.seen[0].url).toBe('https://new.com');
+    });
+  });
+
+  describe('loadManifest', () => {
+    it('returns empty manifest when file does not exist', async () => {
+      const { loadManifest } = await import('../scripts/hourly-types.js');
+      const manifest = loadManifest(join(TMP, 'today-updates.json'));
+      expect(manifest.updates).toEqual([]);
+    });
+
+    it('archives old manifest and returns fresh one on date rollover', async () => {
+      const { loadManifest } = await import('../scripts/hourly-types.js');
+      mkdirSync(join(TMP, 'archive'), { recursive: true });
+      writeFileSync(join(TMP, 'today-updates.json'), JSON.stringify({
+        date: '2026-04-02',
+        updates: [{ tracker: 'test', action: 'update' }],
+      }));
+      const manifest = loadManifest(join(TMP, 'today-updates.json'), join(TMP, 'archive'));
+      expect(manifest.date).toBe(new Date().toISOString().slice(0, 10));
+      expect(manifest.updates).toEqual([]);
+      expect(existsSync(join(TMP, 'archive', '2026-04-02.json'))).toBe(true);
+    });
+  });
+
+  describe('Candidate normalization', () => {
+    it('normalizes RSS and GDELT candidates to common shape', async () => {
+      const { normalizeCandidate } = await import('../scripts/hourly-types.js');
+      const c = normalizeCandidate({
+        title: 'Breaking: Test Event',
+        url: 'https://reuters.com/article',
+        source: 'Reuters',
+        timestamp: '2026-04-03T15:00:00Z',
+      }, 'iran-conflict', 'rss');
+      expect(c.matchedTracker).toBe('iran-conflict');
+      expect(c.feedOrigin).toBe('rss');
+      expect(c.title).toBe('Breaking: Test Event');
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/hourly-types.test.ts 2>&1 | tail -20`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement hourly-types.ts**
+
+Create `scripts/hourly-types.ts`:
+
+```typescript
+import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync } from 'fs';
+import { join, dirname } from 'path';
+
+// --- Types ---
+
+export interface SeenEntry {
+  url: string;
+  tracker: string;
+  eventId: string;
+  ts: string;
+}
+
+export interface HourlyState {
+  lastScan: string;
+  seen: SeenEntry[];
+}
+
+export interface ManifestUpdate {
+  tracker: string;
+  action: 'update' | 'new_tracker';
+  eventIds: string[];
+  sections: string[];
+  tweetId: string | null;
+  timestamp: string;
+  seeded?: boolean;
+}
+
+export interface HourlyManifest {
+  date: string;
+  updates: ManifestUpdate[];
+}
+
+export interface Candidate {
+  title: string;
+  url: string;
+  source: string;
+  timestamp: string;
+  matchedTracker: string | null;
+  feedOrigin: 'rss' | 'gdelt';
+}
+
+export interface TriageResult {
+  index: number;
+  action: 'update' | 'new_tracker' | 'discard';
+  tracker: string | null;
+  confidence: number;
+  summary: string;
+  reason: string;
+  suggestedSlug?: string;
+  suggestedDomain?: string;
+  suggestedRegion?: string;
+  suggestedName?: string;
+}
+
+export interface ActionPlan {
+  updates: ActionPlanUpdate[];
+  newTrackers: ActionPlanNewTracker[];
+  scannedAt: string;
+  candidateCount: number;
+  discardedCount: number;
+}
+
+export interface ActionPlanUpdate {
+  tracker: string;
+  events: { summary: string; sources: string[]; timestamp: string }[];
+}
+
+export interface ActionPlanNewTracker {
+  suggestedSlug: string;
+  suggestedDomain: string;
+  suggestedRegion: string;
+  suggestedName: string;
+  triggerEvent: { summary: string; sources: string[]; timestamp: string };
+}
+
+// --- Paths ---
+
+const ROOT = join(dirname(new URL(import.meta.url).pathname), '..');
+export const PATHS = {
+  hourlyDir: join(ROOT, 'public', '_hourly'),
+  state: join(ROOT, 'public', '_hourly', 'state.json'),
+  manifest: join(ROOT, 'public', '_hourly', 'today-updates.json'),
+  archiveDir: join(ROOT, 'public', '_hourly', 'archive'),
+  trackersDir: join(ROOT, 'trackers'),
+  socialBudget: join(ROOT, 'public', '_social', 'budget.json'),
+  socialHistory: join(ROOT, 'public', '_social', 'history.json'),
+};
+
+// --- State I/O ---
+
+const PRUNE_HOURS = 48;
+
+export function loadState(path: string = PATHS.state): HourlyState {
+  if (!existsSync(path)) {
+    return { lastScan: '', seen: [] };
+  }
+  try {
+    const raw: HourlyState = JSON.parse(readFileSync(path, 'utf8'));
+    const cutoff = new Date(Date.now() - PRUNE_HOURS * 60 * 60 * 1000).toISOString();
+    raw.seen = raw.seen.filter(e => e.ts > cutoff);
+    return raw;
+  } catch {
+    return { lastScan: '', seen: [] };
+  }
+}
+
+export function saveState(state: HourlyState, path: string = PATHS.state): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(state, null, 2), 'utf8');
+}
+
+// --- Manifest I/O ---
+
+export function todayDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function loadManifest(
+  path: string = PATHS.manifest,
+  archiveDir: string = PATHS.archiveDir,
+): HourlyManifest {
+  const today = todayDate();
+  if (!existsSync(path)) {
+    return { date: today, updates: [] };
+  }
+  try {
+    const raw: HourlyManifest = JSON.parse(readFileSync(path, 'utf8'));
+    if (raw.date !== today) {
+      // Archive yesterday's manifest
+      mkdirSync(archiveDir, { recursive: true });
+      renameSync(path, join(archiveDir, `${raw.date}.json`));
+      return { date: today, updates: [] };
+    }
+    return raw;
+  } catch {
+    return { date: today, updates: [] };
+  }
+}
+
+export function saveManifest(manifest: HourlyManifest, path: string = PATHS.manifest): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(manifest, null, 2), 'utf8');
+}
+
+// --- Candidate Normalization ---
+
+export function normalizeCandidate(
+  raw: { title: string; url: string; source: string; timestamp: string },
+  matchedTracker: string | null,
+  feedOrigin: 'rss' | 'gdelt',
+): Candidate {
+  return {
+    title: raw.title,
+    url: raw.url,
+    source: raw.source,
+    timestamp: raw.timestamp,
+    matchedTracker,
+    feedOrigin,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/hourly-types.test.ts 2>&1 | tail -30`
+Expected: All 4 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/hourly-types.ts tests/hourly-types.test.ts
+git commit -m "feat(hourly): add types, state I/O, and manifest utilities"
+```
+
+---
+
+### Task 3: Create RSS/GDELT Polling Script
+
+**Files:**
+- Create: `scripts/hourly-scan.ts`
+- Create: `tests/hourly-scan.test.ts`
+
+- [ ] **Step 1: Write tests for keyword matching and URL dedup**
+
+Create `tests/hourly-scan.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+
+describe('hourly-scan', () => {
+  describe('extractKeywords', () => {
+    it('extracts 4+ char words, lowercased, without stopwords', async () => {
+      const { extractKeywords } = await import('../scripts/hourly-scan.js');
+      const kw = extractKeywords('Iran-US/Israel conflict 2024 military strikes');
+      expect(kw).toContain('iran');
+      expect(kw).toContain('israel');
+      expect(kw).toContain('conflict');
+      expect(kw).toContain('military');
+      expect(kw).toContain('strikes');
+      expect(kw).not.toContain('2024'); // only digits
+    });
+  });
+
+  describe('matchTrackerByKeywords', () => {
+    it('returns tracker slug when >= 2 keyword hits', async () => {
+      const { matchTrackerByKeywords } = await import('../scripts/hourly-scan.js');
+      const trackerKeywords = new Map([
+        ['iran-conflict', new Set(['iran', 'israel', 'conflict', 'military', 'strikes'])],
+        ['gaza-war', new Set(['gaza', 'hamas', 'israel', 'ceasefire'])],
+      ]);
+      const result = matchTrackerByKeywords('Iran military operation near Israel border', trackerKeywords);
+      expect(result).toBe('iran-conflict');
+    });
+
+    it('returns null when no tracker matches >= 2 keywords', async () => {
+      const { matchTrackerByKeywords } = await import('../scripts/hourly-scan.js');
+      const trackerKeywords = new Map([
+        ['iran-conflict', new Set(['iran', 'israel', 'conflict'])],
+      ]);
+      const result = matchTrackerByKeywords('SpaceX launches Starship rocket', trackerKeywords);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('dedup', () => {
+    it('removes candidates with URLs already in state', async () => {
+      const { dedup } = await import('../scripts/hourly-scan.js');
+      const candidates = [
+        { title: 'A', url: 'https://a.com', source: 'A', timestamp: '', matchedTracker: 'x', feedOrigin: 'rss' as const },
+        { title: 'B', url: 'https://b.com', source: 'B', timestamp: '', matchedTracker: 'x', feedOrigin: 'rss' as const },
+      ];
+      const seenUrls = new Set(['https://a.com']);
+      const result = dedup(candidates, seenUrls);
+      expect(result).toHaveLength(1);
+      expect(result[0].title).toBe('B');
+    });
+  });
+
+  describe('parseRssFeed', () => {
+    it('extracts items from RSS XML', async () => {
+      const { parseRssFeed } = await import('../scripts/hourly-scan.js');
+      const xml = `<?xml version="1.0"?>
+        <rss version="2.0">
+          <channel>
+            <item>
+              <title>Test Article</title>
+              <link>https://example.com/article</link>
+              <pubDate>Thu, 03 Apr 2026 15:00:00 GMT</pubDate>
+              <source>Reuters</source>
+            </item>
+          </channel>
+        </rss>`;
+      const items = parseRssFeed(xml);
+      expect(items).toHaveLength(1);
+      expect(items[0].title).toBe('Test Article');
+      expect(items[0].url).toBe('https://example.com/article');
+    });
+
+    it('handles Atom feeds', async () => {
+      const { parseRssFeed } = await import('../scripts/hourly-scan.js');
+      const xml = `<?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <entry>
+            <title>Atom Article</title>
+            <link href="https://example.com/atom"/>
+            <updated>2026-04-03T15:00:00Z</updated>
+          </entry>
+        </feed>`;
+      const items = parseRssFeed(xml);
+      expect(items).toHaveLength(1);
+      expect(items[0].title).toBe('Atom Article');
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/hourly-scan.test.ts 2>&1 | tail -20`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement hourly-scan.ts**
+
+Create `scripts/hourly-scan.ts`:
+
+```typescript
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'fs';
+import { join } from 'path';
+import { XMLParser } from 'fast-xml-parser';
+import { loadState, saveState, normalizeCandidate, PATHS } from './hourly-types.js';
+import type { Candidate, HourlyState } from './hourly-types.js';
+
+// --- Stopwords (same set as generate-sibling-brief.ts) ---
+
+const STOP_WORDS = new Set([
+  'that', 'this', 'with', 'from', 'have', 'been', 'were', 'they',
+  'their', 'about', 'would', 'could', 'should', 'which', 'there',
+  'where', 'when', 'what', 'will', 'into', 'also', 'than', 'them',
+  'then', 'some', 'other', 'more', 'between', 'including', 'during',
+  'after', 'before', 'since', 'under', 'over', 'such', 'each',
+  'through', 'most', 'same',
+]);
+
+// --- Keyword Extraction ---
+
+export function extractKeywords(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z\s]/g, ' ')
+      .split(/\s+/)
+      .filter(w => w.length >= 4 && !STOP_WORDS.has(w))
+  );
+}
+
+// --- Tracker Keyword Matching ---
+
+export function matchTrackerByKeywords(
+  headline: string,
+  trackerKeywords: Map<string, Set<string>>,
+): string | null {
+  const words = extractKeywords(headline);
+  let bestSlug: string | null = null;
+  let bestCount = 0;
+  for (const [slug, kws] of trackerKeywords) {
+    let count = 0;
+    for (const w of words) {
+      if (kws.has(w)) count++;
+    }
+    if (count >= 2 && count > bestCount) {
+      bestSlug = slug;
+      bestCount = count;
+    }
+  }
+  return bestSlug;
+}
+
+// --- RSS Feed Parsing ---
+
+const xmlParser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+});
+
+interface RssItem {
+  title: string;
+  url: string;
+  source: string;
+  timestamp: string;
+}
+
+export function parseRssFeed(xml: string): RssItem[] {
+  const parsed = xmlParser.parse(xml);
+  const items: RssItem[] = [];
+
+  // RSS 2.0
+  const rssItems = parsed?.rss?.channel?.item;
+  if (rssItems) {
+    const arr = Array.isArray(rssItems) ? rssItems : [rssItems];
+    for (const item of arr) {
+      items.push({
+        title: item.title || '',
+        url: item.link || '',
+        source: item.source || item['dc:creator'] || '',
+        timestamp: item.pubDate || item['dc:date'] || '',
+      });
+    }
+    return items;
+  }
+
+  // Atom
+  const atomEntries = parsed?.feed?.entry;
+  if (atomEntries) {
+    const arr = Array.isArray(atomEntries) ? atomEntries : [atomEntries];
+    for (const entry of arr) {
+      items.push({
+        title: entry.title || '',
+        url: entry.link?.['@_href'] || entry.link || '',
+        source: entry.author?.name || '',
+        timestamp: entry.updated || entry.published || '',
+      });
+    }
+  }
+  return items;
+}
+
+// --- URL Dedup ---
+
+export function dedup(candidates: Candidate[], seenUrls: Set<string>): Candidate[] {
+  return candidates.filter(c => !seenUrls.has(c.url));
+}
+
+// --- Collect Seen URLs from Tracker Events ---
+
+function collectEventUrls(slug: string, daysBack: number = 3): Set<string> {
+  const urls = new Set<string>();
+  const eventsDir = join(PATHS.trackersDir, slug, 'data', 'events');
+  if (!existsSync(eventsDir)) return urls;
+
+  const now = new Date();
+  const files = readdirSync(eventsDir).filter(f => f.endsWith('.json'));
+  for (const file of files) {
+    const dateStr = file.replace('.json', '');
+    const fileDate = new Date(dateStr);
+    const daysDiff = (now.getTime() - fileDate.getTime()) / (1000 * 60 * 60 * 24);
+    if (daysDiff > daysBack) continue;
+    try {
+      const events = JSON.parse(readFileSync(join(eventsDir, file), 'utf8'));
+      for (const event of Array.isArray(events) ? events : []) {
+        for (const src of event.sources || []) {
+          if (src.url) urls.add(src.url);
+        }
+      }
+    } catch { /* skip unparseable */ }
+  }
+  return urls;
+}
+
+// --- GDELT API ---
+
+const GDELT_ENDPOINT = 'https://api.gdeltproject.org/api/v2/doc/doc';
+const GDELT_THEMES = 'theme:TERROR OR theme:MILITARY OR theme:NATURAL_DISASTER OR theme:POLITICAL_VIOLENCE';
+
+async function queryGdelt(query: string, maxRecords: number = 50): Promise<RssItem[]> {
+  const params = new URLSearchParams({
+    query: query,
+    mode: 'ArtList',
+    maxrecords: String(maxRecords),
+    timespan: '120',
+    format: 'json',
+    sort: 'ToneDesc',
+  });
+  try {
+    const res = await fetch(`${GDELT_ENDPOINT}?${params}`, { signal: AbortSignal.timeout(10_000) });
+    if (!res.ok) return [];
+    const data = await res.json() as { articles?: { title: string; url: string; source: string; seendate: string }[] };
+    return (data.articles || []).map(a => ({
+      title: a.title || '',
+      url: a.url || '',
+      source: a.source || '',
+      timestamp: a.seendate || '',
+    }));
+  } catch {
+    console.warn('[hourly-scan] GDELT query failed for:', query);
+    return [];
+  }
+}
+
+// --- Load Tracker Configs ---
+
+interface TrackerInfo {
+  slug: string;
+  searchContext: string;
+  rssFeeds: string[];
+  keywords: Set<string>;
+}
+
+function loadActiveTrackers(): TrackerInfo[] {
+  const trackers: TrackerInfo[] = [];
+  const dirs = readdirSync(PATHS.trackersDir);
+  for (const slug of dirs) {
+    const configPath = join(PATHS.trackersDir, slug, 'tracker.json');
+    if (!existsSync(configPath)) continue;
+    try {
+      const config = JSON.parse(readFileSync(configPath, 'utf8'));
+      if (config.status !== 'active') continue;
+      const searchContext = config.ai?.searchContext || '';
+      trackers.push({
+        slug,
+        searchContext,
+        rssFeeds: config.ai?.rssFeeds || [],
+        keywords: extractKeywords(searchContext),
+      });
+    } catch { /* skip */ }
+  }
+  return trackers;
+}
+
+// --- Fetch RSS Feeds ---
+
+async function fetchRssFeeds(feeds: string[]): Promise<RssItem[]> {
+  const items: RssItem[] = [];
+  const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+  for (const feedUrl of feeds) {
+    try {
+      const res = await fetch(feedUrl, { signal: AbortSignal.timeout(5_000) });
+      if (!res.ok) continue;
+      const xml = await res.text();
+      const parsed = parseRssFeed(xml);
+      for (const item of parsed) {
+        if (item.timestamp && new Date(item.timestamp) < twoHoursAgo) continue;
+        items.push(item);
+      }
+    } catch {
+      console.warn(`[hourly-scan] RSS feed failed: ${feedUrl}`);
+    }
+  }
+  return items;
+}
+
+// --- Main ---
+
+export async function scan(): Promise<{ candidates: Candidate[]; state: HourlyState }> {
+  const state = loadState();
+  const seenUrls = new Set(state.seen.map(s => s.url));
+  const trackers = loadActiveTrackers();
+  const trackerKeywords = new Map(trackers.map(t => [t.slug, t.keywords]));
+  const allCandidates: Candidate[] = [];
+
+  // Per-tracker: RSS feeds
+  for (const tracker of trackers) {
+    if (tracker.rssFeeds.length === 0) continue;
+    const items = await fetchRssFeeds(tracker.rssFeeds);
+    for (const item of items) {
+      allCandidates.push(normalizeCandidate(item, tracker.slug, 'rss'));
+    }
+  }
+
+  // Per-tracker: GDELT by searchContext
+  for (const tracker of trackers) {
+    if (!tracker.searchContext) continue;
+    const items = await queryGdelt(tracker.searchContext, 10);
+    for (const item of items) {
+      allCandidates.push(normalizeCandidate(item, tracker.slug, 'gdelt'));
+    }
+  }
+
+  // Global: GDELT sweep for out-of-scope events
+  const globalItems = await queryGdelt(GDELT_THEMES, 50);
+  for (const item of globalItems) {
+    const matched = matchTrackerByKeywords(item.title, trackerKeywords);
+    allCandidates.push(normalizeCandidate(item, matched, 'gdelt'));
+  }
+
+  // Collect event URLs from tracker data for deeper dedup
+  for (const tracker of trackers) {
+    const urls = collectEventUrls(tracker.slug);
+    for (const url of urls) seenUrls.add(url);
+  }
+
+  // Dedup
+  const fresh = dedup(allCandidates, seenUrls);
+
+  // Deduplicate by URL within the batch (keep first seen)
+  const uniqueByUrl = new Map<string, Candidate>();
+  for (const c of fresh) {
+    if (!uniqueByUrl.has(c.url)) uniqueByUrl.set(c.url, c);
+  }
+
+  const candidates = [...uniqueByUrl.values()];
+  state.lastScan = new Date().toISOString();
+  return { candidates, state };
+}
+
+// --- CLI Entry ---
+
+if (process.argv[1]?.endsWith('hourly-scan.ts') || process.argv[1]?.endsWith('hourly-scan.js')) {
+  scan().then(({ candidates, state }) => {
+    if (candidates.length === 0) {
+      console.log('[hourly-scan] No new candidates. Exiting.');
+      saveState(state);
+      process.exit(0);
+    }
+    console.log(`[hourly-scan] ${candidates.length} candidate(s) found.`);
+    // Write candidates for triage step (writeFileSync already imported at top)
+    writeFileSync('/tmp/hourly-candidates.json', JSON.stringify(candidates, null, 2));
+    saveState(state);
+  }).catch(err => {
+    console.error('[hourly-scan] Fatal error:', err);
+    process.exit(1);
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/hourly-scan.test.ts 2>&1 | tail -30`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/hourly-scan.ts tests/hourly-scan.test.ts
+git commit -m "feat(hourly): add RSS/GDELT polling with keyword matching and URL dedup"
+```
+
+---
+
+### Task 4: Create AI Triage Script
+
+**Files:**
+- Create: `scripts/hourly-triage.ts`
+- Create: `tests/hourly-triage.test.ts`
+
+- [ ] **Step 1: Write tests for prompt building and response parsing**
+
+Create `tests/hourly-triage.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+
+describe('hourly-triage', () => {
+  describe('buildTriagePrompt', () => {
+    it('includes tracker context and candidates', async () => {
+      const { buildTriagePrompt } = await import('../scripts/hourly-triage.js');
+      const prompt = buildTriagePrompt(
+        [{ title: 'Iran strikes', url: 'https://a.com', source: 'Reuters', timestamp: '2026-04-03T15:00:00Z', matchedTracker: 'iran-conflict', feedOrigin: 'gdelt' as const }],
+        new Map([['iran-conflict', ['IAEA inspection report', 'US deploys carrier']]]),
+      );
+      expect(prompt).toContain('iran-conflict');
+      expect(prompt).toContain('Iran strikes');
+      expect(prompt).toContain('IAEA inspection report');
+    });
+  });
+
+  describe('parseTriageResponse', () => {
+    it('parses valid JSON response', async () => {
+      const { parseTriageResponse } = await import('../scripts/hourly-triage.js');
+      const json = JSON.stringify({
+        candidates: [
+          { index: 0, action: 'update', tracker: 'iran-conflict', confidence: 0.9, summary: 'New strike', reason: 'Matches' },
+          { index: 1, action: 'discard', tracker: null, confidence: 0.3, summary: 'Old news', reason: 'Dupe' },
+        ],
+      });
+      const results = parseTriageResponse(json);
+      expect(results).toHaveLength(2);
+      expect(results[0].action).toBe('update');
+      expect(results[1].action).toBe('discard');
+    });
+
+    it('extracts JSON from code fences', async () => {
+      const { parseTriageResponse } = await import('../scripts/hourly-triage.js');
+      const response = '```json\n{"candidates":[{"index":0,"action":"discard","tracker":null,"confidence":0.2,"summary":"x","reason":"y"}]}\n```';
+      const results = parseTriageResponse(response);
+      expect(results).toHaveLength(1);
+    });
+
+    it('returns empty array on unparseable response', async () => {
+      const { parseTriageResponse } = await import('../scripts/hourly-triage.js');
+      const results = parseTriageResponse('not json at all');
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('buildActionPlan', () => {
+    it('groups updates by tracker and filters by confidence', async () => {
+      const { buildActionPlan } = await import('../scripts/hourly-triage.js');
+      const candidates = [
+        { title: 'A', url: 'https://a.com', source: 'Reuters', timestamp: 'T1', matchedTracker: 'iran-conflict', feedOrigin: 'gdelt' as const },
+        { title: 'B', url: 'https://b.com', source: 'AP', timestamp: 'T2', matchedTracker: 'iran-conflict', feedOrigin: 'gdelt' as const },
+        { title: 'C', url: 'https://c.com', source: 'BBC', timestamp: 'T3', matchedTracker: null, feedOrigin: 'gdelt' as const },
+      ];
+      const triageResults = [
+        { index: 0, action: 'update' as const, tracker: 'iran-conflict', confidence: 0.9, summary: 'Event A', reason: '' },
+        { index: 1, action: 'update' as const, tracker: 'iran-conflict', confidence: 0.4, summary: 'Event B', reason: '' },
+        { index: 2, action: 'new_tracker' as const, tracker: null, confidence: 0.85, summary: 'Event C', reason: '',
+          suggestedSlug: 'new-thing', suggestedDomain: 'disaster', suggestedRegion: 'europe', suggestedName: 'New Thing' },
+      ];
+      const plan = buildActionPlan(candidates, triageResults);
+      // Event B filtered out (confidence 0.4 < 0.6)
+      expect(plan.updates).toHaveLength(1);
+      expect(plan.updates[0].tracker).toBe('iran-conflict');
+      expect(plan.updates[0].events).toHaveLength(1);
+      // New tracker passes (0.85 >= 0.8)
+      expect(plan.newTrackers).toHaveLength(1);
+      expect(plan.newTrackers[0].suggestedSlug).toBe('new-thing');
+      expect(plan.discardedCount).toBe(1);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/hourly-triage.test.ts 2>&1 | tail -20`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement hourly-triage.ts**
+
+Create `scripts/hourly-triage.ts`:
+
+```typescript
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'fs';
+import { join } from 'path';
+import { PATHS } from './hourly-types.js';
+import type { Candidate, TriageResult, ActionPlan, ActionPlanUpdate, ActionPlanNewTracker } from './hourly-types.js';
+
+// --- Build Triage Prompt ---
+
+export function buildTriagePrompt(
+  candidates: Candidate[],
+  trackerRecentEvents: Map<string, string[]>,
+): string {
+  let prompt = `You are a breaking news triage analyst for Watchboard, a multi-topic intelligence dashboard.
+Given candidate headlines and existing tracker context, classify each candidate.
+
+EXISTING TRACKERS (last 48h event titles):\n`;
+
+  for (const [slug, events] of trackerRecentEvents) {
+    prompt += `- ${slug}: ${JSON.stringify(events.slice(0, 10))}\n`;
+  }
+
+  prompt += `\nCANDIDATES:\n`;
+  for (let i = 0; i < candidates.length; i++) {
+    const c = candidates[i];
+    prompt += `${i}. title: "${c.title}" | url: ${c.url} | source: ${c.source} | time: ${c.timestamp} | matchedTracker: ${c.matchedTracker || 'none'}\n`;
+  }
+
+  prompt += `
+For each candidate, return a JSON object. Rules:
+- "update": headline is a genuinely NEW development for an existing tracker. Not a rehash of old news.
+- "new_tracker": headline describes a major event (conflict, disaster, crisis) NOT covered by any existing tracker. Must be significant enough to warrant its own dashboard.
+- "discard": duplicate of existing event, minor update, opinion piece, or not significant enough.
+
+Return ONLY valid JSON (no markdown fences):
+{"candidates":[
+  {"index":0,"action":"update","tracker":"slug","confidence":0.9,"summary":"one sentence","reason":"why"},
+  {"index":1,"action":"new_tracker","tracker":null,"confidence":0.85,"summary":"one sentence","reason":"why",
+   "suggestedSlug":"kebab-case","suggestedDomain":"conflict|security|disaster|...","suggestedRegion":"middle-east|europe|...","suggestedName":"Human Readable Name"},
+  {"index":2,"action":"discard","tracker":null,"confidence":0.8,"summary":"","reason":"duplicate of existing event"}
+]}`;
+
+  return prompt;
+}
+
+// --- Parse Triage Response ---
+
+export function parseTriageResponse(response: string): TriageResult[] {
+  // Try direct parse
+  try {
+    const parsed = JSON.parse(response);
+    return parsed.candidates || [];
+  } catch { /* try code fence extraction */ }
+
+  // Extract from code fences
+  const fenceMatch = response.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+  if (fenceMatch) {
+    try {
+      const parsed = JSON.parse(fenceMatch[1]);
+      return parsed.candidates || [];
+    } catch { /* fall through */ }
+  }
+
+  // Try finding JSON object by braces
+  const braceStart = response.indexOf('{');
+  const braceEnd = response.lastIndexOf('}');
+  if (braceStart >= 0 && braceEnd > braceStart) {
+    try {
+      const parsed = JSON.parse(response.slice(braceStart, braceEnd + 1));
+      return parsed.candidates || [];
+    } catch { /* give up */ }
+  }
+
+  console.warn('[hourly-triage] Could not parse triage response');
+  return [];
+}
+
+// --- Build Action Plan ---
+
+const UPDATE_CONFIDENCE_THRESHOLD = 0.6;
+const NEW_TRACKER_CONFIDENCE_THRESHOLD = 0.8;
+
+export function buildActionPlan(
+  candidates: Candidate[],
+  triageResults: TriageResult[],
+): ActionPlan {
+  const updates = new Map<string, ActionPlanUpdate>();
+  const newTrackers: ActionPlanNewTracker[] = [];
+  let discardedCount = 0;
+
+  for (const result of triageResults) {
+    const candidate = candidates[result.index];
+    if (!candidate) continue;
+
+    if (result.action === 'update' && result.tracker && result.confidence >= UPDATE_CONFIDENCE_THRESHOLD) {
+      if (!updates.has(result.tracker)) {
+        updates.set(result.tracker, { tracker: result.tracker, events: [] });
+      }
+      updates.get(result.tracker)!.events.push({
+        summary: result.summary,
+        sources: [candidate.url],
+        timestamp: candidate.timestamp,
+      });
+    } else if (result.action === 'new_tracker' && result.confidence >= NEW_TRACKER_CONFIDENCE_THRESHOLD) {
+      newTrackers.push({
+        suggestedSlug: result.suggestedSlug || 'unknown',
+        suggestedDomain: result.suggestedDomain || 'conflict',
+        suggestedRegion: result.suggestedRegion || 'global',
+        suggestedName: result.suggestedName || candidate.title,
+        triggerEvent: {
+          summary: result.summary,
+          sources: [candidate.url],
+          timestamp: candidate.timestamp,
+        },
+      });
+    } else {
+      discardedCount++;
+    }
+  }
+
+  return {
+    updates: [...updates.values()],
+    newTrackers,
+    scannedAt: new Date().toISOString(),
+    candidateCount: candidates.length,
+    discardedCount,
+  };
+}
+
+// --- Collect Recent Event Titles ---
+
+export function collectRecentEventTitles(daysBack: number = 2): Map<string, string[]> {
+  const result = new Map<string, string[]>();
+  const dirs = readdirSync(PATHS.trackersDir);
+  const cutoff = new Date(Date.now() - daysBack * 24 * 60 * 60 * 1000);
+
+  for (const slug of dirs) {
+    const eventsDir = join(PATHS.trackersDir, slug, 'data', 'events');
+    if (!existsSync(eventsDir)) continue;
+    const titles: string[] = [];
+    const files = readdirSync(eventsDir).filter(f => f.endsWith('.json'));
+    for (const file of files) {
+      const dateStr = file.replace('.json', '');
+      if (new Date(dateStr) < cutoff) continue;
+      try {
+        const events = JSON.parse(readFileSync(join(eventsDir, file), 'utf8'));
+        for (const event of Array.isArray(events) ? events : []) {
+          if (event.title) titles.push(event.title);
+        }
+      } catch { /* skip */ }
+    }
+    if (titles.length > 0) result.set(slug, titles);
+  }
+  return result;
+}
+
+// --- Call Claude Sonnet ---
+
+async function callTriage(prompt: string): Promise<string> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY not set');
+
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: 'claude-sonnet-4-6-20250514',
+      max_tokens: 2048,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Anthropic API ${res.status}: ${text}`);
+  }
+  const data = await res.json() as { content: { type: string; text: string }[] };
+  return data.content[0]?.text || '';
+}
+
+// --- CLI Entry ---
+
+export async function triage(candidatesPath: string): Promise<ActionPlan | null> {
+  const candidates: Candidate[] = JSON.parse(readFileSync(candidatesPath, 'utf8'));
+  if (candidates.length === 0) return null;
+
+  const recentEvents = collectRecentEventTitles();
+  const prompt = buildTriagePrompt(candidates, recentEvents);
+  console.log(`[hourly-triage] Sending ${candidates.length} candidate(s) to triage...`);
+
+  const response = await callTriage(prompt);
+  const results = parseTriageResponse(response);
+  const plan = buildActionPlan(candidates, results);
+
+  console.log(`[hourly-triage] Plan: ${plan.updates.length} update(s), ${plan.newTrackers.length} new tracker(s), ${plan.discardedCount} discarded`);
+  return plan;
+}
+
+if (process.argv[1]?.endsWith('hourly-triage.ts') || process.argv[1]?.endsWith('hourly-triage.js')) {
+  const candidatesPath = process.argv[2] || '/tmp/hourly-candidates.json';
+  triage(candidatesPath).then(plan => {
+    if (!plan || (plan.updates.length === 0 && plan.newTrackers.length === 0)) {
+      console.log('[hourly-triage] No actions needed. Exiting.');
+      process.exit(0);
+    }
+    writeFileSync('/tmp/hourly-action-plan.json', JSON.stringify(plan, null, 2));
+    console.log('[hourly-triage] Action plan written to /tmp/hourly-action-plan.json');
+  }).catch(err => {
+    console.error('[hourly-triage] Fatal error:', err);
+    process.exit(1);
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/hourly-triage.test.ts 2>&1 | tail -30`
+Expected: All 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/hourly-triage.ts tests/hourly-triage.test.ts
+git commit -m "feat(hourly): add AI triage prompt builder and action plan assembly"
+```
+
+---
+
+### Task 5: Create Direct X Posting Script
+
+**Files:**
+- Create: `scripts/hourly-post.ts`
+
+- [ ] **Step 1: Implement hourly-post.ts**
+
+Create `scripts/hourly-post.ts` (reuses pattern from `scripts/post-social-queue.ts:17-61`):
+
+```typescript
+import { TwitterApi } from 'twitter-api-v2';
+import { readFileSync, writeFileSync } from 'fs';
+import { loadManifest, saveManifest, PATHS } from './hourly-types.js';
+import type { ManifestUpdate } from './hourly-types.js';
+
+// --- Twitter Client (same pattern as post-social-queue.ts) ---
+
+function getTwitterClient(): TwitterApi | null {
+  const appKey = process.env.X_API_KEY;
+  const appSecret = process.env.X_API_SECRET;
+  const accessToken = process.env.X_ACCESS_TOKEN;
+  const accessSecret = process.env.X_ACCESS_TOKEN_SECRET;
+  if (!appKey || !appSecret || !accessToken || !accessSecret) {
+    console.log('[hourly-post] Missing X API credentials — skipping');
+    return null;
+  }
+  return new TwitterApi({ appKey, appSecret, accessToken, accessSecret });
+}
+
+async function postTweet(client: TwitterApi, text: string): Promise<string | null> {
+  try {
+    const result = await client.v2.tweet({ text });
+    return result.data.id;
+  } catch (err) {
+    console.error('[hourly-post] Tweet failed:', err);
+    return null;
+  }
+}
+
+// --- Budget & History Tracking ---
+
+interface BudgetData {
+  monthlyTarget: number;
+  currentMonth: string;
+  spent: number;
+  tweetsPosted: number;
+  remaining: number;
+}
+
+interface HistoryEntry {
+  tweetId: string;
+  date: string;
+  tracker: string;
+  type: string;
+  voice: string;
+  lang: string;
+  text: string;
+  cost: number;
+  utmClicks: number;
+  publishedAt: string;
+}
+
+function updateBudget(cost: number): void {
+  try {
+    const budget: BudgetData = JSON.parse(readFileSync(PATHS.socialBudget, 'utf8'));
+    const currentMonth = new Date().toISOString().slice(0, 7);
+    if (budget.currentMonth !== currentMonth) {
+      budget.currentMonth = currentMonth;
+      budget.spent = 0;
+      budget.tweetsPosted = 0;
+      budget.remaining = budget.monthlyTarget;
+    }
+    budget.spent = Math.round((budget.spent + cost) * 100) / 100;
+    budget.tweetsPosted += 1;
+    budget.remaining = Math.round((budget.monthlyTarget - budget.spent) * 100) / 100;
+    writeFileSync(PATHS.socialBudget, JSON.stringify(budget, null, 2), 'utf8');
+  } catch (err) {
+    console.warn('[hourly-post] Budget update failed:', err);
+  }
+}
+
+function appendHistory(entry: HistoryEntry): void {
+  try {
+    const history: HistoryEntry[] = JSON.parse(readFileSync(PATHS.socialHistory, 'utf8'));
+    history.push(entry);
+    writeFileSync(PATHS.socialHistory, JSON.stringify(history, null, 2), 'utf8');
+  } catch (err) {
+    console.warn('[hourly-post] History append failed:', err);
+  }
+}
+
+// --- Main ---
+
+export async function postBreaking(
+  tracker: string,
+  tweetText: string,
+  eventIds: string[],
+  sections: string[],
+): Promise<ManifestUpdate> {
+  const now = new Date().toISOString();
+  const update: ManifestUpdate = {
+    tracker,
+    action: 'update',
+    eventIds,
+    sections,
+    tweetId: null,
+    timestamp: now,
+  };
+
+  const client = getTwitterClient();
+  if (client) {
+    const tweetId = await postTweet(client, tweetText);
+    update.tweetId = tweetId;
+    if (tweetId) {
+      updateBudget(0.01);
+      appendHistory({
+        tweetId,
+        date: now.slice(0, 10),
+        tracker,
+        type: 'breaking',
+        voice: 'journalist',
+        lang: 'en',
+        text: tweetText,
+        cost: 0.01,
+        utmClicks: 0,
+        publishedAt: now,
+      });
+      console.log(`[hourly-post] Posted tweet ${tweetId} for ${tracker}`);
+    }
+  }
+
+  // Append to manifest
+  const manifest = loadManifest();
+  manifest.updates.push(update);
+  saveManifest(manifest);
+
+  return update;
+}
+
+export async function postNewTracker(
+  slug: string,
+  name: string,
+  summary: string,
+  seeded: boolean,
+): Promise<ManifestUpdate> {
+  const now = new Date().toISOString();
+  const baseUrl = 'https://watchboard.dev';
+  const link = `${baseUrl}/${slug}/?utm_source=x&utm_medium=breaking_hourly&utm_campaign=${now.slice(0, 10)}`;
+  const tweetText = `BREAKING: New tracker launched \u2014 ${name}. ${summary}\n\nFollow live: ${link}\n\n#Watchboard`;
+
+  const update: ManifestUpdate = {
+    tracker: slug,
+    action: 'new_tracker',
+    eventIds: ['initial-event'],
+    sections: ['events', 'map-points', 'meta'],
+    tweetId: null,
+    timestamp: now,
+    seeded,
+  };
+
+  const client = getTwitterClient();
+  if (client) {
+    // Trim to 280 chars
+    const trimmed = tweetText.length > 280 ? tweetText.slice(0, 277) + '...' : tweetText;
+    const tweetId = await postTweet(client, trimmed);
+    update.tweetId = tweetId;
+    if (tweetId) {
+      updateBudget(0.01);
+      appendHistory({
+        tweetId,
+        date: now.slice(0, 10),
+        tracker: slug,
+        type: 'breaking',
+        voice: 'journalist',
+        lang: 'en',
+        text: trimmed,
+        cost: 0.01,
+        utmClicks: 0,
+        publishedAt: now,
+      });
+    }
+  }
+
+  const manifest = loadManifest();
+  manifest.updates.push(update);
+  saveManifest(manifest);
+
+  return update;
+}
+```
+
+- [ ] **Step 2: Verify module compiles**
+
+Run: `npx tsx --eval "import './scripts/hourly-post.js'" 2>&1`
+Expected: No errors (module loads without executing)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/hourly-post.ts
+git commit -m "feat(hourly): add direct X posting for breaking news"
+```
+
+---
+
+### Task 6: Bootstrap Initial Data Files
+
+**Files:**
+- Create: `public/_hourly/state.json`
+- Create: `public/_hourly/today-updates.json`
+- Modify: `social-config.json`
+
+- [ ] **Step 1: Create _hourly directory and initial files**
+
+Create `public/_hourly/state.json`:
+
+```json
+{
+  "lastScan": "",
+  "seen": []
+}
+```
+
+Create `public/_hourly/today-updates.json`:
+
+```json
+{
+  "date": "2026-04-03",
+  "updates": []
+}
+```
+
+- [ ] **Step 2: Add hourly cost category to social-config.json**
+
+In `social-config.json`, add a `hourlyCosts` key after the existing `apiCosts`:
+
+```json
+"hourlyCosts": {
+  "breakingTweet": 0.01,
+  "newTrackerTweet": 0.01
+},
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add public/_hourly/state.json public/_hourly/today-updates.json social-config.json
+git commit -m "feat(hourly): bootstrap state files and update social config"
+```
+
+---
+
+### Task 7: Create the Workflow File
+
+**Files:**
+- Create: `.github/workflows/hourly-scan.yml`
+
+- [ ] **Step 1: Create the workflow**
+
+Create `.github/workflows/hourly-scan.yml`:
+
+```yaml
+name: Hourly Breaking News Scan
+
+on:
+  schedule:
+    - cron: '0 * * * *' # Every hour
+  workflow_dispatch: {}
+
+concurrency:
+  group: hourly-scan
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  # ─── JOB 1: SCAN ──────────────────────────────────────────────
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      has_actions: ${{ steps.triage.outputs.has_actions }}
+      plan_json: ${{ steps.triage.outputs.plan_json }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+
+      # Step 1 + 2: RSS/GDELT poll + URL dedup
+      - name: Poll news sources
+        id: poll
+        run: |
+          npx tsx scripts/hourly-scan.ts
+          if [ -f /tmp/hourly-candidates.json ]; then
+            count=$(node -e "console.log(JSON.parse(require('fs').readFileSync('/tmp/hourly-candidates.json','utf8')).length)")
+            echo "candidates=$count" >> "$GITHUB_OUTPUT"
+            echo "has_candidates=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "candidates=0" >> "$GITHUB_OUTPUT"
+            echo "has_candidates=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Step 3 + 4: AI triage + action plan
+      - name: AI triage
+        id: triage
+        if: steps.poll.outputs.has_candidates == 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          npx tsx scripts/hourly-triage.ts /tmp/hourly-candidates.json
+
+          if [ -f /tmp/hourly-action-plan.json ]; then
+            # Read plan and check if there are actions
+            node -e "
+              const plan = JSON.parse(require('fs').readFileSync('/tmp/hourly-action-plan.json','utf8'));
+              const hasActions = plan.updates.length > 0 || plan.newTrackers.length > 0;
+              console.log('has_actions=' + hasActions);
+
+              // Build matrix entries
+              const entries = [];
+              for (const u of plan.updates) {
+                entries.push({ type: 'update', tracker: u.tracker, data: JSON.stringify(u) });
+              }
+              for (const nt of plan.newTrackers) {
+                entries.push({ type: 'new_tracker', tracker: nt.suggestedSlug, data: JSON.stringify(nt) });
+              }
+              console.log('plan_json=' + JSON.stringify(entries));
+            " >> "$GITHUB_OUTPUT"
+          else
+            echo "has_actions=false" >> "$GITHUB_OUTPUT"
+            echo "plan_json=[]" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Commit state updates (seen URLs) even when no actions
+      - name: Commit state
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add public/_hourly/state.json || true
+          if git diff --cached --quiet; then
+            echo "No state changes"
+          else
+            git commit -m "chore(hourly): update scan state $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            for i in 1 2 3; do
+              git pull --rebase origin main && git push && break
+              sleep $((RANDOM % 5 + 2))
+            done
+          fi
+
+      - name: Upload action plan
+        if: steps.triage.outputs.has_actions == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: hourly-action-plan
+          path: /tmp/hourly-action-plan.json
+          retention-days: 1
+
+  # ─── JOB 2: ACT ───────────────────────────────────────────────
+  act:
+    needs: scan
+    if: needs.scan.outputs.has_actions == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        entry: ${{ fromJSON(needs.scan.outputs.plan_json) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: hourly-action-plan
+          path: /tmp/
+
+      # ── Existing tracker update ──
+      - name: Update tracker data
+        if: matrix.entry.type == 'update'
+        uses: anthropics/claude-code-action@v1
+        with:
+          allowed_bots: "github-actions[bot]"
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--max-turns 15 --dangerously-skip-permissions"
+          prompt: |
+            You are updating the Watchboard tracker "${{ matrix.entry.tracker }}" with a breaking news event.
+
+            STEP 1: Read the schemas and tracker config:
+            - Read src/lib/schemas.ts (focus on TimelineEventSchema, MapPointSchema, MapLineSchema, SourceSchema)
+            - Read trackers/${{ matrix.entry.tracker }}/tracker.json
+
+            STEP 2: Here is the triage data for this update:
+            ${{ matrix.entry.data }}
+
+            STEP 3: Update the tracker data files:
+            - Create or append to trackers/${{ matrix.entry.tracker }}/data/events/$(date -u +%Y-%m-%d).json
+            - Update trackers/${{ matrix.entry.tracker }}/data/map-points.json if event has a location
+            - Update trackers/${{ matrix.entry.tracker }}/data/map-lines.json if event involves movement/strike
+            - Update trackers/${{ matrix.entry.tracker }}/data/kpis.json if metrics changed
+            - Update trackers/${{ matrix.entry.tracker }}/data/meta.json: set heroHeadline and lastUpdated
+
+            VALIDATION RULES (MUST follow):
+            - year field MUST be a string like "Apr 3, 2026" (NOT a number)
+            - source.pole MUST be one of: "western", "middle_eastern", "eastern", "international"
+            - All IDs must be unique kebab-case strings
+            - NO future dates (today is $(date -u +%Y-%m-%d))
+            - If adding map-lines with cat "strike" or "retaliation": weaponType AND time are REQUIRED
+            - Map coordinates must be within tracker's coordValidation bounds
+            - Merge by ID — never remove existing items, only append
+
+            STEP 4: Generate a tweet for this event:
+            - Write the tweet text to /tmp/tweet-text.txt
+            - Max 280 characters (URLs count as 23 chars via t.co)
+            - Include the tracker link: https://watchboard.dev/${{ matrix.entry.tracker }}/?utm_source=x&utm_medium=breaking_hourly&utm_campaign=$(date -u +%Y-%m-%d)
+            - Add 1 topic hashtag + #Watchboard (2 max)
+            - Tone: breaking news journalist, factual, concise
+
+            STEP 5: Write the list of new event IDs (one per line) to /tmp/event-ids.txt
+            Write the list of sections you modified (one per line) to /tmp/sections.txt
+
+      # ── Post to X ──
+      - name: Post breaking tweet
+        if: matrix.entry.type == 'update'
+        env:
+          X_API_KEY: ${{ secrets.X_API_KEY }}
+          X_API_SECRET: ${{ secrets.X_API_SECRET }}
+          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+        run: |
+          if [ -f /tmp/tweet-text.txt ]; then
+            TWEET_TEXT=$(cat /tmp/tweet-text.txt)
+            EVENT_IDS=$(cat /tmp/event-ids.txt 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+            SECTIONS=$(cat /tmp/sections.txt 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+
+            npx tsx -e "
+              import { postBreaking } from './scripts/hourly-post.js';
+              postBreaking(
+                '${{ matrix.entry.tracker }}',
+                process.env.TWEET_TEXT!,
+                process.env.EVENT_IDS!.split(',').filter(Boolean),
+                process.env.SECTIONS!.split(',').filter(Boolean),
+              ).then(u => console.log('[act] Posted:', JSON.stringify(u)))
+               .catch(e => console.error('[act] Post failed:', e));
+            "
+          fi
+
+      # ── New tracker creation ──
+      - name: Create new tracker
+        if: matrix.entry.type == 'new_tracker'
+        uses: anthropics/claude-code-action@v1
+        with:
+          allowed_bots: "github-actions[bot]"
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--max-turns 25 --dangerously-skip-permissions"
+          prompt: |
+            You are creating a new Watchboard tracker based on a breaking news event.
+
+            STEP 1: Study the system:
+            - Read src/lib/tracker-config.ts for TrackerConfigSchema
+            - Read src/lib/schemas.ts for data schemas
+            - Read one existing tracker as a template (pick one matching the domain below)
+
+            STEP 2: Here is the new tracker specification:
+            ${{ matrix.entry.data }}
+
+            STEP 3: Create trackers/${{ matrix.entry.tracker }}/tracker.json with:
+            - slug: "${{ matrix.entry.tracker }}"
+            - status: "active", temporal: "live"
+            - Appropriate domain, region, country from the spec
+            - startDate: today $(date -u +%Y-%m-%d)
+            - sections: [hero, kpis, timeline, map, claims, political]
+            - Map bounds derived from the event's geographic region (use real coordinates)
+            - 3-4 map categories relevant to the topic
+            - Globe: enabled with 4-5 camera presets at real locations
+            - AI config with searchContext from the trigger event
+            - updateIntervalDays: 1
+            - backfillTargets: {timeline: 10, mapPoints: 5, claims: 5, political: 5}
+
+            STEP 4: Create trackers/${{ matrix.entry.tracker }}/data/ with:
+            - meta.json: populated with trigger event info
+            - events/$(date -u +%Y-%m-%d).json: the trigger event as first entry
+            - map-points.json: event location (if known)
+            - Empty arrays: kpis.json, timeline.json, map-lines.json, claims.json, political.json,
+              casualties.json, econ.json, strike-targets.json, retaliation.json, assets.json, digests.json
+            - update-log.json: {lastRun: "$(date -u +%Y-%m-%dT%H:%M:%SZ)", sections: {}}
+
+            STEP 5: Validate:
+            - Read back tracker.json and verify it's valid JSON
+            - Run: npx tsx -e "import {TrackerConfigSchema} from './src/lib/tracker-config.js'; const c = JSON.parse(require('fs').readFileSync('trackers/${{ matrix.entry.tracker }}/tracker.json','utf8')); TrackerConfigSchema.parse(c); console.log('Config valid')"
+
+            STEP 6: Decide if historical seeding is needed:
+            - If this is a sudden event (earthquake, attack, etc.) write "false" to /tmp/should-seed.txt
+            - If this is an ongoing situation with history write "true" to /tmp/should-seed.txt
+
+      - name: Post new tracker tweet
+        if: matrix.entry.type == 'new_tracker'
+        env:
+          X_API_KEY: ${{ secrets.X_API_KEY }}
+          X_API_SECRET: ${{ secrets.X_API_SECRET }}
+          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+        run: |
+          TRACKER="${{ matrix.entry.tracker }}"
+          SHOULD_SEED=$(cat /tmp/should-seed.txt 2>/dev/null || echo "false")
+
+          # Extract name and summary from the plan data
+          npx tsx -e "
+            const data = ${{ matrix.entry.data }};
+            import { postNewTracker } from './scripts/hourly-post.js';
+            postNewTracker(
+              '${{ matrix.entry.tracker }}',
+              data.suggestedName,
+              data.triggerEvent.summary,
+              '$SHOULD_SEED' === 'true',
+            ).then(u => console.log('[act] Posted new tracker:', JSON.stringify(u)))
+             .catch(e => console.error('[act] Post failed:', e));
+          "
+
+      - name: Trigger seed job
+        if: matrix.entry.type == 'new_tracker'
+        run: |
+          SHOULD_SEED=$(cat /tmp/should-seed.txt 2>/dev/null || echo "false")
+          if [ "$SHOULD_SEED" = "true" ]; then
+            gh workflow run seed-tracker.yml \
+              -f tracker_slug="${{ matrix.entry.tracker }}" \
+              -f sections="all"
+            echo "Seed job triggered for ${{ matrix.entry.tracker }}"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── Validate + Commit ──
+      - name: Validate modified JSON
+        run: |
+          TRACKER="${{ matrix.entry.tracker }}"
+          VALID=true
+          for f in trackers/$TRACKER/data/*.json trackers/$TRACKER/data/events/*.json; do
+            [ -f "$f" ] || continue
+            node -e "JSON.parse(require('fs').readFileSync('$f','utf8'))" 2>/dev/null || {
+              echo "INVALID JSON: $f"
+              VALID=false
+            }
+          done
+          if [ "$VALID" = "false" ]; then
+            echo "::error::JSON validation failed for $TRACKER"
+            exit 1
+          fi
+
+          # Zod validation on event files
+          npx tsx -e "
+            import {TimelineEventSchema} from './src/lib/schemas.js';
+            import {readdirSync, readFileSync} from 'fs';
+            const dir = 'trackers/$TRACKER/data/events';
+            try {
+              for (const f of readdirSync(dir)) {
+                if (!f.endsWith('.json')) continue;
+                const events = JSON.parse(readFileSync(dir+'/'+f,'utf8'));
+                for (const e of Array.isArray(events) ? events : [events]) {
+                  TimelineEventSchema.parse(e);
+                }
+              }
+              console.log('Zod validation passed');
+            } catch(e: any) { console.error('Zod error:', e.message); process.exit(1); }
+          "
+
+      - name: Update update-log
+        run: |
+          TRACKER="${{ matrix.entry.tracker }}"
+          LOG_FILE="trackers/$TRACKER/data/update-log.json"
+          node -e "
+            const fs = require('fs');
+            const log = fs.existsSync('$LOG_FILE')
+              ? JSON.parse(fs.readFileSync('$LOG_FILE','utf8'))
+              : {lastRun:'',sections:{}};
+            log.lastRun = new Date().toISOString();
+            const sections = (process.env.SECTIONS || '').split(',').filter(Boolean);
+            for (const s of sections) log.sections[s] = {lastRun: log.lastRun, status: 'updated'};
+            fs.writeFileSync('$LOG_FILE', JSON.stringify(log, null, 2));
+          "
+        env:
+          SECTIONS: ${{ matrix.entry.type == 'update' && 'events,map-points,kpis,meta' || 'events,map-points,meta' }}
+
+      - name: Commit and push
+        run: |
+          TRACKER="${{ matrix.entry.tracker }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "trackers/$TRACKER/" public/_hourly/ public/_social/ || true
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          TYPE="${{ matrix.entry.type }}"
+          if [ "$TYPE" = "new_tracker" ]; then
+            MSG="feat(hourly): create tracker $TRACKER $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          else
+            MSG="chore(hourly): update $TRACKER $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          fi
+          git commit -m "$MSG"
+          for i in 1 2 3; do
+            git pull --rebase origin main && git push && break
+            sleep $((RANDOM % 8 + 2))
+          done
+
+      - name: Job summary
+        if: always()
+        run: |
+          echo "## Hourly Pipeline — ${{ matrix.entry.tracker }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Type:** ${{ matrix.entry.type }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Timestamp:** $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f /tmp/tweet-text.txt ]; then
+            echo "- **Tweet:** $(cat /tmp/tweet-text.txt)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+```
+
+- [ ] **Step 2: Validate YAML syntax**
+
+Run: `node -e "const yaml = require('yaml'); yaml.parse(require('fs').readFileSync('.github/workflows/hourly-scan.yml','utf8')); console.log('Valid YAML')" 2>&1`
+
+If `yaml` not available: `npx yaml-lint .github/workflows/hourly-scan.yml` or just check with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/hourly-scan.yml'))"`
+
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/hourly-scan.yml
+git commit -m "feat(hourly): add hourly-scan workflow with scan + act jobs"
+```
+
+---
+
+### Task 8: Modify Nightly Pipeline for Hourly Dedup
+
+**Files:**
+- Modify: `.github/workflows/update-data.yml`
+
+- [ ] **Step 1: Add hourly manifest reading to the resolve phase**
+
+In `update-data.yml`, in the resolve job after the eligible trackers step (around line 114), add a new step:
+
+```yaml
+      - name: Read hourly manifest for dedup
+        id: hourly
+        run: |
+          MANIFEST="public/_hourly/today-updates.json"
+          if [ -f "$MANIFEST" ]; then
+            node -e "
+              const manifest = JSON.parse(require('fs').readFileSync('$MANIFEST','utf8'));
+              const today = new Date().toISOString().slice(0,10);
+              if (manifest.date !== today) {
+                console.log('hourly_updates={}');
+                return;
+              }
+              const byTracker = {};
+              for (const u of manifest.updates) {
+                if (!byTracker[u.tracker]) byTracker[u.tracker] = { eventIds: [], sections: [] };
+                byTracker[u.tracker].eventIds.push(...u.eventIds);
+                for (const s of u.sections) {
+                  if (!byTracker[u.tracker].sections.includes(s)) byTracker[u.tracker].sections.push(s);
+                }
+              }
+              console.log('hourly_updates=' + JSON.stringify(byTracker));
+            " >> "$GITHUB_OUTPUT"
+          else
+            echo "hourly_updates={}" >> "$GITHUB_OUTPUT"
+          fi
+```
+
+- [ ] **Step 2: Inject hourly context into the update job prompt**
+
+In the update job, in the step that builds the Claude Code prompt (around line 188 where sibling context is injected), add the hourly dedup block. Find the prompt section and add after the sibling context:
+
+```yaml
+            HOURLY DEDUP — The following events were already ingested today by the hourly pipeline. Do NOT re-add them:
+            ${{ steps.hourly.outputs.hourly_updates }}
+            If sections listed were already updated hourly, focus your effort on OTHER sections not listed.
+```
+
+- [ ] **Step 3: Add manifest cleanup to finalize phase**
+
+In the finalize job, after the metrics commit step (around line 795), add:
+
+```yaml
+      - name: Clean up old hourly manifests
+        run: |
+          ARCHIVE_DIR="public/_hourly/archive"
+          if [ -d "$ARCHIVE_DIR" ]; then
+            find "$ARCHIVE_DIR" -name "*.json" -mtime +3 -delete 2>/dev/null || true
+            echo "Pruned hourly archives older than 3 days"
+          fi
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/update-data.yml
+git commit -m "feat(hourly): integrate hourly manifest dedup into nightly pipeline"
+```
+
+---
+
+### Task 9: Add RSS Feeds to Key Trackers
+
+**Files:**
+- Modify: `trackers/iran-conflict/tracker.json`
+- Modify: `trackers/gaza-war/tracker.json`
+- Modify: `trackers/ukraine-war/tracker.json`
+
+- [ ] **Step 1: Add rssFeeds to iran-conflict**
+
+In `trackers/iran-conflict/tracker.json`, inside the `ai` object, add after `backfillTargets`:
+
+```json
+"rssFeeds": [
+  "https://news.google.com/rss/search?q=Iran+conflict+military&hl=en-US&gl=US&ceid=US:en",
+  "https://www.aljazeera.com/xml/rss/all.xml"
+]
+```
+
+- [ ] **Step 2: Add rssFeeds to gaza-war**
+
+In `trackers/gaza-war/tracker.json`, inside the `ai` object, add after `backfillTargets`:
+
+```json
+"rssFeeds": [
+  "https://news.google.com/rss/search?q=Gaza+war+Israel+Hamas&hl=en-US&gl=US&ceid=US:en",
+  "https://www.aljazeera.com/xml/rss/all.xml"
+]
+```
+
+- [ ] **Step 3: Add rssFeeds to ukraine-war**
+
+In `trackers/ukraine-war/tracker.json`, inside the `ai` object, add after `backfillTargets`:
+
+```json
+"rssFeeds": [
+  "https://news.google.com/rss/search?q=Ukraine+war+Russia&hl=en-US&gl=US&ceid=US:en"
+]
+```
+
+- [ ] **Step 4: Verify build passes**
+
+Run: `npm run build 2>&1 | tail -20`
+Expected: Build succeeds (rssFeeds is optional, valid URL arrays)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add trackers/iran-conflict/tracker.json trackers/gaza-war/tracker.json trackers/ukraine-war/tracker.json
+git commit -m "feat(hourly): add RSS feeds to key conflict trackers"
+```
+
+---
+
+### Task 10: Run Full Test Suite and Final Verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run all hourly tests**
+
+Run: `npx vitest run tests/hourly-*.test.ts 2>&1`
+Expected: All tests PASS
+
+- [ ] **Step 2: Verify build passes with all changes**
+
+Run: `npm run build 2>&1 | tail -30`
+Expected: Build succeeds
+
+- [ ] **Step 3: Verify workflow YAML is valid**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/hourly-scan.yml')); print('Valid')" 2>&1`
+Expected: "Valid"
+
+- [ ] **Step 4: Dry-run the scan script locally (will fail on GDELT network call, but verifies imports)**
+
+Run: `npx tsx -e "import { extractKeywords, matchTrackerByKeywords, dedup, parseRssFeed } from './scripts/hourly-scan.js'; console.log('All exports OK')" 2>&1`
+Expected: "All exports OK"
+
+- [ ] **Step 5: Verify hourly-types exports**
+
+Run: `npx tsx -e "import { loadState, loadManifest, saveState, saveManifest, PATHS } from './scripts/hourly-types.js'; console.log('Paths:', Object.keys(PATHS).join(', '))" 2>&1`
+Expected: Lists all path keys
+
+- [ ] **Step 6: Final commit with any fixups**
+
+Only if previous steps revealed issues. Otherwise, skip.

--- a/docs/superpowers/plans/2026-04-16-desktop-home-sync.md
+++ b/docs/superpowers/plans/2026-04-16-desktop-home-sync.md
@@ -1,0 +1,944 @@
+# Desktop Home Unified Broadcast Sync — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `useBroadcastMode` the single source of truth for the desktop homepage, so `DesktopStoryStrip`, `BroadcastOverlay`, `SidebarPanel`, and the globe camera all reflect the same featured tracker on every tick.
+
+**Architecture:** Keep all three desktop surfaces (lower-third, story strip, sidebar directory) and the globe. Replace the strip's independent `useStoryState` timer with broadcast-driven props. Add a `featuredSlug` prop to the sidebar that scrolls the matching row into view and pulses a LIVE badge. Change `handleSelect` so user clicks on any surface jump the broadcast cycle (and pause it) rather than tear down the experience.
+
+**Tech Stack:** Astro 5 + React 19 islands, TypeScript, CSS, Vitest (for non-UI unit tests; no React Testing Library setup exists, so UI verification is via Playwright / manual browser test).
+
+**Spec:** `docs/superpowers/specs/2026-04-16-desktop-home-sync-design.md`
+
+---
+
+## File Structure
+
+**Modify:**
+- `src/components/islands/CommandCenter/DesktopStoryStrip.tsx` — drop `useStoryState`, accept broadcast-driven props, single progress bar
+- `src/components/islands/CommandCenter/CommandCenter.tsx` — decouple `broadcastEnabled` from `activeTracker`, rewrite `handleSelect`, thread broadcast state into strip and sidebar, delete `handleStoryTrackerChange`
+- `src/components/islands/CommandCenter/SidebarPanel.tsx` — add `featuredSlug` prop, auto-scroll on change, LIVE badge on matching row
+- `src/styles/desktop-stories.css` — simplify progress bar to single segment driven by inline style width
+- `src/styles/global.css` — add `.cc-tracker-live-pulse` animation (small, lives with other global CC styles)
+
+**Leave alone:**
+- `src/components/islands/CommandCenter/useStoryState.ts` — still used by `MobileStoryCarousel`, don't touch
+- `src/components/islands/CommandCenter/useBroadcastMode.ts` — already exposes everything we need
+- `src/components/islands/CommandCenter/BroadcastOverlay.tsx` — already broadcast-driven
+- `src/components/islands/CommandCenter/MobileStoryCarousel.tsx` — mobile only, not affected
+
+---
+
+## Task 1: Rewrite DesktopStoryStrip to props-driven
+
+**Files:**
+- Modify (rewrite): `src/components/islands/CommandCenter/DesktopStoryStrip.tsx`
+
+- [ ] **Step 1.1: Replace DesktopStoryStrip with props-driven version**
+
+Overwrite the file with:
+
+```tsx
+import { useRef, useEffect, useMemo } from 'react';
+import type { TrackerCardData } from '../../../lib/tracker-directory-utils';
+import { relativeTime } from '../../../lib/event-utils';
+import { t, getPreferredLocale } from '../../../i18n/translations';
+
+// ── Types ──
+
+interface Props {
+  basePath: string;
+  trackerQueue: TrackerCardData[];
+  featuredTracker: TrackerCardData | null;
+  currentIndex: number;
+  progress: number;            // 0..1
+  isPaused: boolean;
+  pauseCountdown: number;
+  onCircleClick: (slug: string) => void;
+  onCardClick: () => void;
+}
+
+// ── Constants ──
+
+const MAX_CIRCLES = 20;
+
+const KPI_COLORS = [
+  'var(--accent-red)',
+  'var(--accent-amber)',
+] as const;
+
+const DOMAIN_GRADIENTS: Record<string, string> = {
+  military: 'linear-gradient(135deg, #1a0a0a, #2c1010, #0d1117)',
+  conflict: 'linear-gradient(135deg, #1a0a0a, #2c1010, #0d1117)',
+  politics: 'linear-gradient(135deg, #0a0a1a, #101030, #0d1117)',
+  sports: 'linear-gradient(135deg, #0a1a0a, #102010, #0d1117)',
+  crisis: 'linear-gradient(135deg, #1a0f00, #2c1a05, #0d1117)',
+  culture: 'linear-gradient(135deg, #1a0a1a, #2c102c, #0d1117)',
+  default: 'linear-gradient(135deg, #12141a, #181b23, #0d1117)',
+};
+
+// ── Helpers ──
+
+function domainGradient(domain?: string): string {
+  if (!domain) return DOMAIN_GRADIENTS.default;
+  return DOMAIN_GRADIENTS[domain] ?? DOMAIN_GRADIENTS.default;
+}
+
+// ── Component ──
+
+export default function DesktopStoryStrip({
+  basePath,
+  trackerQueue,
+  featuredTracker,
+  currentIndex,
+  progress,
+  isPaused,
+  pauseCountdown,
+  onCircleClick,
+  onCardClick,
+}: Props) {
+  const locale = getPreferredLocale();
+  const circlesRef = useRef<HTMLDivElement>(null);
+  const seenRef = useRef<Set<string>>(new Set());
+
+  // Accumulate "seen" slugs as cycle advances
+  useEffect(() => {
+    if (featuredTracker) seenRef.current.add(featuredTracker.slug);
+  }, [featuredTracker]);
+
+  // Auto-scroll circle column to keep active circle visible
+  useEffect(() => {
+    const container = circlesRef.current;
+    if (!container) return;
+    const activeCircle = container.children[currentIndex] as HTMLElement | undefined;
+    if (activeCircle) {
+      activeCircle.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }, [currentIndex]);
+
+  const visibleCircles = useMemo(
+    () => trackerQueue.slice(0, MAX_CIRCLES),
+    [trackerQueue],
+  );
+
+  if (visibleCircles.length === 0 || !featuredTracker) return null;
+
+  const kpis = featuredTracker.topKpis.slice(0, 2);
+  const progressPct = Math.max(0, Math.min(100, progress * 100));
+
+  return (
+    <div className="desktop-story-strip">
+      {/* Circle column */}
+      <div className="desktop-story-circles" ref={circlesRef}>
+        {visibleCircles.map((tr, i) => (
+          <div
+            key={tr.slug}
+            className={
+              `desktop-story-circle` +
+              (i === currentIndex ? ' active' : '') +
+              (seenRef.current.has(tr.slug) && i !== currentIndex ? ' seen' : '')
+            }
+            onClick={() => onCircleClick(tr.slug)}
+            title={tr.shortName}
+          >
+            {tr.icon ?? '?'}
+          </div>
+        ))}
+      </div>
+
+      {/* Story card */}
+      <div
+        key={featuredTracker.slug}
+        className="desktop-story-card desktop-story-card-enter"
+        onClick={onCardClick}
+      >
+        {/* Single progress bar driven by broadcast progress */}
+        <div className="desktop-story-progress">
+          <div className="desktop-story-progress-seg">
+            <div
+              className="desktop-story-progress-fill"
+              style={{ width: `${progressPct}%` }}
+            />
+          </div>
+        </div>
+
+        {/* Image */}
+        <div className="desktop-story-image">
+          <DesktopStoryImage tracker={featuredTracker} />
+        </div>
+
+        {/* Paused badge */}
+        {isPaused && (
+          <div className="desktop-story-paused">
+            {t('story.paused', locale)} · {pauseCountdown}s
+          </div>
+        )}
+
+        {/* Header: icon + name + age */}
+        <div className="desktop-story-header">
+          <span className="desktop-story-icon">{featuredTracker.icon ?? '?'}</span>
+          <span className="desktop-story-name">{featuredTracker.shortName}</span>
+          <span className="desktop-story-age" suppressHydrationWarning>
+            {relativeTime(featuredTracker.lastUpdated)}
+          </span>
+        </div>
+
+        {/* Headline */}
+        {featuredTracker.headline && (
+          <div className="desktop-story-content">
+            <p className="desktop-story-headline">{featuredTracker.headline}</p>
+          </div>
+        )}
+
+        {/* KPIs (max 2) */}
+        {kpis.length > 0 && (
+          <div className="desktop-story-kpis">
+            {kpis.map((kpi, i) => (
+              <div key={i} className="desktop-story-kpi">
+                <div
+                  className="desktop-story-kpi-value"
+                  style={{ color: KPI_COLORS[i % KPI_COLORS.length] }}
+                >
+                  {kpi.value}
+                </div>
+                <div className="desktop-story-kpi-label">{kpi.label}</div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Read More link */}
+        <a
+          className="desktop-story-open"
+          href={`${basePath}${featuredTracker.slug}/`}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {t('story.readMore', locale)}
+        </a>
+      </div>
+    </div>
+  );
+}
+
+// ── Image Sub-component (3-tier fallback) ──
+
+function DesktopStoryImage({ tracker }: { tracker: TrackerCardData }) {
+  const slideImage = tracker.eventImages?.[0];
+  if (slideImage) {
+    return (
+      <>
+        <img
+          src={slideImage.url}
+          alt={tracker.headline ?? tracker.shortName}
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          onError={(e) => {
+            (e.target as HTMLImageElement).style.display = 'none';
+          }}
+        />
+        <div className="desktop-story-image-gradient" />
+      </>
+    );
+  }
+
+  if (tracker.latestEventMedia) {
+    return (
+      <>
+        <img
+          src={tracker.latestEventMedia.url}
+          alt={tracker.headline ?? tracker.shortName}
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          onError={(e) => {
+            (e.target as HTMLImageElement).style.display = 'none';
+          }}
+        />
+        <div className="desktop-story-image-gradient" />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div
+        style={{
+          background: domainGradient(tracker.domain),
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: '36px',
+          width: '100%',
+          height: '100%',
+        }}
+      >
+        {tracker.icon ?? '?'}
+      </div>
+      <div className="desktop-story-image-gradient" />
+    </>
+  );
+}
+```
+
+Notes:
+- The previous internal nav-zone overlays (left/right click zones), multi-slide progress segments, and internal `useStoryState` are all removed. Navigation back/forward happens via circle clicks and the broadcast cycle itself.
+- `onCircleClick` and `onCardClick` are the only interaction callbacks, both routed through broadcast in `CommandCenter`.
+
+- [ ] **Step 1.2: Type-check**
+
+Run: `npm run build`
+
+Expected: build fails in `CommandCenter.tsx` because the call site still passes old props (`trackers`, `followedSlugs`, `onTrackerChange`). That's expected — we fix it in Task 2.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add src/components/islands/CommandCenter/DesktopStoryStrip.tsx
+git commit -m "refactor(home): make DesktopStoryStrip props-driven
+
+Drop internal useStoryState hook and per-slide progress. The strip
+now renders whatever tracker and progress the parent passes in,
+making it a dumb view of broadcast state.
+
+Note: this commit intentionally breaks the build; Task 2 updates
+the call site in CommandCenter."
+```
+
+---
+
+## Task 2: Thread broadcast state into CommandCenter, decouple broadcastEnabled
+
+**Files:**
+- Modify: `src/components/islands/CommandCenter/CommandCenter.tsx`
+
+- [ ] **Step 2.1: Change `broadcastEnabled` to only depend on `broadcastOff`**
+
+Find the line (currently ~line 148):
+
+```tsx
+const broadcastEnabled = !activeTracker && !broadcastOff;
+```
+
+Replace with:
+
+```tsx
+const broadcastEnabled = !broadcastOff;
+```
+
+- [ ] **Step 2.2: Delete `handleStoryTrackerChange`**
+
+Find the block starting at `const handleStoryTrackerChange = useCallback((slug: string) => {` (roughly lines 336–368) and delete the entire `useCallback` assignment (from `const handleStoryTrackerChange` through its closing `}, [trackers]);`). This function is no longer called anywhere after we rewire the strip.
+
+- [ ] **Step 2.3: Rewire DesktopStoryStrip call site**
+
+Find the block (currently ~line 664) that renders `<DesktopStoryStrip ...>`:
+
+```tsx
+<DesktopStoryStrip
+  trackers={trackers}
+  basePath={basePath}
+  followedSlugs={followedSlugs}
+  onTrackerChange={handleStoryTrackerChange}
+/>
+```
+
+Replace with:
+
+```tsx
+<DesktopStoryStrip
+  basePath={basePath}
+  trackerQueue={broadcast.trackerQueue as typeof trackers}
+  featuredTracker={(broadcast.featuredTracker as (typeof trackers)[number] | null) ?? null}
+  currentIndex={broadcast.currentIndex}
+  progress={broadcast.progress}
+  isPaused={broadcast.isUserPaused}
+  pauseCountdown={broadcast.pauseCountdown}
+  onCircleClick={(slug) => {
+    broadcast.jumpTo(slug);
+    if (broadcast.isUserPaused) broadcast.userResume();
+    handleDiscoverFeature('story-circle');
+  }}
+  onCardClick={() => {
+    if (broadcast.isUserPaused) {
+      broadcast.userResume();
+    } else {
+      broadcast.userPause();
+    }
+  }}
+/>
+```
+
+Notes:
+- The `as typeof trackers` casts are because `useBroadcastMode`'s internal `TrackerForBroadcast` is structurally a subset of `TrackerCardData` but TypeScript sees them as different types. The cast is safe because `trackerQueue` is filtered from the same `trackers` array passed into `useBroadcastMode`.
+- `handleDiscoverFeature('story-circle')` is OK even if that feature key isn't in the coach hint list; the onboarding util will just record an unknown key.
+
+- [ ] **Step 2.4: Thread `featuredSlug` into SidebarPanel**
+
+Find both `<SidebarPanel ... />` call sites. There is one main usage (currently ~line 732). Add a `featuredSlug` prop:
+
+```tsx
+<SidebarPanel
+  isMobile={isMobile}
+  trackers={trackers}
+  basePath={basePath}
+  activeTracker={activeTracker}
+  hoveredTracker={hoveredTracker}
+  followedSlugs={followedSlugs}
+  liveCount={liveCount}
+  historicalCount={historicalCount}
+  onSelectTracker={handleSelect}
+  onHoverTracker={handleHover}
+  onToggleFollow={handleToggleFollow}
+  compareSlugs={compareSlugs}
+  onToggleCompare={handleToggleCompare}
+  locale={locale}
+  onToggleLocale={handleToggleLocale}
+  searchRef={searchRef}
+  viewMode={viewMode}
+  onChangeViewMode={setViewMode}
+  geoExpandedKeys={viewMode === 'geographic' ? geoExpandedKeys : undefined}
+  onGeoExpandedKeysChange={viewMode === 'geographic' ? setGeoExpandedKeys : undefined}
+  onHoverGeoNode={handleHoverGeoNode}
+  onLeaveGeoNode={handleLeaveGeoNode}
+  onClickGeoNode={handleClickGeoNode}
+  activeGeoPath={activeGeoPath}
+  featuredSlug={broadcastEnabled ? (broadcast.featuredTracker?.slug ?? null) : null}
+/>
+```
+
+The only addition is the final `featuredSlug` line. Leave the other props unchanged.
+
+- [ ] **Step 2.5: Type-check**
+
+Run: `npm run build`
+
+Expected: build still fails because `SidebarPanel` doesn't accept `featuredSlug` yet — we add the prop in Task 4. The `DesktopStoryStrip` call should now type-check. If it doesn't, the cast expression in Step 2.3 may need adjustment.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add src/components/islands/CommandCenter/CommandCenter.tsx
+git commit -m "feat(home): thread broadcast state into strip and sidebar
+
+Decouple broadcastEnabled from activeTracker so clicking a tracker
+no longer tears down the broadcast experience. DesktopStoryStrip
+now reads featured/progress/index from useBroadcastMode directly.
+
+Note: SidebarPanel featuredSlug prop added in next commit; build
+still breaks until Task 4."
+```
+
+---
+
+## Task 3: Rewrite handleSelect to jump broadcast instead of tearing it down
+
+**Files:**
+- Modify: `src/components/islands/CommandCenter/CommandCenter.tsx`
+
+- [ ] **Step 3.1: Replace `handleSelect` body**
+
+Find `handleSelect` (currently ~line 239):
+
+```tsx
+const handleSelect = useCallback((slug: string | null) => {
+  setActiveTracker(slug);
+  if (slug) {
+    setActiveGeoPath(null);
+    setSidebarCollapsed(false);
+  }
+}, []);
+```
+
+Replace with:
+
+```tsx
+const handleSelect = useCallback((slug: string | null) => {
+  setActiveTracker(slug);
+  if (slug) {
+    setActiveGeoPath(null);
+    // Jump broadcast to this tracker and user-pause, so every surface
+    // (lower-third, story strip, sidebar) stays in sync without tearing
+    // down the broadcast experience. Esc or pauseCountdown resumes.
+    if (!broadcastOff) {
+      broadcast.jumpTo(slug);
+      broadcast.userPause();
+    }
+  }
+}, [broadcastOff, broadcast]);
+```
+
+Notes:
+- Intentionally NOT force-expanding the sidebar (`setSidebarCollapsed(false)`). The rail can stay collapsed and show the strip+lower-third sync. Users who want the full directory open can still click the hamburger.
+- `setActiveTracker(slug)` is preserved so the `O` and `C` hotkeys continue to work against a user-selected tracker.
+- If broadcast is off, selection behaves as before (no broadcast interaction).
+
+- [ ] **Step 3.2: Verify Escape still clears active**
+
+Look at the existing keydown handler (`useEffect` near line 371). The `Escape` branch currently does:
+
+```tsx
+if (e.key === 'Escape') {
+  if (showHelp) { setShowHelp(false); return; }
+  if (compareSlugs.length > 0) { setCompareSlugs([]); return; }
+  if (isInput) { (target as HTMLInputElement).blur(); return; }
+  setActiveTracker(null);
+  return;
+}
+```
+
+Change the final `setActiveTracker(null);` line to also resume broadcast if user-paused:
+
+```tsx
+if (e.key === 'Escape') {
+  if (showHelp) { setShowHelp(false); return; }
+  if (compareSlugs.length > 0) { setCompareSlugs([]); return; }
+  if (isInput) { (target as HTMLInputElement).blur(); return; }
+  setActiveTracker(null);
+  if (broadcast.isUserPaused) broadcast.userResume();
+  return;
+}
+```
+
+Add `broadcast` to the effect's dependency array at the bottom of the `useEffect`:
+
+Find:
+```tsx
+}, [activeTracker, showHelp, compareSlugs.length, handleToggleFollow, handleToggleCompare, basePath, locale]);
+```
+
+Change to:
+```tsx
+}, [activeTracker, showHelp, compareSlugs.length, handleToggleFollow, handleToggleCompare, basePath, locale, broadcast]);
+```
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add src/components/islands/CommandCenter/CommandCenter.tsx
+git commit -m "feat(home): clicking a tracker jumps broadcast instead of tearing down
+
+handleSelect now calls broadcast.jumpTo + userPause when a tracker
+is selected, keeping the globe, lower-third, strip, and sidebar in
+sync. Esc clears selection AND resumes broadcast from the paused
+position."
+```
+
+---
+
+## Task 4: Add featuredSlug + LIVE pulse to SidebarPanel
+
+**Files:**
+- Modify: `src/components/islands/CommandCenter/SidebarPanel.tsx`
+- Modify: `src/styles/global.css`
+
+- [ ] **Step 4.1: Add LIVE pulse animation to global.css**
+
+Open `src/styles/global.css`. Append at the end of the file:
+
+```css
+/* ── CommandCenter: broadcast-featured row LIVE pulse ── */
+@keyframes ccLivePulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(46, 204, 113, 0.5);
+  }
+  50% {
+    box-shadow: 0 0 0 4px rgba(46, 204, 113, 0);
+  }
+}
+.cc-tracker-row.cc-tracker-live,
+.cc-tracker-expanded.cc-tracker-live {
+  animation: ccLivePulse 2s ease-in-out infinite;
+}
+.cc-tracker-live-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-left: 6px;
+  padding: 1px 5px;
+  background: rgba(46, 204, 113, 0.15);
+  border: 1px solid rgba(46, 204, 113, 0.4);
+  border-radius: 3px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.42rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #3fb950;
+  text-transform: uppercase;
+}
+.cc-tracker-live-badge::before {
+  content: '';
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #3fb950;
+  animation: ccLivePulse 1.5s ease-in-out infinite;
+}
+```
+
+- [ ] **Step 4.2: Add `featuredSlug` to SidebarPanel Props**
+
+In `src/components/islands/CommandCenter/SidebarPanel.tsx`, find the `interface Props` (currently ~line 18) and add one field near the end (before the closing `}`):
+
+```ts
+// Current tracker featured by broadcast cycle (drives LIVE pulse + auto-scroll)
+featuredSlug?: string | null;
+```
+
+- [ ] **Step 4.3: Add `featuredSlug` to TrackerRow Props + rendering**
+
+Find the `TrackerRow` component's props type (currently ~line 60–71). Add one field:
+
+```ts
+isLive: boolean;
+```
+
+So the full inner type becomes:
+
+```ts
+}: {
+  tracker: TrackerCardData;
+  basePath: string;
+  isActive: boolean;
+  isHovered: boolean;
+  isFollowed: boolean;
+  isCompared: boolean;
+  isLive: boolean;
+  onSelect: (slug: string | null) => void;
+  onHover: (slug: string | null) => void;
+  onToggleFollow: (slug: string) => void;
+  onToggleCompare: (slug: string) => void;
+  locale?: Locale;
+}) {
+```
+
+And add `isLive` to the destructured params at the top of the component (currently ~line 48):
+
+```tsx
+const TrackerRow = memo(function TrackerRow({
+  tracker,
+  basePath,
+  isActive,
+  isHovered,
+  isFollowed,
+  isCompared,
+  isLive,
+  onSelect,
+  onHover,
+  onToggleFollow,
+  onToggleCompare,
+  locale = 'en',
+}: {
+```
+
+- [ ] **Step 4.4: Apply `cc-tracker-live` class + LIVE badge in TrackerRow**
+
+The LIVE badge shows only in the collapsed-row case. In the expanded row, `isActive` is true and the existing active styling already highlights it — only the pulse class gets added there.
+
+**Expanded row** — find (in `TrackerRow`) the block starting `if (isActive) { return (` and the outer `<div>`:
+
+```tsx
+<div
+  ref={rowRef}
+  className="cc-tracker-expanded"
+  style={{
+```
+
+Change the className to:
+
+```tsx
+<div
+  ref={rowRef}
+  className={`cc-tracker-expanded${isLive ? ' cc-tracker-live' : ''}`}
+  style={{
+```
+
+Do NOT add a separate LIVE badge inside the expanded row.
+
+**Collapsed row** — find the `<div>` opening (currently ~line 196: `<div ref={rowRef} className="cc-tracker-row" ...>`). Change the className:
+
+```tsx
+<div
+  ref={rowRef}
+  className={`cc-tracker-row${isLive && !isActive ? ' cc-tracker-live' : ''}`}
+```
+
+Then in the collapsed row, inside `<div style={S.collapsedLeft}>`, find the line:
+
+```tsx
+<span className="cc-tracker-name" style={S.collapsedName}>{tracker.shortName}</span>
+```
+
+Add a LIVE badge right after it:
+
+```tsx
+<span className="cc-tracker-name" style={S.collapsedName}>{tracker.shortName}</span>
+{isLive && !isActive && (
+  <span className="cc-tracker-live-badge" aria-label="Currently featured by broadcast">
+    LIVE
+  </span>
+)}
+```
+
+- [ ] **Step 4.5: Pass `featuredSlug` through and compute `isLive`**
+
+In the main `SidebarPanel` function, destructure the new prop. Find the signature (currently ~line 577):
+
+```tsx
+export default function SidebarPanel({
+  trackers,
+  basePath,
+  activeTracker,
+  ...
+  activeGeoPath,
+}: Props) {
+```
+
+Add `featuredSlug` to the destructure (before the closing `}: Props`):
+
+```tsx
+  activeGeoPath,
+  featuredSlug,
+}: Props) {
+```
+
+Then find both `<TrackerRow` render sites in this file. There are TWO — one in the main grouped list (~line 834) and any others. Use grep if needed: `grep -n "<TrackerRow" SidebarPanel.tsx`.
+
+For each `<TrackerRow` usage, add:
+
+```tsx
+isLive={featuredSlug === t.slug}
+```
+
+e.g., the main one becomes:
+
+```tsx
+<TrackerRow
+  key={t.slug}
+  tracker={t}
+  basePath={basePath}
+  isActive={activeTracker === t.slug}
+  isHovered={hoveredTracker === t.slug}
+  isFollowed={followedSlugs.includes(t.slug)}
+  isCompared={compareSlugs.includes(t.slug)}
+  isLive={featuredSlug === t.slug}
+  onSelect={onSelectTracker}
+  onHover={onHoverTracker}
+  onToggleFollow={onToggleFollow}
+  onToggleCompare={onToggleCompare}
+  locale={locale}
+/>
+```
+
+- [ ] **Step 4.6: Add `data-tracker-slug` attributes to TrackerRow**
+
+In `TrackerRow` (both the expanded and collapsed branches), add `data-tracker-slug={tracker.slug}` to the outer `<div>`:
+
+Expanded branch `<div>`:
+```tsx
+<div
+  ref={rowRef}
+  className={`cc-tracker-expanded${isLive ? ' cc-tracker-live' : ''}`}
+  data-tracker-slug={tracker.slug}
+  style={{
+```
+
+Collapsed branch `<div>`:
+```tsx
+<div
+  ref={rowRef}
+  className={`cc-tracker-row${isLive && !isActive ? ' cc-tracker-live' : ''}`}
+  data-tracker-slug={tracker.slug}
+  style={{
+```
+
+- [ ] **Step 4.7: Add auto-scroll effect in SidebarPanel**
+
+In `SidebarPanel`'s main function, after the existing `useMemo`s and `flatSlugs`, before `handleKeyDown`, add:
+
+```tsx
+// Auto-scroll the broadcast-featured tracker row into view when it changes
+useEffect(() => {
+  if (!featuredSlug) return;
+  const el = document.querySelector<HTMLElement>(
+    `.cc-sidebar [data-tracker-slug="${featuredSlug}"]`,
+  );
+  if (el) {
+    el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+}, [featuredSlug]);
+```
+
+The `.cc-sidebar` class is applied by `CommandCenter.tsx` to the `<nav>` wrapping the sidebar, which scopes the query correctly. No new ref or wrapper needed. Ensure `useEffect` is imported (already is — check the existing imports at the top of the file).
+
+- [ ] **Step 4.8: Type-check and build**
+
+Run: `npm run build`
+
+Expected: PASS. If type errors remain about missing `isLive` in any `<TrackerRow`, add it. If the build complains about unused imports, remove them.
+
+- [ ] **Step 4.9: Commit**
+
+```bash
+git add src/components/islands/CommandCenter/SidebarPanel.tsx src/styles/global.css
+git commit -m "feat(home): LIVE pulse + auto-scroll for broadcast-featured row
+
+Sidebar now highlights the current broadcast tracker with a LIVE
+badge and pulse animation, and auto-scrolls its row into view as
+the cycle advances — making the sidebar feel part of the same
+broadcast surface as the globe and lower-third."
+```
+
+---
+
+## Task 5: Simplify desktop-stories.css for single progress bar
+
+**Files:**
+- Modify: `src/styles/desktop-stories.css`
+
+- [ ] **Step 5.1: Ensure progress-fill transitions smoothly**
+
+In `src/styles/desktop-stories.css`, the existing `.desktop-story-progress-fill` rule is:
+
+```css
+.desktop-story-progress-fill {
+  height: 100%;
+  width: 0%;
+  background: var(--accent-blue, #58a6ff);
+  border-radius: 1px;
+  transition: width 0.1s linear;
+}
+```
+
+Change `transition: width 0.1s linear;` to `transition: width 0.15s linear;` — because broadcast `progress` updates on RAF (~60Hz) but re-renders may be less frequent. A slightly longer transition smooths visual jitter. If jitter isn't observed in manual testing (Task 6), revert this.
+
+- [ ] **Step 5.2: Remove `.complete` / `.upcoming` rules (dead code)**
+
+These classes are no longer set by the component after Task 1. Delete these two rules:
+
+```css
+.desktop-story-progress-fill.complete {
+  width: 100%;
+}
+.desktop-story-progress-fill.upcoming {
+  width: 0%;
+}
+```
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add src/styles/desktop-stories.css
+git commit -m "style(home): simplify story-strip progress bar CSS
+
+Remove dead .complete/.upcoming rules (the strip now uses a single
+progress bar driven by an inline width) and relax transition
+duration slightly to absorb render jitter."
+```
+
+---
+
+## Task 6: Manual verification
+
+**Files:** none (uses running dev server + browser)
+
+- [ ] **Step 6.1: Start the dev server**
+
+Run: `npm run dev`
+
+Expected: Astro reports dev server at `http://localhost:4321/` (or similar). Leave it running.
+
+- [ ] **Step 6.2: Open the homepage in a desktop-width viewport**
+
+Open `http://localhost:4321/` (base path: `/watchboard/` on prod; locally depends on `ASTRO_BASE`). If the page is blank, check the console for hydration errors.
+
+Resize the window to >= 1280×900 to guarantee desktop layout.
+
+- [ ] **Step 6.3: Wait for broadcast to start and observe sync**
+
+Expected within ~5 seconds:
+- Globe begins auto-rotate and flies to a tracker.
+- BroadcastOverlay lower-third appears bottom-left with that tracker's headline.
+- DesktopStoryStrip in the right rail shows the SAME tracker's card, with a single progress bar ticking.
+- After ~8s the cycle advances: globe flies, lower-third changes, strip card changes to the same new tracker. All three stay aligned.
+
+If the strip card differs from the lower-third, Step 1/2 wiring is wrong. Check that `broadcast.featuredTracker` is the prop driving both.
+
+- [ ] **Step 6.4: Expand the sidebar (click hamburger)**
+
+Expected:
+- Sidebar expands to full panel.
+- The row matching the current broadcast tracker has a `LIVE` badge with a pulsing green ring.
+- As the cycle advances, the pulsing badge moves to the new row and the list scrolls that row into view.
+
+- [ ] **Step 6.5: Click a tracker row in the sidebar**
+
+Expected:
+- Globe flies to that tracker.
+- Lower-third updates to that tracker.
+- Strip card updates to match.
+- LIVE badge follows to that tracker's row.
+- A "PAUSED" countdown appears on the lower-third (existing behavior from `userPause`).
+- Sidebar stays expanded (not torn down).
+
+Press `Esc`. Expected: selection clears AND broadcast resumes cycling from the paused position.
+
+- [ ] **Step 6.6: Click a circle in the story strip**
+
+Collapse the sidebar (click collapse button). With broadcast running, click any circle in the strip.
+
+Expected: globe + lower-third + strip card all jump to that tracker; broadcast resumes dwelling on it (no pause, since we called `userResume` after `jumpTo` in Step 2.3's `onCircleClick`).
+
+- [ ] **Step 6.7: Press B to toggle broadcast off**
+
+Expected:
+- Lower-third disappears.
+- DesktopStoryStrip disappears (collapsed rail shows the plain tracker-icon column instead).
+- The bottom breaking-news ticker appears and starts its CSS marquee scroll.
+- Sidebar LIVE badges disappear.
+
+Press `B` again.
+
+Expected: broadcast resumes from the start of the queue; all surfaces re-sync within ~5s.
+
+- [ ] **Step 6.8: Mobile regression check**
+
+Resize the window to ≤ 767px.
+
+Expected:
+- Mobile layout kicks in (globe 40vh at top, sidebar below).
+- `MobileStoryCarousel` appears on the LIVE mobile tab exactly as before.
+- No console errors.
+
+- [ ] **Step 6.9: Lighthouse benchmark (optional, recommended)**
+
+Run Lighthouse (Chrome DevTools → Lighthouse tab) on `http://localhost:4321/` in desktop mode. Record the Performance score.
+
+Expected: score within ±3 points of the pre-change baseline. If it drops substantially, the strip's re-render frequency is the most likely culprit — memoize the circles list or switch `progress` to ref-based rendering.
+
+- [ ] **Step 6.10: Commit any final tweaks**
+
+If manual testing surfaces small issues (CSS spacing, z-index, etc.), fix and commit in one cleanup commit:
+
+```bash
+git add -A
+git commit -m "fix(home): post-verification polish for broadcast sync"
+```
+
+(Skip this step if no tweaks are needed.)
+
+---
+
+## Post-implementation checklist
+
+- [ ] `npm run build` passes
+- [ ] `npm run test` (vitest) passes — no existing UI tests, but safety check
+- [ ] All manual verification steps in Task 6 pass
+- [ ] Commits are clean and incremental (one per task step, not squashed)
+- [ ] Mobile layout untouched (visual check)
+
+## Rollback plan
+
+If something goes wrong in production:
+- Revert the full set of commits on this feature (6 commits + optional cleanup)
+- No data layer, build config, or workflow changes were made — revert is safe
+- `useStoryState.ts` was never modified, so MobileStoryCarousel is unaffected

--- a/docs/superpowers/specs/2026-04-03-hourly-breaking-news-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-03-hourly-breaking-news-pipeline-design.md
@@ -1,0 +1,346 @@
+# Hourly Breaking News Pipeline
+
+**Date:** 2026-04-03
+**Status:** Draft
+
+## Problem
+
+The nightly update pipeline (14:00 UTC) leaves up to 24 hours between data refreshes. Breaking news — new strikes, disasters, major political events — goes untracked until the next nightly run. There is also no mechanism to automatically create trackers when events happen outside the scope of existing trackers.
+
+## Solution
+
+A lightweight hourly workflow that detects breaking news via RSS/API polling, confirms relevance with a micro AI triage call, updates affected trackers, posts to X immediately, and can auto-create new trackers for out-of-scope events.
+
+## Architecture: Two-Phase Workflow
+
+Single workflow (`hourly-scan.yml`), two jobs:
+
+1. **Scan** — deterministic RSS/API poll + 1-2 turn AI triage (only if candidates found)
+2. **Act** — matrix job, parallel per affected tracker: update data + post to X + create new trackers
+
+### Pipeline Flow
+
+```
+Every hour (cron: 0 * * * *)
+
+JOB 1: SCAN
+  Step 1: RSS/API Poll (scripts/hourly-scan.ts)
+    - Per-tracker: fetch configured ai.rssFeeds + GDELT query by searchContext
+    - Global: broad GDELT breaking news query (new-tracker detection)
+    - Output: candidate headlines {title, url, source, timestamp, matchedTracker?}
+
+  Step 2: URL Dedup (deterministic)
+    - Check against public/_hourly/state.json (48h rolling cache)
+    - Check against tracker events from last 3 days
+    - Drop already-seen URLs
+
+  Step 3: AI Triage (only if candidates remain)
+    - 1-2 turn Claude Sonnet call
+    - Input: candidates + last 48h event titles per tracker
+    - Output per candidate:
+        action: "update" | "new_tracker" | "discard"
+        tracker: slug | null
+        confidence: 0-1
+        summary: string
+        suggestedSlug/Domain/Region/Name (if new_tracker)
+
+  Step 4: Build Action Plan
+    - Updates: group by tracker, filter confidence >= 0.6
+    - New trackers: filter confidence >= 0.8
+    - Upload hourly-action-plan.json artifact
+
+JOB 2: ACT (matrix, parallel — only if action plan non-empty)
+  For existing tracker updates:
+    - Claude Code action (10-15 turns) — update affected sections only
+    - Validate (JSON + Zod on modified files, no build gate)
+    - Post to X immediately (direct twitter-api-v2)
+    - Append to public/_hourly/today-updates.json
+    - Update tracker's update-log.json
+
+  For new tracker creation:
+    - Claude Code action (20-25 turns) — generate tracker.json + seed first event
+    - Validate config against TrackerConfigSchema
+    - Post to X (new tracker announcement)
+    - Optionally trigger seed-tracker.yml for historical backfill
+    - Log to hourly manifest
+```
+
+## Detection Layer: RSS/API Polling
+
+### Per-Tracker Polling
+
+New optional field in tracker config: `ai.rssFeeds` (array of RSS/Atom URLs). For trackers with feeds, fetch and parse items from the last 2 hours. For all active trackers, query GDELT API using existing `ai.searchContext` keywords.
+
+All results normalized to: `{title, url, source, timestamp, matchedTracker, feedOrigin}`.
+
+### Global Sweep (New-Tracker Detection)
+
+Single GDELT query for high-impact breaking news. Filter: `theme:TERROR OR theme:MILITARY OR theme:NATURAL_DISASTER OR theme:POLITICAL_VIOLENCE`, sorted by tone intensity (most impactful first), limited to 50 results. Each result compared against all tracker `searchContext` keywords using token overlap. If no tracker matches with >= 2 keyword hits, marked as `matchedTracker: null` — potential new tracker candidate.
+
+### GDELT API
+
+- Endpoint: `https://api.gdeltproject.org/api/v2/doc/doc`
+- Mode: `ArtList`, `timespan:120` (last 2 hours)
+- Format: JSON (title, url, source, language, seendate)
+- Free, no API key required
+- One request per tracker batch + one global query
+
+### URL Dedup
+
+- Load `public/_hourly/state.json` — rolling set of seen URLs from last 48h
+- Also scan `trackers/{slug}/data/events/` for last 3 days to extract source URLs
+- Drop candidates with known URLs
+- Prune state entries older than 48h each run
+
+## AI Triage
+
+Runs only when candidates survive URL dedup. Single 1-2 turn Claude Sonnet call.
+
+### Prompt Structure
+
+```
+You are a breaking news triage analyst. Given candidate headlines and existing
+tracker context, classify each candidate.
+
+EXISTING TRACKERS (last 48h events):
+- {slug}: [event titles...]
+...
+
+CANDIDATES:
+1. {title, url, source, timestamp, matchedTracker}
+...
+
+Return JSON:
+{ "candidates": [
+    { "index": 1, "action": "update"|"new_tracker"|"discard",
+      "tracker": "slug"|null, "confidence": 0-1,
+      "summary": "...", "reason": "...",
+      "suggestedSlug": "...", "suggestedDomain": "...",
+      "suggestedRegion": "...", "suggestedName": "..." (if new_tracker) }
+] }
+```
+
+### Filtering After AI Response
+
+- `action: "update"` — accepted if confidence >= 0.6
+- `action: "new_tracker"` — accepted if confidence >= 0.8
+- `action: "discard"` — dropped
+- Batch dedup: same event from multiple sources → keep highest confidence, merge sources
+
+### Cost Estimate
+
+~2,000-4,000 input tokens, ~500-1,000 output tokens per call. At Sonnet pricing: ~$0.005-0.01 per invocation. Typical day: 3-5 invocations = $0.02-0.05/day.
+
+## Act Job: Existing Tracker Updates
+
+Matrix entry per affected tracker slug.
+
+### Claude Code Action (10-15 turns)
+
+- Reads schemas, tracker config, triage summary + source URLs
+- Scoped to breaking-relevant sections only: `events/`, `map-points`, `map-lines`, `kpis`, `meta`
+- Does NOT touch deeper sections: `econ`, `political`, `claims`, `casualties` (nightly-only)
+- Triage summary means Claude already knows what happened — structures data, doesn't re-search
+- Same validation rules as nightly: year=string, no future dates, weaponType+time for strikes, coordinate bounds, tier sourcing
+- Also generates tweet text for the X post
+
+### Validation
+
+- JSON syntax check on modified files only
+- Zod schema validation on modified files only
+- No build gate (too slow for hourly)
+- Validation failure → skip tracker, log error. Nightly picks it up with fix agent.
+
+### Immediate X Post
+
+- Direct `twitter-api-v2` call (not queue system)
+- Tweet text generated by the same Claude Code action
+- 280 chars, tracker link with UTM: `utm_source=x&utm_medium=breaking_hourly&utm_campaign=YYYY-MM-DD`
+- Budget: append to `public/_social/budget.json` ($0.01/tweet)
+- History: append to `public/_social/history.json` (type: "breaking")
+
+### Manifest + Log
+
+Append to `public/_hourly/today-updates.json`:
+```json
+{
+  "tracker": "iran-conflict",
+  "action": "update",
+  "eventIds": ["iaea-inspection-apr-2026"],
+  "sections": ["events", "map-points", "kpis"],
+  "tweetId": "204019...",
+  "timestamp": "2026-04-03T15:00:00Z"
+}
+```
+
+Update `trackers/{slug}/data/update-log.json`: bump lastRun, mark touched sections.
+
+### Commit Strategy
+
+Each matrix entry runs on a separate runner, so each commits independently:
+- `git add trackers/{slug}/data/ public/_hourly/ public/_social/`
+- Commit message: `chore(hourly): update {slug} TIMESTAMP`
+- Git push retry: 3 attempts with jitter (same as nightly pattern) to handle concurrent pushes from parallel matrix entries
+
+## Act Job: New Tracker Creation
+
+Separate matrix entry per new tracker candidate (confidence >= 0.8).
+
+### Claude Code Action (20-25 turns)
+
+- Receives: suggestedSlug, domain, region, name, trigger event
+- Reads `tracker-config.ts` + `schemas.ts` + auto-selects template tracker by matching domain
+- Generates `tracker.json`:
+  - `status: "active"`, `temporal: "live"`
+  - Map bounds derived from region/event location
+  - 3-4 map categories, 3-4 camera presets, basic nav sections
+  - `searchContext` from trigger event
+  - `updateIntervalDays: 1`
+  - Conservative `backfillTargets` (timeline: 10, mapPoints: 5)
+- Creates `trackers/{slug}/data/`:
+  - `meta.json` — trigger event as heroHeadline
+  - `events/YYYY-MM-DD.json` — trigger event as first entry
+  - `map-points.json` — event location if known
+  - All other data files as empty arrays
+  - `update-log.json` — initialized
+- Validates config against `TrackerConfigSchema`
+
+### Seed Job
+
+- Claude action outputs `shouldSeed: boolean`
+- Sudden events (earthquake, attack) → no seed, tracker starts from now
+- Ongoing situations (building crisis) → trigger `seed-tracker.yml` via `gh workflow run`
+
+### X Post
+
+Special format: "BREAKING: New tracker launched — {name}. {summary}. Follow live: {link}"
+
+## Nightly Pipeline Integration
+
+Two changes to `update-data.yml`:
+
+### Change 1: Resolve Phase Reads Hourly Manifest
+
+After determining eligible trackers, read `public/_hourly/today-updates.json`:
+- Tracker fully covered by hourly (all enabled sections) → skip entirely
+- Tracker partially covered → scope nightly to untouched sections only
+
+### Change 2: Update Phase Prompt Includes Hourly Event IDs
+
+Extra prompt block per tracker:
+```
+ALREADY INGESTED TODAY (by hourly pipeline — do NOT re-add these):
+- Event IDs: ["iaea-inspection-apr-2026", ...]
+- Sections already updated: ["events", "map-points", "kpis"]
+Focus on sections NOT listed above.
+```
+
+Same injection pattern as existing sibling brief.
+
+### Manifest Lifecycle
+
+- `public/_hourly/today-updates.json` — one file per day, date-keyed by UTC date
+- Date rollover: each hourly run computes today's UTC date. If `today-updates.json` has a different `date` field, archive it to `public/_hourly/archive/YYYY-MM-DD.json` and start fresh. This handles midnight cleanly.
+- Nightly finalize cleans up archive entries older than 3 days
+- `public/_hourly/state.json` — pruned to 48h by hourly scan
+- Nightly social queue generator sees hourly posts in `history.json`, avoids duplicating
+
+## File Layout
+
+### New Files
+
+```
+.github/workflows/hourly-scan.yml           — the workflow
+scripts/hourly-scan.ts                       — RSS/API polling + URL dedup
+scripts/hourly-triage.ts                     — AI triage prompt builder + response parser
+scripts/hourly-post.ts                       — direct X posting for breaking news
+public/_hourly/state.json                    — rolling URL/headline cache (48h)
+public/_hourly/today-updates.json            — daily manifest for nightly dedup
+```
+
+### Modified Files
+
+```
+src/lib/tracker-config.ts                    — add optional ai.rssFeeds to AiConfigSchema
+.github/workflows/update-data.yml            — resolve + update phases read hourly manifest
+social-config.json                           — add hourly cost tracking category
+```
+
+### Config Addition
+
+```typescript
+// in AiConfigSchema:
+rssFeeds: z.array(z.string().url()).optional()
+```
+
+### State File Shape
+
+```json
+{
+  "lastScan": "2026-04-03T15:00:00Z",
+  "seen": [
+    { "url": "https://reuters.com/...", "tracker": "iran-conflict", "eventId": "...", "ts": "..." }
+  ]
+}
+```
+
+### Manifest File Shape
+
+```json
+{
+  "date": "2026-04-03",
+  "updates": [
+    {
+      "tracker": "iran-conflict",
+      "action": "update",
+      "eventIds": ["iaea-inspection-apr-2026"],
+      "sections": ["events", "map-points", "kpis"],
+      "tweetId": "204019...",
+      "timestamp": "2026-04-03T15:00:00Z"
+    },
+    {
+      "tracker": "turkey-earthquake-2026",
+      "action": "new_tracker",
+      "eventIds": ["initial-quake-report"],
+      "sections": ["events", "map-points", "meta"],
+      "tweetId": "204020...",
+      "timestamp": "2026-04-03T15:00:00Z",
+      "seeded": false
+    }
+  ]
+}
+```
+
+## Error Handling
+
+### Quiet Hours (most common)
+Poll returns nothing or all deduped → exit early, no AI, no Job 2. Runtime: ~30s.
+
+### RSS/API Failures
+- Per-feed timeout: 5s → skip feed, continue
+- GDELT down → continue with RSS feeds only
+- All sources fail → exit cleanly, next hour retries
+
+### AI Triage Failures
+- Unparseable response → skip triage, log error. Candidates reappear next hour (URLs not added to seen cache until processed).
+- Timeout: 60s max
+
+### Tracker Update Failures
+- Zod validation fails → skip tracker, log. Nightly picks up with fix agent.
+- Claude Code fails → same, skip and log.
+- Matrix isolation: one tracker failing doesn't block others.
+
+### X Posting Failures
+- API error → data still commits, tweet marked `failed` in manifest. No retry.
+- Rate limit → same graceful failure.
+
+### New Tracker Failures
+- Config validation fails → don't create directory, log candidate to state for retry.
+- Partial creation → `rm -rf trackers/{slug}/` before commit.
+
+### Concurrency
+- Overlap with nightly: git push retry (3 attempts, jitter)
+- Two hourly runs overlap: `concurrency: { group: hourly-scan, cancel-in-progress: true }`
+
+### Manifest Corruption
+- Unparseable JSON → reset to empty, log warning. Append-only data means worst case is one hour of reprocessing.

--- a/docs/superpowers/specs/2026-04-16-desktop-home-sync-design.md
+++ b/docs/superpowers/specs/2026-04-16-desktop-home-sync-design.md
@@ -1,0 +1,208 @@
+# Desktop Home — Unified Broadcast Sync
+
+**Date:** 2026-04-16
+**Status:** Design
+**Scope:** Homepage `CommandCenter` on desktop (≥ 768px viewport). Mobile layout unchanged.
+
+## Problem
+
+On desktop, the homepage has three surfaces that each display "the current story":
+
+1. **BroadcastOverlay lower-third** — floats bottom-left over the globe (broadcast mode)
+2. **DesktopStoryStrip** — icon column + small story card inside the 52px collapsed right rail (broadcast mode)
+3. **SidebarPanel** — full tracker directory (OPS/GEO/DOMAIN tabs) shown when the rail is expanded or a tracker is clicked
+
+The three surfaces are driven by two independent state machines:
+
+- `useBroadcastMode` drives the globe camera, lower-third, and built-in ticker
+- `useStoryState` (inside `DesktopStoryStrip`) drives the circle column and its own card on an independent 12s timer
+
+Observed symptoms:
+
+- The strip's active circle and card don't match the lower-third's featured tracker
+- Clicking a tracker collapses the broadcast experience and swaps in the directory layout, so the two screenshots (broadcast view vs. directory view) feel like different apps
+- The standalone breaking-news ticker at the bottom runs its own CSS marquee, unrelated to the broadcast cycle, so when broadcast is on there are two tickers with different motion
+
+## Goal
+
+One broadcast cycle drives every surface. When the cycle advances to tracker X:
+
+- Globe flies to X
+- Lower-third shows X
+- Story strip circle for X is active, strip card shows X, strip progress bar ticks with broadcast progress
+- Sidebar (when expanded) auto-scrolls to X's row and marks it with a "LIVE" pulse tied to broadcast progress
+- The BroadcastOverlay's own ticker centers X (already works)
+
+Any click on any surface calls into the same broadcast state (`jumpTo` / `userPause`). Nothing tears the experience down.
+
+Not in scope: layout redesign, removing components, new features, mobile changes.
+
+## Architecture
+
+### Single source of truth
+
+`useBroadcastMode` is the orchestrator. Verified exposed state (read from hook):
+
+- `featuredTracker: TrackerForBroadcast | null`
+- `currentIndex: number` — position in `trackerQueue`
+- `progress: number` — 0..1 within the current dwell (advances only while `phase === 'dwelling'`)
+- `phase: 'idle' | 'transitioning' | 'dwelling' | 'paused'`
+- `trackerQueue: TrackerForBroadcast[]` (stable ref, contents refreshed when inputs change)
+- `isUserPaused: boolean`
+- `pauseCountdown: number`
+
+The hook does **not** track a sub-slide index within a tracker. The lower-third uses a single progress bar tied to `progress`; the strip will do the same. No hook changes needed.
+
+Callers:
+
+- `jumpTo(slug)` — jump cycle to a specific tracker
+- `userPause()` / `userResume()` — pause broadcast without disabling it
+- `goToNext()` / `goToPrev()` — manual step
+- `resetPauseTimer()` — keep pause alive on interaction
+
+### Component wiring
+
+```
+useBroadcastMode (orchestrator)
+   │
+   ├─► GlobePanel (flyTo camera) ....................... already wired
+   ├─► BroadcastOverlay (lower-third + own ticker) ..... already wired
+   ├─► DesktopStoryStrip ............................... REWIRE: drop useStoryState; props-driven
+   ├─► SidebarPanel .................................... REWIRE: add featuredSlug prop, auto-scroll + LIVE pulse
+   └─► Bottom ticker (CommandCenter inline) ............ already gated off when broadcast on — no change
+```
+
+User actions that feed back in:
+
+- Globe marker click → `handleSelect(slug)` → `broadcast.jumpTo(slug)` + `userPause()`
+- Story strip circle click → `broadcast.jumpTo(slug)` + (resume if paused)
+- Sidebar row click → `broadcast.jumpTo(slug)` + `userPause()` (today: disables broadcast entirely; new: keeps it running in paused state so resume puts user back in the stream)
+- Sidebar row hover → `handleHover(slug)` (unchanged — sets `hoveredTracker`, drives hover highlight on globe; does not move cycle)
+- Bottom ticker item click (when broadcast off) → same as today: navigate to tracker page
+
+## Components
+
+### DesktopStoryStrip — props-driven rewrite
+
+Drop the internal `useStoryState` hook entirely. New props:
+
+```ts
+interface Props {
+  basePath: string;
+  // Broadcast-driven state
+  trackerQueue: TrackerForBroadcast[];   // from broadcast.trackerQueue
+  featuredTracker: TrackerForBroadcast | null;
+  currentIndex: number;
+  progress: number;            // 0..1
+  isPaused: boolean;
+  pauseCountdown: number;
+  // Callbacks
+  onCircleClick: (slug: string) => void;
+  onCardClick: () => void;      // toggle pause
+}
+```
+
+Internals simplified:
+
+- Circles are `trackerQueue.slice(0, MAX_CIRCLES)` with the one at `currentIndex` marked active; "seen" is derived from indexes `< currentIndex` (simple local `useRef<Set<string>>` populated on `currentIndex` change)
+- ONE progress bar tied to `progress` (removes the per-slide progress segments and the internal RAF)
+- Card = render of `featuredTracker` passed in
+
+**Ownership:** the eligible/queue list lives in `useBroadcastMode` and is exposed as `trackerQueue`; `DesktopStoryStrip` reads it from props, never recomputes. This ensures strip circles and globe focus always agree.
+
+### SidebarPanel — LIVE row indicator + auto-scroll
+
+Add one new prop:
+
+```ts
+featuredSlug?: string | null;  // current broadcast featured tracker
+broadcastProgress?: number;     // 0..1, optional visual tie-in
+```
+
+Behavior when `featuredSlug` is set and broadcast is running:
+
+- Find the row for `featuredSlug` and `scrollIntoView({ block: 'nearest', behavior: 'smooth' })` when `featuredSlug` changes
+- Add a "● LIVE" badge on that row with a pulse animation
+- Pulse CSS animation duration is independent of `broadcastProgress` (keeping it a simple CSS pulse keeps render cost zero). `broadcastProgress` is accepted but not required; we may skip wiring it for v1.
+
+When `featuredSlug` is null (broadcast off) or equals `activeTracker`, skip the LIVE badge — user-selected active styling takes precedence.
+
+Row auto-scroll must not fight the existing `TrackerRow` auto-scroll on `isActive || isHovered`. Decision: add one effect in the parent list that reacts to `featuredSlug` changes and scrolls; individual-row auto-scroll stays unchanged. The two effects can both run on the same slug without conflict (both call `scrollIntoView` with `nearest`).
+
+### CommandCenter — glue changes
+
+1. **`handleSelect` rewrite:**
+   - Today: sets `activeTracker`, clears geo path, force-expands sidebar (side effect: `broadcastEnabled = !activeTracker && !broadcastOff` → broadcast turns off entirely).
+   - New: calls `broadcast.jumpTo(slug)` + `broadcast.userPause()`; does NOT set `activeTracker` (or sets it but does not derive `broadcastEnabled` from it). Sidebar does not force-expand.
+   - We still need the user-selected-tracker concept for the `O` hotkey (open dashboard) and `C` (compare). Keep `activeTracker` but change `broadcastEnabled = !broadcastOff` (independent of `activeTracker`). The previous "Esc clears active" still works.
+
+2. **Remove bottom ticker when broadcast is on:**
+   - Today: `{breakingTrackers.length > 0 && !broadcastEnabled && <Ticker />}` already gates on broadcast off. ✓ Already correct. No change.
+
+3. **Pass broadcast state to `SidebarPanel` and `DesktopStoryStrip`:**
+   - `featuredSlug={broadcast.featuredTracker?.slug ?? null}`
+   - Full broadcast object for the strip
+
+4. **`handleStoryTrackerChange` removal:** This callback exists only to let `DesktopStoryStrip`'s internal timer fly the globe. With the strip no longer owning a timer, this is dead code — delete.
+
+## Data flow
+
+```
+useBroadcastMode.currentIndex ticks
+       │
+       ├──► featuredTracker updates
+       │         │
+       │         ├──► GlobePanel.flyTo  (already)
+       │         ├──► BroadcastOverlay (already)
+       │         ├──► DesktopStoryStrip.card / circles (NEW)
+       │         └──► SidebarPanel auto-scroll + LIVE pulse (NEW)
+       │
+       └──► progress ticks (0..1)
+                 │
+                 ├──► BroadcastOverlay progress bar (already)
+                 └──► DesktopStoryStrip single progress bar (NEW — was own RAF + multi-segment)
+```
+
+## Edge cases
+
+- **User paused (`isUserPaused`):** `phase` becomes `paused`; `progress` stops updating (strip progress bar freezes); lower-third expands (existing behavior); sidebar LIVE pulse freezes (CSS `animation-play-state: paused` when we add a `.paused` class). No cycle advancement.
+- **Broadcast disabled (`broadcastOff` true):** `featuredTracker` null; strip reverts to "not rendered" path (CommandCenter already renders icon column instead of strip). Sidebar LIVE badge hidden. Bottom ticker visible.
+- **Active tracker set (user clicked):** broadcast paused on that tracker, lower-third shows it, sidebar row highlighted as active (not LIVE), strip circles show that index. Esc resumes broadcast.
+- **No eligible trackers for broadcast:** existing guard in `useBroadcastMode` returns null `featuredTracker`; no surfaces show broadcast state. Safe.
+- **Locale change mid-broadcast:** locale affects headline/text only; no sync concern.
+
+## Testing
+
+Manual verification (webapp-testing skill or Playwright):
+
+1. Load `/` on desktop. Wait for broadcast to start. Confirm globe, lower-third, and strip circle all point to same tracker.
+2. Let cycle advance. Confirm all three update together; strip progress bar visually ticks in sync with lower-third progress bar.
+3. Expand sidebar. Confirm the LIVE-pulsing row matches the current featured tracker. Let cycle advance. Confirm the pulsed row moves + auto-scrolls.
+4. Click a tracker row in the expanded sidebar. Confirm: globe flies, lower-third updates to that tracker, strip circle updates, broadcast enters paused state with countdown badge, sidebar row shows LIVE pulse (broadcast still "on"). Press Esc; broadcast resumes from that tracker's position.
+5. Click a strip circle. Confirm same behavior as #4.
+6. Press `B` to toggle broadcast off. Confirm bottom ticker appears, strip disappears (icons column takes over), sidebar LIVE badge disappears, lower-third disappears.
+7. Re-press `B`. Confirm broadcast resumes; everything syncs within one cycle step.
+8. Mobile viewport (<768px): no regressions — story carousel behavior unchanged.
+
+## File touch list
+
+- `src/components/islands/CommandCenter/DesktopStoryStrip.tsx` — drop `useStoryState`, accept broadcast props, render from them
+- `src/components/islands/CommandCenter/useStoryState.ts` — leave in place (MobileStoryCarousel still uses it), verify no shared-state leakage
+- `src/components/islands/CommandCenter/SidebarPanel.tsx` — accept `featuredSlug`, add auto-scroll effect, add LIVE badge markup + CSS class
+- `src/components/islands/CommandCenter/CommandCenter.tsx` — rewrite `handleSelect`, thread broadcast state into strip/sidebar, delete `handleStoryTrackerChange`
+- `src/components/islands/CommandCenter/useBroadcastMode.ts` — verify `slideIndex` and `trackerQueue` are exposed as expected; add if missing
+- `src/styles/desktop-stories.css` — minor (only if progress bar now driven by `progress` prop via inline style — may need `transition` tweak)
+- One new CSS rule for `.cc-tracker-live-pulse` (can go in an existing global or command-center-mobile.css despite the name; prefer `src/styles/global.css` or a new small file — decision deferred to implementation)
+
+## Risks
+
+- **Eligibility mismatch:** `useStoryState` today computes its own eligibility (followedSlugs, has image, etc.). `useBroadcastMode`'s queue is `trackers.filter(t => t.mapCenter && t.headline)` sorted by relevance. These lists differ. After this change, the strip uses `broadcast.trackerQueue` as-is — this IS the behavior change, and it's what unifies the experience. Accept the tradeoff: the strip will only show trackers eligible for the broadcast cycle (need a map center + headline).
+- **Re-render cost:** `DesktopStoryStrip` re-renders whenever broadcast `progress` updates (~60Hz). The strip is small (<30 DOM nodes) so acceptable. If profiling shows hot-spot, memoize static sub-trees.
+
+## Implementation order
+
+1. Rewrite `DesktopStoryStrip` to props-driven: accept `trackerQueue`, `featuredTracker`, `currentIndex`, `progress`, `isPaused`, `pauseCountdown`, `onCircleClick`, `onCardClick`. Remove import of `useStoryState`.
+2. In `CommandCenter`: change `broadcastEnabled = !broadcastOff` (decouple from `activeTracker`). Thread broadcast state into the strip. Delete `handleStoryTrackerChange`.
+3. Rewrite `handleSelect`: instead of setting `activeTracker` + force-expanding sidebar, call `broadcast.jumpTo(slug)` + `broadcast.userPause()`. Keep setting `activeTracker` for hotkey targets (O, C) and keep Esc's "clear active" behavior.
+4. Add `featuredSlug` prop to `SidebarPanel`. In the list-rendering section, add an effect that scrolls the row matching `featuredSlug` into view on change, and add a `.cc-tracker-live` class + pulse animation CSS.
+5. Manual verification via Playwright (steps 1–8 in Testing). Run Lighthouse before/after on `/` — expect no regression (one fewer RAF timer running, fewer independent animations).

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -240,9 +240,15 @@ export default function CommandCenter({
     setActiveTracker(slug);
     if (slug) {
       setActiveGeoPath(null);
-      setSidebarCollapsed(false);
+      // Jump broadcast to this tracker and user-pause, so every surface
+      // (lower-third, story strip, sidebar) stays in sync without tearing
+      // down the broadcast experience. Esc or pauseCountdown resumes.
+      if (!broadcastOff) {
+        broadcast.jumpTo(slug);
+        broadcast.userPause();
+      }
     }
-  }, []);
+  }, [broadcastOff, broadcast]);
 
   const handleHover = useCallback((slug: string | null) => {
     setHoveredTracker(slug);
@@ -378,6 +384,7 @@ export default function CommandCenter({
         if (compareSlugs.length > 0) { setCompareSlugs([]); return; }
         if (isInput) { (target as HTMLInputElement).blur(); return; }
         setActiveTracker(null);
+        if (broadcast.isUserPaused) broadcast.userResume();
         return;
       }
 
@@ -437,7 +444,7 @@ export default function CommandCenter({
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [activeTracker, showHelp, compareSlugs.length, handleToggleFollow, handleToggleCompare, basePath, locale]);
+  }, [activeTracker, showHelp, compareSlugs.length, handleToggleFollow, handleToggleCompare, basePath, locale, broadcast]);
 
   const sidebarStyle: React.CSSProperties = isMobile
     ? mobileTab === 'trackers' ? styles.sidebar : { ...styles.sidebar, display: 'none' }

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -155,6 +155,9 @@ export default function CommandCenter({
     followedSlugs,
   );
 
+  const broadcastRef = useRef(broadcast);
+  broadcastRef.current = broadcast;
+
   useEffect(() => {
     const hash = viewMode === 'operations' ? '' : viewMode === 'geographic' ? '#geo' : '#domain';
     if (hash) {
@@ -244,11 +247,11 @@ export default function CommandCenter({
       // (lower-third, story strip, sidebar) stays in sync without tearing
       // down the broadcast experience. Esc or pauseCountdown resumes.
       if (!broadcastOff) {
-        broadcast.jumpTo(slug);
-        broadcast.userPause();
+        broadcastRef.current.jumpTo(slug);
+        broadcastRef.current.userPause();
       }
     }
-  }, [broadcastOff, broadcast]);
+  }, [broadcastOff]);
 
   const handleHover = useCallback((slug: string | null) => {
     setHoveredTracker(slug);
@@ -384,7 +387,7 @@ export default function CommandCenter({
         if (compareSlugs.length > 0) { setCompareSlugs([]); return; }
         if (isInput) { (target as HTMLInputElement).blur(); return; }
         setActiveTracker(null);
-        if (broadcast.isUserPaused) broadcast.userResume();
+        if (broadcastRef.current.isUserPaused) broadcastRef.current.userResume();
         return;
       }
 
@@ -444,7 +447,7 @@ export default function CommandCenter({
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [activeTracker, showHelp, compareSlugs.length, handleToggleFollow, handleToggleCompare, basePath, locale, broadcast]);
+  }, [activeTracker, showHelp, compareSlugs.length, handleToggleFollow, handleToggleCompare, basePath, locale]);
 
   const sidebarStyle: React.CSSProperties = isMobile
     ? mobileTab === 'trackers' ? styles.sidebar : { ...styles.sidebar, display: 'none' }
@@ -677,15 +680,15 @@ export default function CommandCenter({
                 isPaused={broadcast.isUserPaused}
                 pauseCountdown={broadcast.pauseCountdown}
                 onCircleClick={(slug) => {
-                  broadcast.jumpTo(slug);
-                  if (broadcast.isUserPaused) broadcast.userResume();
+                  broadcastRef.current.jumpTo(slug);
+                  if (broadcastRef.current.isUserPaused) broadcastRef.current.userResume();
                   handleDiscoverFeature('story-circle');
                 }}
                 onCardClick={() => {
-                  if (broadcast.isUserPaused) {
-                    broadcast.userResume();
+                  if (broadcastRef.current.isUserPaused) {
+                    broadcastRef.current.userResume();
                   } else {
-                    broadcast.userPause();
+                    broadcastRef.current.userPause();
                   }
                 }}
               />

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -145,7 +145,7 @@ export default function CommandCenter({
     toggleCityLights?: () => void;
   }>(null);
 
-  const broadcastEnabled = !activeTracker && !broadcastOff;
+  const broadcastEnabled = !broadcastOff;
 
   const broadcast = useBroadcastMode(
     trackers,
@@ -332,40 +332,6 @@ export default function CommandCenter({
   const handleClearCompare = useCallback(() => {
     setCompareSlugs([]);
   }, []);
-
-  const handleStoryTrackerChange = useCallback((slug: string) => {
-    const tracker = trackers.find(t => t.slug === slug);
-    if (tracker?.mapCenter) {
-      // Dynamic zoom based on tracker scope
-      const region = tracker.region;
-      const domain = tracker.domain;
-      let altitude = 2.0; // default
-      let duration = 1800; // ms
-
-      // Country-level trackers: zoom closer
-      if (tracker.country && !tracker.aggregate) {
-        altitude = 1.2;
-        duration = 2200;
-      }
-      // Regional conflicts: medium zoom
-      if (region === 'middle-east' || region === 'southeast-asia') {
-        altitude = 1.5;
-        duration = 2000;
-      }
-      // Global/multi-region trackers: wide view
-      if (domain === 'economy' || domain === 'science' || region === 'global' || tracker.aggregate) {
-        altitude = 3.0;
-        duration = 2500;
-      }
-      // Historical trackers: slower, more cinematic
-      if (tracker.temporal === 'historical') {
-        duration = 3000;
-      }
-
-      globeRef.current?.flyTo?.(tracker.mapCenter.lat, tracker.mapCenter.lon, altitude, duration);
-      globeRef.current?.setAutoRotate?.(false);
-    }
-  }, [trackers]);
 
   // Global keyboard shortcuts
   useEffect(() => {
@@ -644,7 +610,7 @@ export default function CommandCenter({
       )}
       {isMobile && mobileTab === 'live' && (
         <div style={{ flex: '1 1 0%', overflow: 'hidden', position: 'relative' as const, minHeight: 0 }}>
-          <MobileStoryCarousel trackers={trackers} basePath={basePath} followedSlugs={followedSlugs} onTrackerChange={handleStoryTrackerChange} />
+          <MobileStoryCarousel trackers={trackers} basePath={basePath} followedSlugs={followedSlugs} />
         </div>
       )}
       <nav className="cc-sidebar" style={sidebarStyle} aria-label="Tracker directory">
@@ -662,10 +628,25 @@ export default function CommandCenter({
             </button>
             {broadcastEnabled ? (
               <DesktopStoryStrip
-                trackers={trackers}
                 basePath={basePath}
-                followedSlugs={followedSlugs}
-                onTrackerChange={handleStoryTrackerChange}
+                trackerQueue={broadcast.trackerQueue as typeof trackers}
+                featuredTracker={(broadcast.featuredTracker as (typeof trackers)[number] | null) ?? null}
+                currentIndex={broadcast.currentIndex}
+                progress={broadcast.progress}
+                isPaused={broadcast.isUserPaused}
+                pauseCountdown={broadcast.pauseCountdown}
+                onCircleClick={(slug) => {
+                  broadcast.jumpTo(slug);
+                  if (broadcast.isUserPaused) broadcast.userResume();
+                  handleDiscoverFeature('story-circle');
+                }}
+                onCardClick={() => {
+                  if (broadcast.isUserPaused) {
+                    broadcast.userResume();
+                  } else {
+                    broadcast.userPause();
+                  }
+                }}
               />
             ) : (
               <div style={styles.collapsedTrackerIcons}>
@@ -754,6 +735,7 @@ export default function CommandCenter({
               onLeaveGeoNode={handleLeaveGeoNode}
               onClickGeoNode={handleClickGeoNode}
               activeGeoPath={activeGeoPath}
+              featuredSlug={broadcastEnabled ? (broadcast.featuredTracker?.slug ?? null) : null}
             />
           </>
         )}

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -663,8 +663,8 @@ export default function CommandCenter({
             {broadcastEnabled ? (
               <DesktopStoryStrip
                 basePath={basePath}
-                trackerQueue={broadcast.trackerQueue as typeof trackers}
-                featuredTracker={(broadcast.featuredTracker as (typeof trackers)[number] | null) ?? null}
+                trackerQueue={broadcast.trackerQueue}
+                featuredTracker={broadcast.featuredTracker ?? null}
                 currentIndex={broadcast.currentIndex}
                 progress={broadcast.progress}
                 isPaused={broadcast.isUserPaused}

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -333,6 +333,40 @@ export default function CommandCenter({
     setCompareSlugs([]);
   }, []);
 
+  const handleStoryTrackerChange = useCallback((slug: string) => {
+    const tracker = trackers.find(t => t.slug === slug);
+    if (tracker?.mapCenter) {
+      // Dynamic zoom based on tracker scope
+      const region = tracker.region;
+      const domain = tracker.domain;
+      let altitude = 2.0; // default
+      let duration = 1800; // ms
+
+      // Country-level trackers: zoom closer
+      if (tracker.country && !tracker.aggregate) {
+        altitude = 1.2;
+        duration = 2200;
+      }
+      // Regional conflicts: medium zoom
+      if (region === 'middle-east' || region === 'southeast-asia') {
+        altitude = 1.5;
+        duration = 2000;
+      }
+      // Global/multi-region trackers: wide view
+      if (domain === 'economy' || domain === 'science' || region === 'global' || tracker.aggregate) {
+        altitude = 3.0;
+        duration = 2500;
+      }
+      // Historical trackers: slower, more cinematic
+      if (tracker.temporal === 'historical') {
+        duration = 3000;
+      }
+
+      globeRef.current?.flyTo?.(tracker.mapCenter.lat, tracker.mapCenter.lon, altitude, duration);
+      globeRef.current?.setAutoRotate?.(false);
+    }
+  }, [trackers]);
+
   // Global keyboard shortcuts
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -610,7 +644,7 @@ export default function CommandCenter({
       )}
       {isMobile && mobileTab === 'live' && (
         <div style={{ flex: '1 1 0%', overflow: 'hidden', position: 'relative' as const, minHeight: 0 }}>
-          <MobileStoryCarousel trackers={trackers} basePath={basePath} followedSlugs={followedSlugs} />
+          <MobileStoryCarousel trackers={trackers} basePath={basePath} followedSlugs={followedSlugs} onTrackerChange={handleStoryTrackerChange} />
         </div>
       )}
       <nav className="cc-sidebar" style={sidebarStyle} aria-label="Tracker directory">

--- a/src/components/islands/CommandCenter/DesktopStoryStrip.tsx
+++ b/src/components/islands/CommandCenter/DesktopStoryStrip.tsx
@@ -65,20 +65,31 @@ export default function DesktopStoryStrip({
     if (featuredTracker) seenRef.current.add(featuredTracker.slug);
   }, [featuredTracker]);
 
+  // Slide a window over trackerQueue so the active circle stays visible.
+  const { visibleCircles, visibleActiveIndex } = useMemo(() => {
+    const total = trackerQueue.length;
+    if (total <= MAX_CIRCLES) {
+      return { visibleCircles: trackerQueue, visibleActiveIndex: currentIndex };
+    }
+    const half = Math.floor(MAX_CIRCLES / 2);
+    let start = currentIndex - half;
+    if (start < 0) start = 0;
+    if (start + MAX_CIRCLES > total) start = total - MAX_CIRCLES;
+    return {
+      visibleCircles: trackerQueue.slice(start, start + MAX_CIRCLES),
+      visibleActiveIndex: currentIndex - start,
+    };
+  }, [trackerQueue, currentIndex]);
+
   // Auto-scroll circle column to keep active circle visible
   useEffect(() => {
     const container = circlesRef.current;
     if (!container) return;
-    const activeCircle = container.children[currentIndex] as HTMLElement | undefined;
+    const activeCircle = container.children[visibleActiveIndex] as HTMLElement | undefined;
     if (activeCircle) {
       activeCircle.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }
-  }, [currentIndex]);
-
-  const visibleCircles = useMemo(
-    () => trackerQueue.slice(0, MAX_CIRCLES),
-    [trackerQueue],
-  );
+  }, [visibleActiveIndex]);
 
   if (visibleCircles.length === 0 || !featuredTracker) return null;
 
@@ -90,18 +101,21 @@ export default function DesktopStoryStrip({
       {/* Circle column */}
       <div className="desktop-story-circles" ref={circlesRef}>
         {visibleCircles.map((tr, i) => (
-          <div
+          <button
+            type="button"
             key={tr.slug}
             className={
               `desktop-story-circle` +
-              (i === currentIndex ? ' active' : '') +
-              (seenRef.current.has(tr.slug) && i !== currentIndex ? ' seen' : '')
+              (i === visibleActiveIndex ? ' active' : '') +
+              (seenRef.current.has(tr.slug) && i !== visibleActiveIndex ? ' seen' : '')
             }
             onClick={() => onCircleClick(tr.slug)}
             title={tr.shortName}
+            aria-label={`Jump broadcast to ${tr.shortName}`}
+            aria-current={i === visibleActiveIndex ? 'true' : undefined}
           >
             {tr.icon ?? '?'}
-          </div>
+          </button>
         ))}
       </div>
 
@@ -109,7 +123,19 @@ export default function DesktopStoryStrip({
       <div
         key={featuredTracker.slug}
         className="desktop-story-card desktop-story-card-enter"
+        role="button"
+        tabIndex={0}
+        aria-label={featuredTracker.headline ?? `Toggle broadcast pause for ${featuredTracker.shortName}`}
         onClick={onCardClick}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            // Only trigger if the target is the card itself, not a child interactive element
+            if (e.target === e.currentTarget) {
+              e.preventDefault();
+              onCardClick();
+            }
+          }
+        }}
       >
         {/* Single progress bar driven by broadcast progress */}
         <div className="desktop-story-progress">

--- a/src/components/islands/CommandCenter/DesktopStoryStrip.tsx
+++ b/src/components/islands/CommandCenter/DesktopStoryStrip.tsx
@@ -1,22 +1,25 @@
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useEffect, useMemo } from 'react';
 import type { TrackerCardData } from '../../../lib/tracker-directory-utils';
-import { useStoryState } from './useStoryState';
 import { relativeTime } from '../../../lib/event-utils';
 import { t, getPreferredLocale } from '../../../i18n/translations';
 
 // ── Types ──
 
 interface Props {
-  trackers: TrackerCardData[];
   basePath: string;
-  followedSlugs: string[];
-  onTrackerChange?: (slug: string) => void;
+  trackerQueue: TrackerCardData[];
+  featuredTracker: TrackerCardData | null;
+  currentIndex: number;
+  progress: number;            // 0..1
+  isPaused: boolean;
+  pauseCountdown: number;
+  onCircleClick: (slug: string) => void;
+  onCardClick: () => void;
 }
 
 // ── Constants ──
 
 const MAX_CIRCLES = 20;
-const AUTO_ADVANCE_MS = 12_000;
 
 const KPI_COLORS = [
   'var(--accent-red)',
@@ -43,140 +46,106 @@ function domainGradient(domain?: string): string {
 // ── Component ──
 
 export default function DesktopStoryStrip({
-  trackers,
   basePath,
-  followedSlugs,
-  onTrackerChange,
+  trackerQueue,
+  featuredTracker,
+  currentIndex,
+  progress,
+  isPaused,
+  pauseCountdown,
+  onCircleClick,
+  onCardClick,
 }: Props) {
   const locale = getPreferredLocale();
-
-  const story = useStoryState({
-    trackers,
-    followedSlugs,
-    autoAdvanceMs: AUTO_ADVANCE_MS,
-    onTrackerChange,
-  });
-
   const circlesRef = useRef<HTMLDivElement>(null);
+  const seenRef = useRef<Set<string>>(new Set());
+
+  // Accumulate "seen" slugs as cycle advances
+  useEffect(() => {
+    if (featuredTracker) seenRef.current.add(featuredTracker.slug);
+  }, [featuredTracker]);
 
   // Auto-scroll circle column to keep active circle visible
   useEffect(() => {
     const container = circlesRef.current;
     if (!container) return;
-    const activeCircle = container.children[story.currentIndex] as HTMLElement | undefined;
+    const activeCircle = container.children[currentIndex] as HTMLElement | undefined;
     if (activeCircle) {
       activeCircle.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }
-  }, [story.currentIndex]);
+  }, [currentIndex]);
 
-  // Circle click: go to that index and resume if paused
-  const handleCircleClick = useCallback(
-    (index: number) => {
-      story.goTo(index);
-      if (story.paused) story.handleResume();
-    },
-    [story.goTo, story.paused, story.handleResume],
+  const visibleCircles = useMemo(
+    () => trackerQueue.slice(0, MAX_CIRCLES),
+    [trackerQueue],
   );
 
-  // Card click: toggle pause/resume
-  const handleCardClick = useCallback(
-    (e: React.MouseEvent) => {
-      // Don't toggle when clicking nav zones or links
-      const target = e.target as HTMLElement;
-      if (target.closest('.desktop-story-nav-left, .desktop-story-nav-right, .desktop-story-open')) return;
+  if (visibleCircles.length === 0 || !featuredTracker) return null;
 
-      if (story.paused) {
-        story.handleResume();
-      } else {
-        story.handlePause();
-      }
-    },
-    [story.paused, story.handlePause, story.handleResume],
-  );
-
-  // Nav zone clicks
-  const handlePrev = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      if (!story.paused) story.goPrev();
-    },
-    [story.paused, story.goPrev],
-  );
-
-  const handleNext = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      if (!story.paused) story.goNext();
-    },
-    [story.paused, story.goNext],
-  );
-
-  if (story.eligible.length === 0) return null;
-
-  const tracker = story.eligible[story.currentIndex];
-  const slideCount = Math.max(1, tracker.eventImages?.length ?? 1);
-  const kpis = tracker.topKpis.slice(0, 2);
+  const kpis = featuredTracker.topKpis.slice(0, 2);
+  const progressPct = Math.max(0, Math.min(100, progress * 100));
 
   return (
     <div className="desktop-story-strip">
       {/* Circle column */}
       <div className="desktop-story-circles" ref={circlesRef}>
-        {story.eligible.slice(0, MAX_CIRCLES).map((t, i) => (
+        {visibleCircles.map((tr, i) => (
           <div
-            key={t.slug}
-            className={`desktop-story-circle${i === story.currentIndex ? ' active' : ''}${story.seenSlugs.has(t.slug) && i !== story.currentIndex ? ' seen' : ''}`}
-            onClick={() => handleCircleClick(i)}
-            title={t.shortName}
+            key={tr.slug}
+            className={
+              `desktop-story-circle` +
+              (i === currentIndex ? ' active' : '') +
+              (seenRef.current.has(tr.slug) && i !== currentIndex ? ' seen' : '')
+            }
+            onClick={() => onCircleClick(tr.slug)}
+            title={tr.shortName}
           >
-            {t.icon ?? '?'}
+            {tr.icon ?? '?'}
           </div>
         ))}
       </div>
 
       {/* Story card */}
       <div
-        key={tracker.slug}
+        key={featuredTracker.slug}
         className="desktop-story-card desktop-story-card-enter"
-        onClick={handleCardClick}
+        onClick={onCardClick}
       >
-        {/* Progress bars */}
+        {/* Single progress bar driven by broadcast progress */}
         <div className="desktop-story-progress">
-          {Array.from({ length: slideCount }, (_, i) => (
-            <div key={i} className="desktop-story-progress-seg">
-              <div
-                ref={i === story.slideIndex ? story.progressBarRef : undefined}
-                className={`desktop-story-progress-fill${i < story.slideIndex ? ' complete' : ''}${i > story.slideIndex ? ' upcoming' : ''}`}
-                style={i === story.slideIndex ? { width: '0%' } : undefined}
-              />
-            </div>
-          ))}
+          <div className="desktop-story-progress-seg">
+            <div
+              className="desktop-story-progress-fill"
+              style={{ width: `${progressPct}%` }}
+            />
+          </div>
         </div>
 
         {/* Image */}
         <div className="desktop-story-image">
-          <DesktopStoryImage tracker={tracker} slideIndex={story.slideIndex} />
+          <DesktopStoryImage tracker={featuredTracker} />
         </div>
 
         {/* Paused badge */}
-        {story.paused && (
+        {isPaused && (
           <div className="desktop-story-paused">
-            {t('story.paused', locale)} · {story.pauseCountdown}s
+            {t('story.paused', locale)} · {pauseCountdown}s
           </div>
         )}
 
         {/* Header: icon + name + age */}
         <div className="desktop-story-header">
-          <span className="desktop-story-icon">{tracker.icon ?? '?'}</span>
-          <span className="desktop-story-name">{tracker.shortName}</span>
+          <span className="desktop-story-icon">{featuredTracker.icon ?? '?'}</span>
+          <span className="desktop-story-name">{featuredTracker.shortName}</span>
           <span className="desktop-story-age" suppressHydrationWarning>
-            {relativeTime(tracker.lastUpdated)}
+            {relativeTime(featuredTracker.lastUpdated)}
           </span>
         </div>
 
         {/* Headline */}
-        {tracker.headline && (
+        {featuredTracker.headline && (
           <div className="desktop-story-content">
-            <p className="desktop-story-headline">{tracker.headline}</p>
+            <p className="desktop-story-headline">{featuredTracker.headline}</p>
           </div>
         )}
 
@@ -200,19 +169,11 @@ export default function DesktopStoryStrip({
         {/* Read More link */}
         <a
           className="desktop-story-open"
-          href={`${basePath}${tracker.slug}/`}
+          href={`${basePath}${featuredTracker.slug}/`}
           onClick={(e) => e.stopPropagation()}
         >
           {t('story.readMore', locale)}
         </a>
-
-        {/* Navigation zones (hidden when paused) */}
-        {!story.paused && (
-          <>
-            <div className="desktop-story-nav-left" onClick={handlePrev} />
-            <div className="desktop-story-nav-right" onClick={handleNext} />
-          </>
-        )}
       </div>
     </div>
   );
@@ -220,15 +181,8 @@ export default function DesktopStoryStrip({
 
 // ── Image Sub-component (3-tier fallback) ──
 
-function DesktopStoryImage({
-  tracker,
-  slideIndex = 0,
-}: {
-  tracker: TrackerCardData;
-  slideIndex?: number;
-}) {
-  // Tier 0: Slide-indexed event image
-  const slideImage = tracker.eventImages?.[slideIndex];
+function DesktopStoryImage({ tracker }: { tracker: TrackerCardData }) {
+  const slideImage = tracker.eventImages?.[0];
   if (slideImage) {
     return (
       <>
@@ -246,7 +200,6 @@ function DesktopStoryImage({
     );
   }
 
-  // Tier 1: Latest event media
   if (tracker.latestEventMedia) {
     return (
       <>
@@ -264,7 +217,6 @@ function DesktopStoryImage({
     );
   }
 
-  // Tier 2: Domain gradient + emoji fallback
   return (
     <>
       <div

--- a/src/components/islands/CommandCenter/SidebarPanel.tsx
+++ b/src/components/islands/CommandCenter/SidebarPanel.tsx
@@ -99,7 +99,7 @@ const TrackerRow = memo(function TrackerRow({
     return (
       <div
         ref={rowRef}
-        className={`cc-tracker-expanded${isLive ? ' cc-tracker-live' : ''}`}
+        className={`cc-tracker-expanded${isLive && !isActive ? ' cc-tracker-live' : ''}`}
         data-tracker-slug={tracker.slug}
         style={{
           ...S.expandedRow,

--- a/src/components/islands/CommandCenter/SidebarPanel.tsx
+++ b/src/components/islands/CommandCenter/SidebarPanel.tsx
@@ -41,6 +41,8 @@ interface Props {
   onLeaveGeoNode?: () => void;
   onClickGeoNode?: (nodeId: string, level: string) => void;
   activeGeoPath?: string[] | null;
+  // Current tracker featured by broadcast cycle (drives LIVE pulse + auto-scroll)
+  featuredSlug?: string | null;
 }
 
 // ── TrackerRow ──
@@ -52,6 +54,7 @@ const TrackerRow = memo(function TrackerRow({
   isHovered,
   isFollowed,
   isCompared,
+  isLive,
   onSelect,
   onHover,
   onToggleFollow,
@@ -64,6 +67,7 @@ const TrackerRow = memo(function TrackerRow({
   isHovered: boolean;
   isFollowed: boolean;
   isCompared: boolean;
+  isLive: boolean;
   onSelect: (slug: string | null) => void;
   onHover: (slug: string | null) => void;
   onToggleFollow: (slug: string) => void;
@@ -95,7 +99,8 @@ const TrackerRow = memo(function TrackerRow({
     return (
       <div
         ref={rowRef}
-        className="cc-tracker-expanded"
+        className={`cc-tracker-expanded${isLive ? ' cc-tracker-live' : ''}`}
+        data-tracker-slug={tracker.slug}
         style={{
           ...S.expandedRow,
           borderColor: `${color}50`,
@@ -195,7 +200,8 @@ const TrackerRow = memo(function TrackerRow({
   return (
     <div
       ref={rowRef}
-      className="cc-tracker-row"
+      className={`cc-tracker-row${isLive && !isActive ? ' cc-tracker-live' : ''}`}
+      data-tracker-slug={tracker.slug}
       style={{
         ...S.collapsedRow,
         borderLeftColor: color,
@@ -229,6 +235,11 @@ const TrackerRow = memo(function TrackerRow({
         </span>
         <span style={S.icon}>{tracker.icon || ''}</span>
         <span className="cc-tracker-name" style={S.collapsedName}>{tracker.shortName}</span>
+        {isLive && !isActive && (
+          <span className="cc-tracker-live-badge" aria-label="Currently featured by broadcast">
+            LIVE
+          </span>
+        )}
         {isCompared && <span style={S.compareDot} />}
         {tracker.latestEventMedia && (
           <img
@@ -599,6 +610,7 @@ export default function SidebarPanel({
   onLeaveGeoNode,
   onClickGeoNode,
   activeGeoPath,
+  featuredSlug,
 }: Props) {
   const [activeDomain, setActiveDomain] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -625,6 +637,17 @@ export default function SidebarPanel({
     [groups],
   );
 
+  // Auto-scroll the broadcast-featured tracker row into view when it changes
+  useEffect(() => {
+    if (!featuredSlug) return;
+    const el = document.querySelector<HTMLElement>(
+      `.cc-sidebar [data-tracker-slug="${featuredSlug}"]`,
+    );
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }, [featuredSlug]);
+
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
       onSelectTracker(null);
@@ -649,7 +672,7 @@ export default function SidebarPanel({
   const isSearching = activeDomain !== null || searchQuery.trim().length > 0;
 
   return (
-    <div style={S.sidebar} onKeyDown={handleKeyDown} tabIndex={-1}>
+    <div className="cc-sidebar" style={S.sidebar} onKeyDown={handleKeyDown} tabIndex={-1}>
       {!isMobile && (
         <div style={S.header}>
           <div style={S.headerLeft}>
@@ -839,6 +862,7 @@ export default function SidebarPanel({
                               isHovered={hoveredTracker === t.slug}
                               isFollowed={followedSlugs.includes(t.slug)}
                               isCompared={compareSlugs.includes(t.slug)}
+                              isLive={featuredSlug === t.slug}
                               onSelect={onSelectTracker}
                               onHover={onHoverTracker}
                               onToggleFollow={onToggleFollow}

--- a/src/components/islands/CommandCenter/SidebarPanel.tsx
+++ b/src/components/islands/CommandCenter/SidebarPanel.tsx
@@ -236,7 +236,7 @@ const TrackerRow = memo(function TrackerRow({
         <span style={S.icon}>{tracker.icon || ''}</span>
         <span className="cc-tracker-name" style={S.collapsedName}>{tracker.shortName}</span>
         {isLive && !isActive && (
-          <span className="cc-tracker-live-badge" aria-label="Currently featured by broadcast">
+          <span className="cc-tracker-live-badge" role="status" aria-label="Currently featured by broadcast">
             LIVE
           </span>
         )}

--- a/src/components/islands/CommandCenter/useBroadcastMode.ts
+++ b/src/components/islands/CommandCenter/useBroadcastMode.ts
@@ -28,11 +28,11 @@ interface GlobeHandle {
   setAutoRotate?: (enabled: boolean, speed?: number) => void;
 }
 
-interface BroadcastState {
-  featuredTracker: TrackerForBroadcast | null;
+interface BroadcastState<T = TrackerForBroadcast> {
+  featuredTracker: T | null;
   phase: BroadcastPhase;
   progress: number;
-  trackerQueue: TrackerForBroadcast[];
+  trackerQueue: T[];
   currentIndex: number;
   pause: () => void;
   resume: () => void;
@@ -64,14 +64,14 @@ function altitudeForDistance(dist: number): number {
 
 const USER_PAUSE_DURATION_S = 15;
 
-export function useBroadcastMode(
-  trackers: TrackerForBroadcast[],
+export function useBroadcastMode<T extends TrackerForBroadcast>(
+  trackers: T[],
   globeRef: React.RefObject<GlobeHandle | null>,
   enabled: boolean,
   onFeatureTracker?: (slug: string | null) => void,
   followedSlugs: string[] = [],
-): BroadcastState {
-  const queue = useRef<TrackerForBroadcast[]>([]);
+): BroadcastState<T> {
+  const queue = useRef<T[]>([]);
   const indexRef = useRef(0);
   const phaseRef = useRef<BroadcastPhase>('idle');
   const phaseStartRef = useRef(0);
@@ -81,7 +81,7 @@ export function useBroadcastMode(
   const userPausedRef = useRef(false);
   const pauseTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const [featuredTracker, setFeaturedTracker] = useState<TrackerForBroadcast | null>(null);
+  const [featuredTracker, setFeaturedTracker] = useState<T | null>(null);
   const [phase, setPhase] = useState<BroadcastPhase>('idle');
   const [progress, setProgress] = useState(0);
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -100,7 +100,7 @@ export function useBroadcastMode(
     if (mountedRef.current) setPhase(p);
   }, []);
 
-  const flyToTracker = useCallback((tracker: TrackerForBroadcast, prevTracker?: TrackerForBroadcast) => {
+  const flyToTracker = useCallback((tracker: T, prevTracker?: T) => {
     if (!tracker.mapCenter || !globeRef.current?.flyTo) return;
 
     const dist = prevTracker?.mapCenter

--- a/src/components/islands/CommandCenter/useBroadcastMode.ts
+++ b/src/components/islands/CommandCenter/useBroadcastMode.ts
@@ -72,6 +72,7 @@ export function useBroadcastMode<T extends TrackerForBroadcast>(
   followedSlugs: string[] = [],
 ): BroadcastState<T> {
   const queue = useRef<T[]>([]);
+  const [trackerQueueState, setTrackerQueueState] = useState<T[]>([]);
   const indexRef = useRef(0);
   const phaseRef = useRef<BroadcastPhase>('idle');
   const phaseStartRef = useRef(0);
@@ -91,7 +92,9 @@ export function useBroadcastMode<T extends TrackerForBroadcast>(
   // Build queue: active trackers with mapCenter, sorted by relevance
   useEffect(() => {
     const eligible = trackers.filter(t => t.mapCenter && t.headline);
-    queue.current = sortByRelevance(eligible, followedSlugs);
+    const sorted = sortByRelevance(eligible, followedSlugs);
+    queue.current = sorted;
+    setTrackerQueueState(sorted);
   }, [trackers, followedSlugs]);
 
   const setPhaseState = useCallback((p: BroadcastPhase) => {
@@ -293,7 +296,7 @@ export function useBroadcastMode<T extends TrackerForBroadcast>(
     featuredTracker,
     phase,
     progress,
-    trackerQueue: queue.current,
+    trackerQueue: trackerQueueState,
     currentIndex,
     pause,
     resume,

--- a/src/styles/desktop-stories.css
+++ b/src/styles/desktop-stories.css
@@ -37,6 +37,12 @@
   cursor: pointer;
   transition: transform 0.15s ease, border-color 0.2s ease, opacity 0.2s ease;
   flex-shrink: 0;
+  padding: 0;
+  font-family: inherit;
+  color: inherit;
+  line-height: 1;
+  appearance: none;
+  -webkit-appearance: none;
 }
 .desktop-story-circle:hover {
   transform: scale(1.1);

--- a/src/styles/desktop-stories.css
+++ b/src/styles/desktop-stories.css
@@ -211,25 +211,6 @@
   background: rgba(88, 166, 255, 0.08);
 }
 
-/* ── Navigation zones (invisible click areas) ── */
-.desktop-story-nav-left,
-.desktop-story-nav-right {
-  position: absolute;
-  top: 0;
-  bottom: 40px;
-  z-index: 5;
-  cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
-}
-.desktop-story-nav-left {
-  left: 0;
-  width: 40%;
-}
-.desktop-story-nav-right {
-  right: 0;
-  width: 60%;
-}
-
 /* ── Card enter animation ── */
 .desktop-story-card-enter {
   animation: desktopStoryFadeIn 0.25s ease-out;

--- a/src/styles/desktop-stories.css
+++ b/src/styles/desktop-stories.css
@@ -81,13 +81,7 @@
   width: 0%;
   background: var(--accent-blue, #58a6ff);
   border-radius: 1px;
-  transition: width 0.1s linear;
-}
-.desktop-story-progress-fill.complete {
-  width: 100%;
-}
-.desktop-story-progress-fill.upcoming {
-  width: 0%;
+  transition: width 0.15s linear;
 }
 
 /* ── Image area ── */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3369,3 +3369,42 @@ body::before {
     transform: none;
   }
 }
+
+/* ── CommandCenter: broadcast-featured row LIVE pulse ── */
+@keyframes ccLivePulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(46, 204, 113, 0.5);
+  }
+  50% {
+    box-shadow: 0 0 0 4px rgba(46, 204, 113, 0);
+  }
+}
+.cc-tracker-row.cc-tracker-live,
+.cc-tracker-expanded.cc-tracker-live {
+  animation: ccLivePulse 2s ease-in-out infinite;
+}
+.cc-tracker-live-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-left: 6px;
+  padding: 1px 5px;
+  background: rgba(46, 204, 113, 0.15);
+  border: 1px solid rgba(46, 204, 113, 0.4);
+  border-radius: 3px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.42rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #3fb950;
+  text-transform: uppercase;
+}
+.cc-tracker-live-badge::before {
+  content: '';
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #3fb950;
+  animation: ccLivePulse 1.5s ease-in-out infinite;
+}


### PR DESCRIPTION
## Summary

Unifies the three parallel "story" surfaces on the desktop homepage so a single `useBroadcastMode` cycle drives every surface in lockstep:

- **Globe camera** — flies to the featured tracker
- **BroadcastOverlay lower-third** — shows the featured tracker
- **DesktopStoryStrip** — circles + card now read from broadcast state (was an independent 12s timer)
- **SidebarPanel** — auto-scrolls to the featured row and paints it with a "● LIVE" badge + pulse animation
- **Bottom ticker** — already correctly gated off when broadcast is on (no change)

### Click behaviour — differs by surface, by design

| Surface | Behaviour on click |
|---|---|
| **Sidebar row** | `broadcast.jumpTo(slug)` + `broadcast.userPause()` — user is inspecting, cycle pauses on that tracker; `Esc` or pauseCountdown resumes |
| **Globe marker** | Same as sidebar row (selection semantics) |
| **Story-strip circle** | `broadcast.jumpTo(slug)` + auto-resume if paused — circles are cycle-navigation, not selection |
| **Story-strip card** | Toggles `userPause` / `userResume` on the cycle |

The common thread is that every click routes through `broadcast.jumpTo`, keeping every surface in sync. `userPause` vs. `userResume` differs based on whether the gesture is "I want to explore this" (row/marker) or "step me through the cycle" (circle/card).

## Design artifacts

- Spec: `docs/superpowers/specs/2026-04-16-desktop-home-sync-design.md`
- Plan: `docs/superpowers/plans/2026-04-16-desktop-home-sync.md`

## Files changed

- `src/components/islands/CommandCenter/DesktopStoryStrip.tsx` — rewritten as a dumb props-driven view; circles + card now have keyboard/ARIA semantics; circle-rendering window slides so active stays visible past index 19
- `src/components/islands/CommandCenter/CommandCenter.tsx` — threads broadcast state into strip + sidebar, rewires `handleSelect`, adds `broadcastRef` to prevent 60Hz callback churn
- `src/components/islands/CommandCenter/SidebarPanel.tsx` — adds `featuredSlug` prop, `data-tracker-slug` attributes, auto-scroll effect, LIVE badge with `role=status`
- `src/components/islands/CommandCenter/useBroadcastMode.ts` — made generic over tracker type (removes unsound casts); mirrors `trackerQueue` to state for proper reactivity
- `src/styles/global.css` — `@keyframes ccLivePulse` + LIVE badge styles
- `src/styles/desktop-stories.css` — drops dead progress-segment + nav-zone rules; adds button-reset properties to `.desktop-story-circle`

`useStoryState.ts` and `MobileStoryCarousel` are untouched — mobile experience preserved (spec explicitly out of scope).

## Test plan

- [ ] Desktop (≥ 768px): globe, lower-third, strip card, active circle all show the same tracker within one cycle
- [ ] Expand the sidebar — the broadcast-featured row has a LIVE pulse; auto-scrolls on cycle advance
- [ ] Click a row in the sidebar: all surfaces jump; countdown pause badge appears; Esc resumes
- [ ] Click a strip circle: all surfaces jump; cycle continues (no pause)
- [ ] Tab through strip circles + card via keyboard; Enter/Space activates
- [ ] Let cycle advance past index 19 (20+ seconds on a 64-tracker queue): active circle still visible and scrolled into view
- [ ] Press `B`: lower-third + strip disappear, bottom breaking ticker appears. Press `B` again: broadcast resumes
- [ ] Mobile (≤ 767px): `MobileStoryCarousel` unchanged, globe fly-to on carousel advance still works
- [ ] Screen reader: LIVE badge announced as "Currently featured by broadcast"; circles announced with `aria-label="Jump broadcast to <name>"` and `aria-current` on active
- [ ] Lighthouse Performance: no regression vs. main

## Notes for reviewer

- Commit `31a34b14` is an unrelated chore commit that landed on this branch (plan docs for a different hourly-pipeline feature + `.gitignore` for firebase keys). Happy to rebase it out if preferred.
- Pre-existing test failures in `src/i18n/translations.test.ts` (7 accent-mismatch assertions) also fail on `main` — not introduced here.
- Deferred follow-ups: consolidate altitude heuristics between `handleStoryTrackerChange` and `useBroadcastMode.flyToTracker`; add Vitest coverage for `useBroadcastMode` transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)