### PR TITLE
feat(video): composite scoring + positive mode

### DIFF
--- a/video-simulation-2026-04-18.txt
+++ b/video-simulation-2026-04-18.txt
@@ -1,0 +1,105 @@
+
+=== CONFLICT mode (2026-04-18) ===
+1. 🇺🇦 Ukraine War — score: 148 [SELECTED]
+   Headline: Gunman kills six at Kyiv grocery store, takes hostages before being shot dead by security forces
+   KPI: RUSSIAN MILITARY CASUALTIES 1.301
+   Domain: conflict | Temporal: live | Days: 1508
+
+2. 🇲🇲 Myanmar — score: 148 [SELECTED]
+   Headline: TNLA Welcomes Junta Government, Fracturing Three Brotherhood Alliance; SAC Bombs Monastery and Kills Civilians During Thingyan; SCEF Resistance Coalition Formed
+   KPI: PEOPLE KILLED BY JUNTA (AAPP) 7941
+   Domain: conflict | Temporal: live | Days: 1902
+
+3. 🛡️ NATO-US Tensions — score: 148 [SELECTED]
+   Headline: STOLTENBERG: 'NATO NOT WRITTEN IN STONE' — Trump Declares 'Will Not Support Us in Future'; Europe Forms Autonomous Hormuz Coalition; Magyar Nominated as Hungarian PM
+   KPI: NATO AVERAGE DEFENSE SPENDING (% GDP) 2.71
+   Domain: conflict | Temporal: live | Days: 3371
+
+   4. 🇮🇳 India-Pakistan — score: 148
+   Headline: Pahalgam Anniversary Approaches: Security on High Alert
+   KPI: LOC CEASEFIRE VIOLATIONS (2026 YTD) 1
+   Domain: conflict | Temporal: live | Days: 28735
+
+   5. 🦁 Somalia — score: 148
+   Headline: Somalia: Parliament Expired Apr 14, Puntland Declares Constitutional Vacuum; 54 Al-Shabaab Killed in Juba Airstrikes; Gorgor Forces Deployed as Presidential Term Enters Final 27 Days
+   KPI: AL-SHABAAB TERRITORIAL CONTROL 20
+   Domain: conflict | Temporal: live | Days: 7060
+
+   6. 🌊 SE Asia Escalation — score: 148
+   Headline: Philippines Accuses China of Cyanide Sabotage at Second Thomas Shoal; Balikatan 2026 Opens April 20
+   KPI: PHILIPPINES VFA/SOVFA PARTNERS 3
+   Domain: conflict | Temporal: live | Days: 2292
+
+   7. ⚔️ Sudan Conflict — score: 148
+   Headline: US Sanctions Colombian RSF Mercenary Networks; Berlin Conference Pledges €1.3B for Sudan
+   KPI: ESTIMATED DEATHS 150000
+   Domain: conflict | Temporal: live | Days: 1099
+
+   8. 🕊️ Israel-Palestine — score: 148
+   Headline: Israeli Forces Kill Person at Negohot Settlement in West Bank
+   KPI: GAZA DEATHS SINCE OCT 7 72317
+   Domain: conflict | Temporal: live | Days: 28452
+
+   9. 🕊️ Gaza War — score: 148
+   Headline: UNICEF: Two Water Truck Aid Workers Killed by Israeli Fire While Delivering Aid in Gaza
+   KPI: PALESTINIANS KILLED (GAZA) 72285
+   Domain: conflict | Temporal: live | Days: 909
+
+   10. 🔴 October 7 — score: 143
+   Headline: Hamas-US Cairo Talks Collapse Without Progress; Ceasefire Violations Mount as Disarmament Impasse Deepens
+   KPI: ISRAELIS KILLED (OCT 7) 1195
+   Domain: conflict | Temporal: historical | Days: 924
+
+
+
+=== POSITIVE mode (2026-04-18) ===
+1. 🤖 China Tech — score: 120 [SELECTED]
+   Headline: Stanford: China Has 'Nearly Erased' US AI Lead — Gap Now Just 39 Arena Points
+   KPI: HUAWEI REVENUE (2025) 127.6
+   Domain: science | Temporal: live | Days: 3982
+
+2. 🎤 BTS — score: 120 [SELECTED]
+   Headline: BTS Tokyo Dome Night 2 Live-Broadcast to 75+ Countries — ARIRANG Locks Historic 3rd Consecutive Billboard 200 No. 1
+   KPI: BILLBOARD HOT 100 NO. 1 HITS 7
+   Domain: culture | Temporal: live | Days: 4692
+
+3. 🧬 Cancer Breakthroughs — score: 120 [SELECTED]
+   Headline: MD Anderson Unveils New Cancer Breakthroughs at AACR Conference
+   KPI: FDA-APPROVED CAR-T CELL THERAPIES 7
+   Domain: science | Temporal: live | Days: 3025
+
+   4. 🐰 Bad Bunny — score: 105
+   Headline: Bad Bunny Wins Pollstar Latin Tour of the Year as European Leg of DTMF World Tour Approaches
+   KPI: ALL-TIME SPOTIFY STREAMS 100
+   Domain: culture | Temporal: live | Days: 3679
+
+   5. 🌙 Artemis II — score: 105
+   Headline: Artemis II Crew Holds Postflight Briefing; Mobile Launcher 1 Rolls to VAB for Artemis III
+   KPI: TOTAL ARTEMIS INVESTMENT 100
+   Domain: space | Temporal: live | Days: 3045
+
+   6. 🚀 SpaceX — score: 105
+   Headline: Booster 19 Fires All 33 Raptor 3 Engines — IFT-12 Ground Milestones Cleared; 600th Booster Landing Imminent
+   KPI: 2026 ORBITAL LAUNCHES 47
+   Domain: space | Temporal: live | Days: 8749
+
+   7. 🧬 CRISPR — score: 105
+   Headline: CRISPR Gene Therapy: From Laboratory to Clinic
+   KPI: FDA/EMA APPROVED CRISPR THERAPIES 1
+   Domain: science | Temporal: live | Days: 5038
+
+   8. 🌐 Digital Inclusion — score: 105
+   Headline: Global Digital Divide: 2.6 Billion Still Offline
+   KPI: GLOBAL INTERNET PENETRATION 67.4
+   Domain: science | Temporal: live | Days: 2296
+
+   9. 🌱 Reforestation — score: 105
+   Headline: UN Decade on Ecosystem Restoration: Midpoint — 300M Hectares Under Restoration
+   KPI: BONN CHALLENGE PLEDGES 215
+   Domain: science | Temporal: live | Days: 7044
+
+   10. ⚡ Battery Revolution — score: 105
+   Headline: Battery Technology Enters Its Breakthrough Decade
+   KPI: GLOBAL EV BATTERY DEMAND (2025 EST.) 1228
+   Domain: science | Temporal: live | Days: 2296
+

