### PR TITLE
fix(home): default sidebar expanded on wide screens (≥ 1280px)

### DIFF
--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -17,6 +17,7 @@ import DesktopStoryStrip from './DesktopStoryStrip';
 import { getDiscoveredFeatures, markFeatureDiscovered, getNextCoachHint } from '../../../lib/onboarding';
 
 const FOLLOWS_KEY = 'watchboard-follows';
+const SIDEBAR_PREF_KEY = 'watchboard-sidebar-pref'; // 'expanded' | 'collapsed'
 
 function loadFollows(): string[] {
   try {
@@ -196,6 +197,17 @@ export default function CommandCenter({
     const discovered = getDiscoveredFeatures();
     setDiscoveredFeatures(discovered);
     setCoachHint(getNextCoachHint(discovered));
+
+    // Sidebar default: expanded on wide desktops (≥ 1280px), collapsed on narrow
+    // screens. User's explicit preference in localStorage overrides the default.
+    const storedPref = localStorage.getItem(SIDEBAR_PREF_KEY);
+    if (storedPref === 'expanded') {
+      setSidebarCollapsed(false);
+    } else if (storedPref === 'collapsed') {
+      setSidebarCollapsed(true);
+    } else if (window.innerWidth >= 1280) {
+      setSidebarCollapsed(false);
+    }
   }, []);
 
   useEffect(() => {
@@ -661,7 +673,10 @@ export default function CommandCenter({
         {!isMobile && sidebarCollapsed ? (
           <div style={styles.collapsedSidebarContent}>
             <button
-              onClick={() => setSidebarCollapsed(false)}
+              onClick={() => {
+                setSidebarCollapsed(false);
+                try { localStorage.setItem(SIDEBAR_PREF_KEY, 'expanded'); } catch {}
+              }}
               style={styles.sidebarToggleBtn}
               aria-label="Expand sidebar"
               title="Expand sidebar"
@@ -733,7 +748,10 @@ export default function CommandCenter({
           <>
             {!isMobile && (
               <button
-                onClick={() => setSidebarCollapsed(true)}
+                onClick={() => {
+                  setSidebarCollapsed(true);
+                  try { localStorage.setItem(SIDEBAR_PREF_KEY, 'collapsed'); } catch {}
+                }}
                 style={styles.sidebarCollapseBtn}
                 aria-label="Collapse sidebar"
                 title="Collapse sidebar"


### PR DESCRIPTION
## Problem

On wide desktops, first-load of the homepage showed a collapsed 220px rail with just an icon strip — no search, no OPS/GEO/DOMAIN tabs, no visible tracker directory. Users had to find and click a small hamburger to reveal the actual navigation panel. That's what the "empty space on the right" looks like on a ≥ 1280px screen.

## Change

\`src/components/islands/CommandCenter/CommandCenter.tsx\`:

- SSR-safe default remains \`sidebarCollapsed = true\` (hydration match)
- On mount, pick the real default:
  - If user has an explicit preference in localStorage → use that
  - Else if viewport width ≥ 1280px → expand
  - Else → stay collapsed
- Persist explicit toggles to \`localStorage['watchboard-sidebar-pref']\` so the choice sticks across sessions

Narrow screens (< 1280px) keep the current collapsed-first behavior. Mobile (< 768px) is unaffected.

## Test plan

- [ ] 1440×900: first load shows full sidebar (search + tabs + tracker list)
- [ ] 1280×800: first load shows expanded
- [ ] 1100×800: first load shows collapsed (unchanged)
- [ ] Collapse on wide → reload → still collapsed (preference persists)
- [ ] Expand on narrow → reload → still expanded (preference wins over width default)
- [ ] Clear localStorage → reload on wide → expanded again (default returns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)