--- a/video/render.ts
+++ b/video/render.ts
@@ -2,9 +2,15 @@
  * CLI render script for Watchboard daily video.
  *
  * Usage: cd video && npx tsx render.ts
+ *        cd video && npx tsx render.ts --mode positive
+ *        cd video && npx tsx render.ts --mode positive --dry-run
  *
  * Fetches breaking data, bundles the Remotion project, and renders to MP4.
  * Every step has graceful fallbacks so we always produce SOMETHING.
+ *
+ * Flags:
+ *   --mode <conflict|positive>  Video scoring mode (default: conflict)
+ *   --dry-run                   Fetch and print scored trackers, then exit without rendering
  */
 import { execSync } from 'node:child_process';
 import { readFileSync, existsSync, mkdirSync, readdirSync, copyFileSync, statSync } from 'node:fs';
@@ -14,12 +20,35 @@ import { renderMedia, selectComposition } from '@remotion/renderer';
 import type { BreakingData } from './src/data/types.js';
 import { SAMPLE_DATA } from './src/data/types.js';
 import { calculateDuration } from './src/Video.js';
+import type { VideoMode } from './src/data/fetch-breaking.js';
 
 const ROOT_DIR = resolve(import.meta.dirname ?? '.');
 const DATA_PATH = resolve(ROOT_DIR, 'src/data/breaking.json');
 const OUTPUT_DIR = resolve(ROOT_DIR, 'output');
 const ENTRY_POINT = resolve(ROOT_DIR, 'src/Root.tsx');
 const NARRATION_PATH = resolve(ROOT_DIR, 'src/assets/narration.mp3');
+
+function parseCliFlags(): { mode: VideoMode; dryRun: boolean } {
+  const args = process.argv.slice(2);
+  let mode: VideoMode = 'conflict';
+  let dryRun = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--mode' && i + 1 < args.length) {
+      const value = args[i + 1];
+      if (value === 'positive' || value === 'conflict') {
+        mode = value;
+      } else {
+        console.warn(`Unknown mode "${value}", defaulting to "conflict"`);
+      }
+      i++; // skip value
+    } else if (args[i] === '--dry-run') {
+      dryRun = true;
+    }
+  }
+
+  return { mode, dryRun };
+}
 
 // Earth texture candidates in priority order
 const EARTH_TEXTURE_CANDIDATES = [
@@ -53,16 +82,37 @@ async function downloadThumbnail(url: string): Promise<Buffer | null> {
 }
 
 async function main(): Promise<void> {
+  const { mode, dryRun } = parseCliFlags();
+
+  // Set VIDEO_MODE env var so fetch-breaking.ts picks it up
+  process.env.VIDEO_MODE = mode;
+
   console.log('=== Watchboard Video Renderer ===\n');
+  console.log(`  Mode: ${mode}${dryRun ? ' (dry-run)' : ''}\n`);
 
   // Step 1: Fetch breaking data (with fallback to sample data)
   console.log('[1/4] Fetching breaking data...');
   let data: BreakingData;
+  const dryRunFlag = dryRun ? ' --dry-run' : '';
   try {
-    execSync('npx tsx src/data/fetch-breaking.ts', {
+    execSync(`npx tsx src/data/fetch-breaking.ts${dryRunFlag}`, {
       cwd: ROOT_DIR,
       stdio: 'inherit',
+      env: { ...process.env, VIDEO_MODE: mode },
     });
+
+    if (dryRun) {
+      // In dry-run mode, fetch-breaking.ts prints scores but may not write the file.
+      // Read the data if available, otherwise use sample for the summary.
+      if (existsSync(DATA_PATH)) {
+        data = JSON.parse(readFileSync(DATA_PATH, 'utf-8'));
+      } else {
+        data = SAMPLE_DATA;
+      }
+      console.log('\nDry-run complete. No video rendered.');
+      return;
+    }
+
     data = JSON.parse(readFileSync(DATA_PATH, 'utf-8'));
   } catch (err) {
     console.warn('  Failed to fetch breaking data — using sample data:', (err as Error).message);

--- a/video/src/data/fetch-breaking.ts
+++ b/video/src/data/fetch-breaking.ts
@@ -2,7 +2,12 @@
  * Fetches the top 3 breaking trackers from the Watchboard data directory.
  * Falls back to sample data if the tracker files are unavailable.
  *
+ * Supports two scoring modes via VIDEO_MODE env var:
+ *   - "conflict" (default): prioritizes breaking news, recent updates, conflict trackers
+ *   - "positive": prioritizes science/space/culture trackers, excludes war-related tags
+ *
  * Usage: npx tsx video/src/data/fetch-breaking.ts
+ *        VIDEO_MODE=positive npx tsx video/src/data/fetch-breaking.ts
  */
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
@@ -11,12 +16,20 @@ import { SAMPLE_DATA, type BreakingData, type BreakingTracker } from './types.js
 const TRACKERS_DIR = resolve(import.meta.dirname ?? '.', '../../../trackers');
 const OUTPUT_PATH = resolve(import.meta.dirname ?? '.', './breaking.json');
 
+export type VideoMode = 'conflict' | 'positive';
+
+const POSITIVE_DOMAINS = ['science', 'space', 'culture'] as const;
+const EXCLUDED_TAGS_FOR_POSITIVE = ['war', 'conflict', 'terrorism', 'sanctions', 'military'] as const;
+
 interface TrackerConfig {
   slug: string;
   name: string;
   shortName?: string;
   icon: string;
   status: string;
+  domain?: string;
+  temporal?: string;
+  tags?: string[];
   map?: { center?: { lat: number; lon: number } };
 }
 
@@ -32,6 +45,17 @@ interface KpiItem {
   label: string;
   value: string;
   source: string;
+}
+
+export interface ScoredCandidate {
+  tracker: BreakingTracker;
+  score: number;
+  breaking: boolean;
+  lastUpdated: string;
+  domain?: string;
+  temporal?: string;
+  tags?: string[];
+  dayCount: number;
 }
 
 function parseKpiNumericValue(raw: string): number {
@@ -70,7 +94,64 @@ function findThumbnailUrls(slug: string): string[] {
   return [...new Set(urls)];
 }
 
-function loadTrackerBreaking(slug: string): BreakingTracker | null {
+function daysSince(dateStr: string): number {
+  const then = new Date(dateStr).getTime();
+  const now = Date.now();
+  return Math.max(0, Math.floor((now - then) / 86_400_000));
+}
+
+/**
+ * Computes a numeric score for a tracker candidate based on the video mode.
+ *
+ * Returns null if the candidate should be excluded entirely (e.g., wrong domain
+ * or excluded tags in positive mode).
+ */
+export function scoreCandidate(candidate: ScoredCandidate, mode: VideoMode): number | null {
+  const age = daysSince(candidate.lastUpdated);
+
+  if (mode === 'positive') {
+    // REQUIRED: domain must be in the positive list
+    if (!candidate.domain || !POSITIVE_DOMAINS.includes(candidate.domain as typeof POSITIVE_DOMAINS[number])) {
+      return null;
+    }
+    // Exclude trackers with war-related tags
+    if (candidate.tags?.some((tag) => EXCLUDED_TAGS_FOR_POSITIVE.includes(tag as typeof EXCLUDED_TAGS_FOR_POSITIVE[number]))) {
+      return null;
+    }
+
+    let score = 50; // domain match bonus (always awarded since we passed the check)
+    if (age <= 7) score += 30;
+    else if (age <= 30) score += 15;
+    else if (age <= 90) score += 5;
+    if (candidate.temporal === 'live') score += 20;
+    if (candidate.breaking) score += 15;
+    if (candidate.dayCount > 1000) score += 5;
+    return score;
+  }
+
+  // conflict mode (default)
+  let score = 0;
+  if (candidate.breaking) score += 100;
+  if (age <= 1) score += 30;
+  else if (age <= 7) score += 15;
+  else if (age <= 30) score += 5;
+  if (candidate.domain === 'conflict') score += 10;
+  if (candidate.temporal === 'live') score += 5;
+  if (candidate.dayCount > 0) score += 3;
+  return score;
+}
+
+interface LoadedTrackerData {
+  tracker: BreakingTracker;
+  breaking: boolean;
+  lastUpdated: string;
+  domain?: string;
+  temporal?: string;
+  tags?: string[];
+  dayCount: number;
+}
+
+function loadTrackerBreaking(slug: string): LoadedTrackerData | null {
   const trackerDir = join(TRACKERS_DIR, slug);
   const configPath = join(trackerDir, 'tracker.json');
   const metaPath = join(trackerDir, 'data', 'meta.json');
@@ -108,7 +189,7 @@ function loadTrackerBreaking(slug: string): BreakingTracker | null {
 
     const thumbnailUrls = findThumbnailUrls(slug);
 
-    return {
+    const tracker: BreakingTracker = {
       slug: config.slug,
       name: config.shortName ?? config.name,
       icon: config.icon,
@@ -122,13 +203,31 @@ function loadTrackerBreaking(slug: string): BreakingTracker | null {
       mapCenter: [lat, lng],
       thumbnailUrls,
     };
+
+    return {
+      tracker,
+      breaking: meta.breaking === true,
+      lastUpdated: meta.lastUpdated ?? '2000-01-01',
+      domain: config.domain,
+      temporal: config.temporal,
+      tags: config.tags,
+      dayCount: meta.dayCount ?? 0,
+    };
   } catch {
     console.warn(`Failed to load tracker: ${slug}`);
     return null;
   }
 }
 
-function fetchBreakingData(): BreakingData {
+export interface FetchBreakingOptions {
+  mode?: VideoMode;
+  dryRun?: boolean;
+}
+
+export function fetchBreakingData(options: FetchBreakingOptions = {}): BreakingData {
+  const mode = options.mode ?? 'conflict';
+  const dryRun = options.dryRun ?? false;
+
   if (!existsSync(TRACKERS_DIR)) {
     console.warn('Trackers directory not found, using sample data.');
     return SAMPLE_DATA;
@@ -138,36 +237,56 @@ function fetchBreakingData(): BreakingData {
     .filter((d) => d.isDirectory())
     .map((d) => d.name);
 
-  // Prioritize trackers with breaking=true in meta, then most recently updated
-  const candidates: Array<{ tracker: BreakingTracker; breaking: boolean; lastUpdated: string }> =
-    [];
+  const scored: ScoredCandidate[] = [];
 
   for (const slug of slugs) {
-    const tracker = loadTrackerBreaking(slug);
-    if (!tracker) continue;
+    const loaded = loadTrackerBreaking(slug);
+    if (!loaded) continue;
 
-    const metaPath = join(TRACKERS_DIR, slug, 'data', 'meta.json');
-    let isBreaking = false;
-    let lastUpdated = '2000-01-01';
+    const candidate: ScoredCandidate = {
+      tracker: loaded.tracker,
+      score: 0,
+      breaking: loaded.breaking,
+      lastUpdated: loaded.lastUpdated,
+      domain: loaded.domain,
+      temporal: loaded.temporal,
+      tags: loaded.tags,
+      dayCount: loaded.dayCount,
+    };
 
-    try {
-      const meta: MetaData = JSON.parse(readFileSync(metaPath, 'utf-8'));
-      isBreaking = meta.breaking === true;
-      lastUpdated = meta.lastUpdated ?? lastUpdated;
-    } catch {
-      // skip
-    }
+    const calculatedScore = scoreCandidate(candidate, mode);
+    if (calculatedScore === null) continue; // excluded by mode filter
 
-    candidates.push({ tracker, breaking: isBreaking, lastUpdated });
+    candidate.score = calculatedScore;
+    scored.push(candidate);
   }
 
-  // Sort: breaking first, then by lastUpdated desc
-  candidates.sort((a, b) => {
-    if (a.breaking !== b.breaking) return a.breaking ? -1 : 1;
+  // Sort by score descending, then by lastUpdated descending as tiebreaker
+  scored.sort((a, b) => {
+    if (a.score !== b.score) return b.score - a.score;
     return b.lastUpdated.localeCompare(a.lastUpdated);
   });
 
-  const top3 = candidates.slice(0, 3).map((c) => c.tracker);
+  if (dryRun) {
+    const today = new Date().toISOString().split('T')[0];
+    const modeLabel = mode.toUpperCase();
+    console.log(`\n=== ${modeLabel} mode (${today}) ===`);
+    for (let i = 0; i < Math.min(scored.length, 10); i++) {
+      const c = scored[i];
+      const rank = i < 3 ? `${i + 1}.` : `   ${i + 1}.`;
+      const selected = i < 3 ? ' [SELECTED]' : '';
+      console.log(`${rank} ${c.tracker.icon} ${c.tracker.name} — score: ${c.score}${selected}`);
+      console.log(`   Headline: ${c.tracker.headline}`);
+      console.log(`   KPI: ${c.tracker.kpiLabel} ${c.tracker.kpiValue}`);
+      console.log(`   Domain: ${c.domain ?? 'n/a'} | Temporal: ${c.temporal ?? 'n/a'} | Days: ${c.dayCount}`);
+      console.log('');
+    }
+    if (scored.length === 0) {
+      console.log('  No trackers matched this mode.\n');
+    }
+  }
+
+  const top3 = scored.slice(0, 3).map((c) => c.tracker);
 
   if (top3.length === 0) {
     console.warn('No active trackers found, using sample data.');
@@ -178,13 +297,25 @@ function fetchBreakingData(): BreakingData {
   return { date: today, trackers: top3 };
 }
 
-// Main execution
-const data = fetchBreakingData();
+// Main execution — only when run directly
+const isMain = import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith('fetch-breaking.ts');
 
-const outputDir = resolve(OUTPUT_PATH, '..');
-if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });
+if (isMain) {
+  const envMode = (process.env.VIDEO_MODE ?? 'conflict') as VideoMode;
+  const mode: VideoMode = envMode === 'positive' ? 'positive' : 'conflict';
+  const dryRun = process.argv.includes('--dry-run');
 
-writeFileSync(OUTPUT_PATH, JSON.stringify(data, null, 2));
-console.log(`Breaking data written to ${OUTPUT_PATH}`);
-console.log(`Date: ${data.date}`);
-console.log(`Trackers: ${data.trackers.map((t) => `${t.icon} ${t.name}`).join(', ')}`);
+  const data = fetchBreakingData({ mode, dryRun });
+
+  if (!dryRun) {
+    const outputDir = resolve(OUTPUT_PATH, '..');
+    if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });
+
+    writeFileSync(OUTPUT_PATH, JSON.stringify(data, null, 2));
+    console.log(`Breaking data written to ${OUTPUT_PATH}`);
+    console.log(`Date: ${data.date}`);
+    console.log(`Mode: ${mode}`);
+    console.log(`Trackers: ${data.trackers.map((t) => `${t.icon} ${t.name}`).join(', ')}`);
+  }
+}


### PR DESCRIPTION
## Summary

- **Replaced simple 2-level sort** (breaking → lastUpdated) with a **weighted composite scoring function** in `video/src/data/fetch-breaking.ts`
- **Added `positive` video mode** for science/space/culture trackers (Meta-safe domains — no war/conflict content)
- **Added CLI flags**: `--mode <conflict|positive>` and `--dry-run` to `render.ts`

## Scoring System

### Conflict mode (default, improved)
| Signal | Points |
|--------|--------|
| `breaking=true` | +100 |
| Updated ≤24h / ≤7d / ≤30d | +30 / +15 / +5 |
| `domain === "conflict"` | +10 |
| `temporal === "live"` | +5 |
| `dayCount > 0` | +3 |

### Positive mode
| Signal | Points |
|--------|--------|
| `domain` in science/space/culture | +50 (required) |
| Updated ≤7d / ≤30d / ≤90d | +30 / +15 / +5 |
| `temporal === "live"` | +20 |
| `breaking=true` | +15 |
| `dayCount > 1000` | +5 |

Positive mode **excludes** trackers with tags: `war`, `conflict`, `terrorism`, `sanctions`, `military`.

## Simulation (2026-04-18)

**Conflict:** 🇺🇦 Ukraine War (148) · 🇲🇲 Myanmar (148) · 🛡️ NATO-US Tensions (148)
**Positive:** 🤖 China Tech (120) · 🎤 BTS (120) · 🧬 Cancer Breakthroughs (120)

## Usage

```bash
npx tsx render.ts --mode positive --dry-run   # preview positive picks
npx tsx render.ts --mode positive              # render positive video
VIDEO_MODE=positive npx tsx src/data/fetch-breaking.ts  # fetch only
```

## Test plan
- [x] Dry-run simulation for both modes produces expected output
- [ ] `npm run build` passes (no type errors from unchanged video composition)
- [ ] Full render with `--mode positive` produces valid MP4

🤖 Generated with [Claude Code](https://claude.com/claude-code)