### PR TITLE
feat(home): sidebar right-panel — hero + minimal feed redesign

### DIFF
--- a/docs/superpowers/plans/2026-04-22-right-panel-hero-minimal.md
+++ b/docs/superpowers/plans/2026-04-22-right-panel-hero-minimal.md
@@ -1,0 +1,1358 @@
+# Right Panel — Hero + Minimal Feed Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the decoration-heavy tracker list in the homepage sidebar with a two-part layout — one editorial hero card on top (static, highest-relevance tracker) and a minimal two-line feed below. Drop tier chips, colored borders, freshness dots, and group-header labels; tabs become inline text-only with an underline indicator.
+
+**Architecture:** Small-scoped migration. One new pure helper (`selectHeroTracker`), two new components (`HeroCard`, `FeedRow`), a restyled `ViewModeToggle`, and a rewritten body in `SidebarPanel`. No change to broadcast state flow, search logic, or the expanded active-tracker row.
+
+**Tech Stack:** Astro 5 + React 19 islands, TypeScript, CSS. Vitest for the hero-selection pure function. No React Testing Library — UI verified via Playwright (existing `/tmp/verify_final.py` pattern).
+
+**Spec:** `docs/superpowers/specs/2026-04-22-right-panel-hero-minimal-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `src/lib/hero-selection.ts` — `selectHeroTracker` pure function
+- `src/lib/hero-selection.test.ts` — Vitest tests
+- `src/components/islands/CommandCenter/HeroCard.tsx` — top hero component
+- `src/components/islands/CommandCenter/FeedRow.tsx` — minimal two-line row
+
+**Modify:**
+- `src/components/islands/CommandCenter/ViewModeToggle.tsx` — restyle to inline underline tabs
+- `src/components/islands/CommandCenter/SidebarPanel.tsx` — replace collapsed-row rendering with `FeedRow`, insert hero above the list, drop `RecentEventsFeed` + group headers + sort dropdown + domain-mode tab row
+- `src/styles/global.css` — add `.cc-hero-card`, `.cc-feed-row`, `.cc-feed-tabs` rules; update the PR #106 `.cc-tracker-live` pulse selector to also target `.cc-feed-row.cc-tracker-live`
+
+**Leave alone:**
+- `src/lib/relevance.ts` — `sortByRelevance` used as-is
+- `src/components/islands/CommandCenter/GeoAccordion.tsx` — reused unchanged in GEO view
+- `src/components/islands/CommandCenter/CommandCenter.tsx` — no changes; `featuredSlug` prop already wired
+
+---
+
+## Task 1: `selectHeroTracker` pure helper + tests
+
+**Files:**
+- Create: `src/lib/hero-selection.ts`
+- Create: `src/lib/hero-selection.test.ts`
+
+- [ ] **Step 1.1: Write the failing tests**
+
+Create `src/lib/hero-selection.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { selectHeroTracker } from './hero-selection';
+import type { TrackerCardData } from './tracker-directory-utils';
+
+function makeTracker(overrides: Partial<TrackerCardData> & { slug: string }): TrackerCardData {
+  return {
+    slug: overrides.slug,
+    shortName: overrides.shortName ?? overrides.slug,
+    name: overrides.name ?? overrides.slug,
+    description: '',
+    icon: '',
+    color: '#3498db',
+    status: 'active',
+    temporal: 'live',
+    domain: 'conflict',
+    region: 'global',
+    startDate: '2024-01-01',
+    sections: [],
+    dayCount: 0,
+    lastUpdated: '2026-04-22T00:00:00Z',
+    topKpis: [],
+    headline: 'Default headline',
+    latestEventMedia: { url: 'https://example.com/a.jpg', source: 'Src', tier: 1 },
+    eventImages: [],
+    isBreaking: false,
+    recentEventCount: 0,
+    avgSourceTier: 2,
+    sectionsUpdatedCount: 0,
+    ...(overrides as TrackerCardData),
+  } as TrackerCardData;
+}
+
+describe('selectHeroTracker', () => {
+  it('returns null when the list is empty', () => {
+    expect(selectHeroTracker([], [])).toBeNull();
+  });
+
+  it('returns null when no tracker has a headline', () => {
+    const trackers = [
+      makeTracker({ slug: 'a', headline: undefined }),
+      makeTracker({ slug: 'b', headline: '' }),
+    ];
+    expect(selectHeroTracker(trackers, [])).toBeNull();
+  });
+
+  it('excludes trackers with no media and empty eventImages', () => {
+    const trackers = [
+      makeTracker({ slug: 'no-media', latestEventMedia: undefined, eventImages: [] }),
+      makeTracker({ slug: 'has-media', latestEventMedia: { url: 'x', source: 's', tier: 1 } }),
+    ];
+    expect(selectHeroTracker(trackers, [])?.slug).toBe('has-media');
+  });
+
+  it('accepts trackers with eventImages even if latestEventMedia is missing', () => {
+    const trackers = [
+      makeTracker({
+        slug: 'by-events',
+        latestEventMedia: undefined,
+        eventImages: [{ url: 'x', source: 's', tier: 1 }],
+      }),
+    ];
+    expect(selectHeroTracker(trackers, [])?.slug).toBe('by-events');
+  });
+
+  it('excludes archived trackers', () => {
+    const trackers = [
+      makeTracker({ slug: 'archived', status: 'archived' }),
+      makeTracker({ slug: 'active' }),
+    ];
+    expect(selectHeroTracker(trackers, [])?.slug).toBe('active');
+  });
+
+  it('prefers breaking > followed > editorial > recency', () => {
+    const trackers = [
+      makeTracker({
+        slug: 'breaking',
+        isBreaking: true,
+        lastUpdated: '2026-04-01T00:00:00Z',
+      }),
+      makeTracker({
+        slug: 'followed',
+        isBreaking: false,
+        lastUpdated: '2026-04-22T00:00:00Z',
+      }),
+    ];
+    expect(selectHeroTracker(trackers, ['followed'])?.slug).toBe('breaking');
+  });
+
+  it('returns the followed tracker when nothing is breaking', () => {
+    const trackers = [
+      makeTracker({ slug: 'a' }),
+      makeTracker({ slug: 'b' }),
+    ];
+    expect(selectHeroTracker(trackers, ['b'])?.slug).toBe('b');
+  });
+
+  it('is stable — same input, same output', () => {
+    const trackers = [
+      makeTracker({ slug: 'x', recentEventCount: 5 }),
+      makeTracker({ slug: 'y', recentEventCount: 2 }),
+    ];
+    const a = selectHeroTracker(trackers, []);
+    const b = selectHeroTracker(trackers, []);
+    expect(a?.slug).toBe(b?.slug);
+  });
+});
+```
+
+- [ ] **Step 1.2: Run tests — confirm they fail**
+
+Run: `npm test -- --run src/lib/hero-selection.test.ts`
+
+Expected: FAIL with "Cannot find module './hero-selection'".
+
+- [ ] **Step 1.3: Implement the pure function**
+
+Create `src/lib/hero-selection.ts`:
+
+```ts
+import type { TrackerCardData } from './tracker-directory-utils';
+import { sortByRelevance } from './relevance';
+
+/**
+ * Pick the hero tracker for the sidebar: the highest-relevance active tracker
+ * that has a headline and at least one usable image. Returns null if none qualify.
+ *
+ * Stable for a given (trackers, followedSlugs) pair.
+ */
+export function selectHeroTracker(
+  trackers: TrackerCardData[],
+  followedSlugs: string[],
+): TrackerCardData | null {
+  const eligible = trackers.filter(t =>
+    t.status === 'active' &&
+    typeof t.headline === 'string' &&
+    t.headline.length > 0 &&
+    (t.latestEventMedia != null || (t.eventImages?.length ?? 0) > 0)
+  );
+  if (eligible.length === 0) return null;
+  const sorted = sortByRelevance(eligible, followedSlugs);
+  return sorted[0] ?? null;
+}
+```
+
+- [ ] **Step 1.4: Run tests — confirm they pass**
+
+Run: `npm test -- --run src/lib/hero-selection.test.ts`
+
+Expected: PASS — all 8 tests.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/lib/hero-selection.ts src/lib/hero-selection.test.ts
+git commit -m "feat(home): add selectHeroTracker pure helper
+
+Picks the highest-relevance active tracker with a headline and
+image to feature in the sidebar hero card. Reuses the existing
+sortByRelevance scoring. Stable for a given (trackers, follows)
+pair — broadcast cycling does not change the hero."
+```
+
+---
+
+## Task 2: `HeroCard` component + CSS
+
+**Files:**
+- Create: `src/components/islands/CommandCenter/HeroCard.tsx`
+- Modify: `src/styles/global.css` (append)
+
+- [ ] **Step 2.1: Write the component**
+
+Create `src/components/islands/CommandCenter/HeroCard.tsx`:
+
+```tsx
+import { memo } from 'react';
+import type { TrackerCardData } from '../../../lib/tracker-directory-utils';
+import { relativeTime } from '../../../lib/event-utils';
+import { t, type Locale } from '../../../i18n/translations';
+
+const DOMAIN_GRADIENTS: Record<string, string> = {
+  military: 'linear-gradient(135deg, #1a0a0a, #2c1010, #0d1117)',
+  conflict: 'linear-gradient(135deg, #1a0a0a, #2c1010, #0d1117)',
+  politics: 'linear-gradient(135deg, #0a0a1a, #101030, #0d1117)',
+  sports: 'linear-gradient(135deg, #0a1a0a, #102010, #0d1117)',
+  crisis: 'linear-gradient(135deg, #1a0f00, #2c1a05, #0d1117)',
+  culture: 'linear-gradient(135deg, #1a0a1a, #2c102c, #0d1117)',
+  default: 'linear-gradient(135deg, #12141a, #181b23, #0d1117)',
+};
+
+interface Props {
+  tracker: TrackerCardData;
+  isBroadcastFeatured: boolean;
+  basePath: string;
+  locale: Locale;
+  onSelect: (slug: string) => void;
+}
+
+export default memo(function HeroCard({
+  tracker,
+  isBroadcastFeatured,
+  basePath: _basePath,
+  locale,
+  onSelect,
+}: Props) {
+  const thumbUrl = tracker.latestEventMedia?.url ?? tracker.eventImages?.[0]?.url ?? null;
+  const gradient = DOMAIN_GRADIENTS[tracker.domain ?? 'default'] ?? DOMAIN_GRADIENTS.default;
+  const headline = (locale === 'es' && tracker.headlineEs) ? tracker.headlineEs : tracker.headline;
+  const source = tracker.latestEventMedia?.source;
+  const tier = tracker.latestEventMedia?.tier;
+
+  const handleClick = () => onSelect(tracker.slug);
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onSelect(tracker.slug);
+    }
+  };
+
+  return (
+    <div
+      className={`cc-hero-card${isBroadcastFeatured ? ' cc-hero-card-live' : ''}`}
+      role="button"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      aria-label={`Open ${tracker.shortName} dashboard`}
+    >
+      <div
+        className="cc-hero-thumb"
+        style={thumbUrl ? undefined : { background: gradient }}
+      >
+        {thumbUrl ? (
+          <img
+            src={thumbUrl}
+            alt=""
+            loading="lazy"
+            referrerPolicy="no-referrer"
+            onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+          />
+        ) : (
+          <span className="cc-hero-thumb-icon">{tracker.icon ?? '?'}</span>
+        )}
+      </div>
+      <div className="cc-hero-body">
+        <div className="cc-hero-context">
+          {tracker.dayCount > 0 && `${t('hero.day', locale)} ${tracker.dayCount} · `}
+          {(tracker.domain ?? '').toUpperCase()}
+        </div>
+        <div className="cc-hero-name-row">
+          <span className="cc-hero-name">{tracker.shortName}</span>
+          {isBroadcastFeatured && (
+            <span className="cc-hero-live" role="status" aria-label="Currently featured by broadcast">
+              <span className="cc-hero-live-dot" />LIVE
+            </span>
+          )}
+        </div>
+        {headline && <div className="cc-hero-headline">{headline}</div>}
+        <div className="cc-hero-meta">
+          {source && tier != null && (
+            <span className="cc-hero-source">T{tier} · {source}</span>
+          )}
+          <span className="cc-hero-time" suppressHydrationWarning>
+            {relativeTime(tracker.lastUpdated).toUpperCase()}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+});
+```
+
+- [ ] **Step 2.2: Append CSS to `global.css`**
+
+Add to the end of `/Users/artemiopadilla/Documents/repos/GitHub/personal/watchboard/src/styles/global.css`:
+
+```css
+/* ─── Sidebar Hero Card ─── */
+.cc-hero-card {
+  display: flex;
+  gap: 12px;
+  padding: 14px;
+  margin: 8px 10px 4px;
+  background: var(--bg-card, #181b23);
+  border: 1px solid var(--border, #2a2d3a);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.cc-hero-card:hover {
+  border-color: var(--accent-blue, #58a6ff);
+  background: var(--bg-card-hover, #1e2130);
+}
+.cc-hero-card:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}
+.cc-hero-card.cc-hero-card-live {
+  border-color: rgba(46, 204, 113, 0.35);
+}
+
+.cc-hero-thumb {
+  width: 96px;
+  height: 96px;
+  border-radius: 6px;
+  flex-shrink: 0;
+  overflow: hidden;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.cc-hero-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.cc-hero-thumb-icon {
+  font-size: 42px;
+  opacity: 0.7;
+}
+
+.cc-hero-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.cc-hero-context {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.5rem;
+  letter-spacing: 0.15em;
+  color: var(--text-muted, #8b8fa2);
+  text-transform: uppercase;
+}
+.cc-hero-name-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.cc-hero-name {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--text-primary, #e8e9ed);
+  text-transform: uppercase;
+}
+.cc-hero-live {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 5px;
+  background: rgba(46, 204, 113, 0.15);
+  border: 1px solid rgba(46, 204, 113, 0.4);
+  border-radius: 3px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.45rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: #3fb950;
+}
+.cc-hero-live-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #3fb950;
+  animation: ccLivePulse 1.6s ease-in-out infinite;
+}
+.cc-hero-headline {
+  font-family: 'Inter', 'DM Sans', sans-serif;
+  font-size: 0.82rem;
+  font-weight: 500;
+  line-height: 1.35;
+  color: var(--text-primary, #e8e9ed);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin-top: 2px;
+}
+.cc-hero-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 4px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.5rem;
+  letter-spacing: 0.08em;
+  color: var(--text-muted, #8b8fa2);
+  text-transform: uppercase;
+}
+
+/* Mid-width (768-1279px): smaller thumb */
+@media (min-width: 768px) and (max-width: 1279px) {
+  .cc-hero-thumb { width: 64px; height: 64px; }
+  .cc-hero-thumb-icon { font-size: 30px; }
+  .cc-hero-headline { font-size: 0.74rem; -webkit-line-clamp: 2; }
+}
+```
+
+- [ ] **Step 2.3: Add i18n key for hero**
+
+Open `/Users/artemiopadilla/Documents/repos/GitHub/personal/watchboard/src/i18n/translations.ts` and add a `hero.day` entry.
+
+Find the English block (search for `"cc.day"` or similar short keys near the top of the `en` translations). Add:
+
+```ts
+'hero.day': 'DAY',
+```
+
+Mirror it in `es`, `fr`, `pt` blocks (same key, same value — "DAY" is a common-enough English term that the untranslated fallback is acceptable; if you prefer localized, use "DÍA" / "JOUR" / "DIA").
+
+- [ ] **Step 2.4: Build check**
+
+Run: `npm run build 2>&1 | tail -10`
+
+Expected: TypeScript compiles. Pre-existing Zod/data errors may remain — those are unrelated.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/components/islands/CommandCenter/HeroCard.tsx src/styles/global.css src/i18n/translations.ts
+git commit -m "feat(home): add HeroCard component + CSS
+
+Editorial hero card for the sidebar top. Shows thumbnail, day/domain
+context line, tracker shortName (with LIVE pulse when broadcast-
+featured), headline (3-line clamp), and a T{tier} · source · time
+meta footer. Click or Enter/Space opens the tracker dashboard.
+Responsive thumb size at 768-1279px."
+```
+
+---
+
+## Task 3: `FeedRow` component + CSS
+
+**Files:**
+- Create: `src/components/islands/CommandCenter/FeedRow.tsx`
+- Modify: `src/styles/global.css` (append + update existing `.cc-tracker-live` rule)
+
+- [ ] **Step 3.1: Write the component**
+
+Create `src/components/islands/CommandCenter/FeedRow.tsx`:
+
+```tsx
+import { memo, useRef, useEffect } from 'react';
+import type { TrackerCardData } from '../../../lib/tracker-directory-utils';
+import { relativeTime } from '../../../lib/event-utils';
+import { t, type Locale } from '../../../i18n/translations';
+
+interface Props {
+  tracker: TrackerCardData;
+  isHovered: boolean;
+  isFollowed: boolean;
+  isCompared: boolean;
+  isLive: boolean;
+  isDimmed: boolean;
+  basePath: string;
+  locale: Locale;
+  onSelect: (slug: string | null) => void;
+  onHover: (slug: string | null) => void;
+  onToggleFollow: (slug: string) => void;
+  onToggleCompare: (slug: string) => void;
+}
+
+export default memo(function FeedRow({
+  tracker,
+  isHovered,
+  isFollowed,
+  isCompared,
+  isLive,
+  isDimmed,
+  basePath: _basePath,
+  locale,
+  onSelect,
+  onHover,
+  onToggleFollow,
+  onToggleCompare,
+}: Props) {
+  const rowRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll into view when hovered (mirrors old TrackerRow behavior)
+  useEffect(() => {
+    if (isHovered && rowRef.current) {
+      rowRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }, [isHovered]);
+
+  const headline = (locale === 'es' && tracker.headlineEs) ? tracker.headlineEs : tracker.headline;
+
+  return (
+    <div
+      ref={rowRef}
+      className={`cc-feed-row${isLive ? ' cc-tracker-live' : ''}${isDimmed ? ' cc-feed-row-dim' : ''}`}
+      data-tracker-slug={tracker.slug}
+      onClick={(e) => {
+        if (e.shiftKey) {
+          onToggleCompare(tracker.slug);
+        } else {
+          onSelect(tracker.slug);
+        }
+      }}
+      onMouseEnter={() => onHover(tracker.slug)}
+      onMouseLeave={() => onHover(null)}
+      title={tracker.shortName}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          onSelect(tracker.slug);
+        }
+      }}
+    >
+      <span className="cc-feed-icon">{tracker.icon ?? ''}</span>
+      <div className="cc-feed-body">
+        <div className="cc-feed-top">
+          <span className="cc-feed-name">{tracker.shortName}</span>
+          {isLive && <span className="cc-feed-live-dot" role="status" aria-label="Live" />}
+        </div>
+        {headline && <div className="cc-feed-headline">{headline}</div>}
+      </div>
+      <div className="cc-feed-right">
+        <span className="cc-feed-time" suppressHydrationWarning>
+          {relativeTime(tracker.lastUpdated)}
+        </span>
+        <div className="cc-feed-actions">
+          <button
+            type="button"
+            className={`cc-feed-action cc-feed-follow${isFollowed ? ' is-on' : ''}`}
+            onClick={(e) => { e.stopPropagation(); onToggleFollow(tracker.slug); }}
+            title={isFollowed ? t('sidebar.unfollow', locale) : t('sidebar.follow', locale)}
+            aria-label={isFollowed ? t('sidebar.unfollow', locale) : t('sidebar.follow', locale)}
+          >
+            {isFollowed ? '★' : '☆'}
+          </button>
+          <button
+            type="button"
+            className={`cc-feed-action cc-feed-compare${isCompared ? ' is-on' : ''}`}
+            onClick={(e) => { e.stopPropagation(); onToggleCompare(tracker.slug); }}
+            title={isCompared ? t('sidebar.removeFromComparison', locale) : t('sidebar.addToComparison', locale)}
+            aria-label={isCompared ? t('sidebar.removeFromComparison', locale) : t('sidebar.addToComparison', locale)}
+          >
+            {isCompared ? '◆' : '◇'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+});
+```
+
+- [ ] **Step 3.2: Append feed-row CSS + update PR #106 live pulse selector**
+
+First, find the PR #106 live pulse rule in `global.css` (search for `.cc-tracker-row.cc-tracker-live`). It should look like:
+
+```css
+.cc-tracker-row.cc-tracker-live,
+.cc-tracker-expanded.cc-tracker-live {
+  animation: ccLivePulse 2s ease-in-out infinite;
+}
+```
+
+Replace that selector with:
+
+```css
+.cc-feed-row.cc-tracker-live,
+.cc-tracker-expanded.cc-tracker-live {
+  animation: none; /* the inline live-dot pulses on its own; avoid pulsing the whole row */
+}
+```
+
+Rationale: the old pulsing `box-shadow` on the entire row was flagged in PR #106's code review as a potential paint-cost hotspot on low-end devices. The feed row uses a dedicated `.cc-feed-live-dot` pseudo-element instead. We keep the selector for the expanded row case (existing) but disable the row-level pulse in the new design.
+
+Now append at the end of the file:
+
+```css
+/* ─── Sidebar Feed Row ─── */
+.cc-feed-row {
+  display: grid;
+  grid-template-columns: 22px 1fr auto;
+  gap: 4px 10px;
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: background 0.15s ease, opacity 0.2s ease;
+  align-items: start;
+  border-left: 2px solid transparent;
+}
+.cc-feed-row:hover {
+  background: var(--bg-card-hover, #1e2130);
+}
+.cc-feed-row:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: -2px;
+}
+.cc-feed-row.cc-tracker-live {
+  border-left-color: #3fb950;
+}
+.cc-feed-row.cc-feed-row-dim .cc-feed-icon,
+.cc-feed-row.cc-feed-row-dim .cc-feed-name {
+  opacity: 0.55;
+}
+.cc-feed-row.cc-feed-row-dim .cc-feed-headline {
+  opacity: 0.45;
+}
+
+.cc-feed-icon {
+  font-size: 1rem;
+  line-height: 1.2;
+  grid-row: 1 / span 2;
+  align-self: center;
+  text-align: center;
+}
+
+.cc-feed-body {
+  min-width: 0;
+}
+.cc-feed-top {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 2px;
+}
+.cc-feed-name {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--text-primary, #e8e9ed);
+  text-transform: uppercase;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cc-feed-live-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #3fb950;
+  box-shadow: 0 0 6px rgba(46, 204, 113, 0.6);
+  animation: ccLivePulse 1.6s ease-in-out infinite;
+  flex-shrink: 0;
+}
+.cc-feed-headline {
+  font-family: 'Inter', 'DM Sans', sans-serif;
+  font-size: 0.66rem;
+  line-height: 1.3;
+  color: var(--text-secondary, #9498a8);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cc-feed-right {
+  grid-row: 1 / span 2;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.cc-feed-time {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.5rem;
+  letter-spacing: 0.04em;
+  color: var(--text-muted, #8b8fa2);
+}
+.cc-feed-actions {
+  display: flex;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+.cc-feed-row:hover .cc-feed-actions {
+  opacity: 1;
+}
+.cc-feed-action {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 3px;
+  font-size: 0.6rem;
+  color: var(--text-muted, #8b8fa2);
+  line-height: 1;
+}
+.cc-feed-action.is-on {
+  opacity: 1;
+  color: #f39c12;
+}
+.cc-feed-compare.is-on {
+  color: var(--accent-blue, #58a6ff);
+}
+.cc-feed-follow:hover,
+.cc-feed-compare:hover {
+  color: var(--text-primary, #e8e9ed);
+}
+
+/* Follow star stays visible when followed, even without hover */
+.cc-feed-row .cc-feed-follow.is-on {
+  opacity: 1;
+}
+.cc-feed-row:not(:hover) .cc-feed-actions:has(.is-on) {
+  opacity: 1;
+}
+```
+
+- [ ] **Step 3.3: Build check**
+
+Run: `npm run build 2>&1 | tail -10`
+
+Expected: TypeScript compiles.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add src/components/islands/CommandCenter/FeedRow.tsx src/styles/global.css
+git commit -m "feat(home): add FeedRow component
+
+Two-line minimal row: icon + UPPERCASE name + truncated headline +
+relative time. Follow/compare buttons fade in on hover (or stay on
+when toggled). LIVE pulse shows as a small green dot + left-edge
+accent for the broadcast-featured tracker. Older-than-48h rows
+dim via the cc-feed-row-dim modifier. Update PR #106 selector
+target to .cc-feed-row; disable row-level box-shadow pulse
+(replaced by the inline live dot) per prior review feedback."
+```
+
+---
+
+## Task 4: Restyle `ViewModeToggle` to inline underline tabs
+
+**Files:**
+- Modify: `src/components/islands/CommandCenter/ViewModeToggle.tsx`
+- Modify: `src/styles/global.css`
+
+- [ ] **Step 4.1: Rewrite ViewModeToggle to a class-based underline layout**
+
+Open `src/components/islands/CommandCenter/ViewModeToggle.tsx` and replace the entire file content with:
+
+```tsx
+import { memo } from 'react';
+
+export type ViewMode = 'operations' | 'geographic' | 'domain';
+
+interface Props {
+  mode: ViewMode;
+  onChange: (mode: ViewMode) => void;
+}
+
+const MODES: { id: ViewMode; label: string }[] = [
+  { id: 'operations', label: 'OPS' },
+  { id: 'geographic', label: 'GEO' },
+  { id: 'domain', label: 'DOMAIN' },
+];
+
+export default memo(function ViewModeToggle({ mode, onChange }: Props) {
+  return (
+    <div className="cc-feed-tabs" role="tablist" aria-label="Tracker list view">
+      {MODES.map(m => (
+        <button
+          key={m.id}
+          type="button"
+          role="tab"
+          aria-selected={mode === m.id}
+          className={`cc-feed-tab${mode === m.id ? ' is-active' : ''}`}
+          onClick={() => onChange(m.id)}
+        >
+          {m.label}
+        </button>
+      ))}
+    </div>
+  );
+});
+```
+
+- [ ] **Step 4.2: Append tab CSS to `global.css`**
+
+Append:
+
+```css
+/* ─── Sidebar Inline Tabs ─── */
+.cc-feed-tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--border, #2a2d3a);
+  margin-bottom: 4px;
+}
+.cc-feed-tab {
+  background: none;
+  border: none;
+  padding: 8px 10px 6px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.55rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: var(--text-muted, #8b8fa2);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px; /* overlap the container's bottom border */
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.cc-feed-tab:hover {
+  color: var(--text-primary, #e8e9ed);
+}
+.cc-feed-tab.is-active {
+  color: var(--accent-blue, #58a6ff);
+  border-bottom-color: var(--accent-blue, #58a6ff);
+}
+.cc-feed-tab:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}
+```
+
+- [ ] **Step 4.3: Build check**
+
+Run: `npm run build 2>&1 | tail -10`
+
+Expected: TypeScript compiles (file imports are simpler now, no inline styles).
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add src/components/islands/CommandCenter/ViewModeToggle.tsx src/styles/global.css
+git commit -m "style(home): inline underline tabs for ViewModeToggle
+
+Drop the pill/chip styling; tabs are now text-only (OPS / GEO /
+DOMAIN) with an underline indicator under the active tab, sitting
+directly above the feed list. Accessible via role=tablist /
+role=tab with aria-selected."
+```
+
+---
+
+## Task 5: Rewrite `SidebarPanel` body
+
+This is the largest task — the `SidebarPanel` body currently uses `RecentEventsFeed` + `groupTrackers` + a sort dropdown + a domain-tabs row + `TrackerRow`s with colored borders and dots. We replace the render output with: search → inline tabs → hero → divider-separated feed.
+
+**Files:**
+- Modify: `src/components/islands/CommandCenter/SidebarPanel.tsx`
+
+- [ ] **Step 5.1: Import new components and helper**
+
+Near the top of `SidebarPanel.tsx`, add imports:
+
+```tsx
+import FeedRow from './FeedRow';
+import HeroCard from './HeroCard';
+import { selectHeroTracker } from '../../../lib/hero-selection';
+```
+
+- [ ] **Step 5.2: Remove the collapsed branch from `TrackerRow`; delegate to `FeedRow`**
+
+Find the `TrackerRow` component (around line 48) and the collapsed-row return block (around line 195, starts with `// Collapsed row`).
+
+Replace the entire collapsed branch (from the `// Collapsed row` comment through the closing `);` of its return) with a single call to `FeedRow`:
+
+```tsx
+  // Collapsed: delegate to FeedRow
+  return (
+    <FeedRow
+      tracker={tracker}
+      isHovered={isHovered}
+      isFollowed={isFollowed}
+      isCompared={isCompared}
+      isLive={isLive}
+      isDimmed={false} /* the parent SidebarPanel controls dimming via wrappers — keep false here */
+      basePath={basePath}
+      locale={locale}
+      onSelect={onSelect}
+      onHover={onHover}
+      onToggleFollow={onToggleFollow}
+      onToggleCompare={onToggleCompare}
+    />
+  );
+```
+
+The `TrackerRow` expanded branch (the `if (isActive) { return ( ... ) }` block) stays untouched — that's the active-tracker detail view.
+
+Clean up now-unused locals in `TrackerRow` if lint flags them (e.g., `getFreshnessDot`, `computeFreshness` usage in the collapsed block). Leave them if still used elsewhere.
+
+- [ ] **Step 5.3: Compute hero tracker in `SidebarPanel`**
+
+Inside the main `SidebarPanel` function body, after the existing `useMemo` calls for `filtered`, `sortedFiltered`, `groups`, etc., add:
+
+```tsx
+const heroTracker = useMemo(
+  () => selectHeroTracker(trackers, followedSlugs),
+  [trackers, followedSlugs],
+);
+```
+
+Place this before the `return` statement. `trackers` is the full directory prop, NOT `filtered` — the hero is independent of search/filter state.
+
+- [ ] **Step 5.4: Remove the sort dropdown block**
+
+Find the "Sort dropdown" block (search for `{(viewMode || 'operations') !== 'geographic' && (`). Delete the entire block including the closing `)}`.
+
+Also remove the `sortTrackers` call and the `sortKey` state. Locate:
+- `const [sortKey, setSortKey] = useState<SortKey>('name');`
+- `const sortedFiltered = useMemo(() => sortTrackers(filtered, sortKey), [filtered, sortKey]);`
+
+Replace the `sortedFiltered` line with:
+
+```tsx
+const sortedFiltered = useMemo(
+  () => sortByRelevance(filtered, followedSlugs),
+  [filtered, followedSlugs],
+);
+```
+
+And delete the `sortKey` state line. Ensure `sortByRelevance` is imported (add `import { sortByRelevance } from '../../../lib/relevance';` if not already there).
+
+Also remove `SortKey`, `getSortOptions`, `sortTrackers`, and `RecentEventsFeed` if they're unused after this edit (check with grep). If `RecentEventsFeed` is only referenced from its render site, delete its declaration too — it's a large ~150 line block.
+
+- [ ] **Step 5.5: Remove the domain-tabs block from the render (replaced by inline tabs)**
+
+Find the "Domain tabs — only in domain mode" block (search for `(viewMode || 'operations') === 'domain' && (`). Delete the entire block.
+
+The domain filter logic (`activeDomain`) will now be accessed through a different UX: for v1, remove domain filtering entirely when in DOMAIN view — each domain is its own group header. (Trackers are still grouped by domain via `groupTrackers(sortedFiltered)`.) Clicking a group header to filter is deferred.
+
+Also delete the `activeDomain` state and the call to `setActiveDomain` if present. Remove the call from `filterTrackers` arguments:
+
+```tsx
+// Before
+const filtered = useMemo(
+  () => filterTrackers(trackers, activeDomain, searchQuery),
+  [trackers, activeDomain, searchQuery],
+);
+
+// After
+const filtered = useMemo(
+  () => filterTrackers(trackers, null, searchQuery),
+  [trackers, searchQuery],
+);
+```
+
+- [ ] **Step 5.6: Replace the list render block with the new hero + feed layout**
+
+Find the `{/* Tracker list */}` block. Replace the entire `<div style={S.list}>...</div>` with:
+
+```tsx
+{/* Hero — hidden during search */}
+{!isSearching && heroTracker && (
+  <HeroCard
+    tracker={heroTracker}
+    isBroadcastFeatured={featuredSlug === heroTracker.slug}
+    basePath={basePath}
+    locale={locale}
+    onSelect={onSelectTracker}
+  />
+)}
+
+{/* Tracker list */}
+<div style={S.list}>
+  {(viewMode || 'operations') === 'geographic' ? (
+    <GeoAccordion
+      trackers={filtered}
+      basePath={basePath}
+      activeTracker={activeTracker}
+      onSelectTracker={onSelectTracker}
+      onHoverTracker={onHoverTracker}
+      expandedKeys={geoExpandedKeys}
+      onExpandedKeysChange={onGeoExpandedKeysChange}
+      onHoverGeoNode={onHoverGeoNode}
+      onLeaveGeoNode={onLeaveGeoNode}
+      onClickGeoNode={onClickGeoNode}
+      activeGeoPath={activeGeoPath}
+    />
+  ) : (
+    <FeedList
+      trackers={sortedFiltered}
+      followedSlugs={followedSlugs}
+      activeTracker={activeTracker}
+      hoveredTracker={hoveredTracker}
+      compareSlugs={compareSlugs}
+      featuredSlug={featuredSlug ?? null}
+      basePath={basePath}
+      locale={locale}
+      viewMode={(viewMode || 'operations') as ViewMode}
+      onSelectTracker={onSelectTracker}
+      onHoverTracker={onHoverTracker}
+      onToggleFollow={onToggleFollow}
+      onToggleCompare={onToggleCompare}
+      isSearching={isSearching}
+    />
+  )}
+</div>
+```
+
+- [ ] **Step 5.7: Add the `FeedList` subcomponent inside `SidebarPanel.tsx`**
+
+Near the other sub-component declarations at the top of the file (after `TrackerRow`, before `SidebarPanel`), add:
+
+```tsx
+// ── FeedList ──
+
+const OLDER_THRESHOLD_MS = 48 * 3600 * 1000;
+
+interface FeedListProps {
+  trackers: TrackerCardData[];
+  followedSlugs: string[];
+  activeTracker: string | null;
+  hoveredTracker: string | null;
+  compareSlugs: string[];
+  featuredSlug: string | null;
+  basePath: string;
+  locale: Locale;
+  viewMode: ViewMode;
+  onSelectTracker: (slug: string | null) => void;
+  onHoverTracker: (slug: string | null) => void;
+  onToggleFollow: (slug: string) => void;
+  onToggleCompare: (slug: string) => void;
+  isSearching: boolean;
+}
+
+const FeedList = memo(function FeedList({
+  trackers,
+  followedSlugs,
+  activeTracker,
+  hoveredTracker,
+  compareSlugs,
+  featuredSlug,
+  basePath,
+  locale,
+  viewMode,
+  onSelectTracker,
+  onHoverTracker,
+  onToggleFollow,
+  onToggleCompare,
+  isSearching,
+}: FeedListProps) {
+  const now = Date.now();
+  const followed = new Set(followedSlugs);
+
+  const renderOne = (tracker: TrackerCardData, isDimmed: boolean) => {
+    const isActive = activeTracker === tracker.slug;
+    if (isActive) {
+      return (
+        <TrackerRow
+          key={tracker.slug}
+          tracker={tracker}
+          basePath={basePath}
+          isActive
+          isHovered={hoveredTracker === tracker.slug}
+          isFollowed={followed.has(tracker.slug)}
+          isCompared={compareSlugs.includes(tracker.slug)}
+          isLive={featuredSlug === tracker.slug}
+          onSelect={onSelectTracker}
+          onHover={onHoverTracker}
+          onToggleFollow={onToggleFollow}
+          onToggleCompare={onToggleCompare}
+          locale={locale}
+        />
+      );
+    }
+    return (
+      <FeedRow
+        key={tracker.slug}
+        tracker={tracker}
+        isHovered={hoveredTracker === tracker.slug}
+        isFollowed={followed.has(tracker.slug)}
+        isCompared={compareSlugs.includes(tracker.slug)}
+        isLive={featuredSlug === tracker.slug}
+        isDimmed={isDimmed && !isSearching}
+        basePath={basePath}
+        locale={locale}
+        onSelect={onSelectTracker}
+        onHover={onHoverTracker}
+        onToggleFollow={onToggleFollow}
+        onToggleCompare={onToggleCompare}
+      />
+    );
+  };
+
+  if (trackers.length === 0) {
+    return (
+      <div style={{
+        padding: '24px 12px',
+        textAlign: 'center',
+        fontFamily: "'JetBrains Mono', monospace",
+        fontSize: '0.62rem',
+        color: 'var(--text-muted)',
+      }}>
+        No trackers match.
+      </div>
+    );
+  }
+
+  // DOMAIN view: group by tracker.domain, no dim-older split (user asked for
+  // domain groups to drive visual hierarchy).
+  if (viewMode === 'domain') {
+    const byDomain = new Map<string, TrackerCardData[]>();
+    for (const t of trackers) {
+      const key = t.domain ?? 'other';
+      const arr = byDomain.get(key) ?? [];
+      arr.push(t);
+      byDomain.set(key, arr);
+    }
+    return (
+      <>
+        {Array.from(byDomain.entries()).map(([domain, list]) => (
+          <div key={domain}>
+            <div className="cc-feed-group-divider" aria-label={domain.toUpperCase()}>
+              {domain.toUpperCase()}
+            </div>
+            {list.map(tr => renderOne(tr, false))}
+          </div>
+        ))}
+      </>
+    );
+  }
+
+  // OPS view: followed first, then recent, then older (dimmed), separated by
+  // 1px dividers (no text labels).
+  const followedTrackers: TrackerCardData[] = [];
+  const recent: TrackerCardData[] = [];
+  const older: TrackerCardData[] = [];
+
+  for (const t of trackers) {
+    if (followed.has(t.slug)) {
+      followedTrackers.push(t);
+      continue;
+    }
+    const age = now - new Date(t.lastUpdated).getTime();
+    if (age > OLDER_THRESHOLD_MS) older.push(t);
+    else recent.push(t);
+  }
+
+  return (
+    <>
+      {followedTrackers.length > 0 && (
+        <>
+          {followedTrackers.map(tr => renderOne(tr, false))}
+          {(recent.length > 0 || older.length > 0) && <div className="cc-feed-divider" />}
+        </>
+      )}
+      {recent.map(tr => renderOne(tr, false))}
+      {older.length > 0 && <div className="cc-feed-divider" />}
+      {older.map(tr => renderOne(tr, true))}
+    </>
+  );
+});
+```
+
+Ensure `ViewMode` and `Locale` types are imported at the top of the file (check — they likely already are).
+
+- [ ] **Step 5.8: Add divider CSS**
+
+Append to `global.css`:
+
+```css
+.cc-feed-divider {
+  height: 1px;
+  background: var(--border, #2a2d3a);
+  margin: 6px 10px;
+  opacity: 0.5;
+}
+.cc-feed-group-divider {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.5rem;
+  letter-spacing: 0.22em;
+  color: var(--text-muted, #8b8fa2);
+  padding: 14px 12px 4px;
+  border-top: 1px solid var(--border, #2a2d3a);
+  margin-top: 6px;
+}
+.cc-feed-group-divider:first-child {
+  border-top: none;
+  margin-top: 0;
+}
+```
+
+- [ ] **Step 5.9: Build + verify**
+
+Run: `npm run build 2>&1 | tail -10`
+
+Expected: TypeScript compiles. Pre-existing Zod errors remain.
+
+If there are TS errors about unused imports or props on the now-deleted blocks, remove them. Common cleanups:
+- `SortKey`, `getSortOptions`, `sortTrackers` — delete
+- `computeDomainCounts`, `getVisibleDomains` usage in the old domain-tabs block — deleted with the block
+- The `tab` and `tabCount` style functions in `S = { ... }` — delete
+
+- [ ] **Step 5.10: Commit**
+
+```bash
+git add src/components/islands/CommandCenter/SidebarPanel.tsx src/styles/global.css
+git commit -m "feat(home): rewrite SidebarPanel body around hero + feed
+
+- Hero card shown above the list (hidden during search)
+- Inline underline tabs replace the pill ViewModeToggle
+- Remove sort dropdown, domain-tabs row, RecentEventsFeed, and
+  group-header labels; grouping is done by divider + dim-older now
+- OPS view: followed / recent / older (dimmed) split by dividers
+- DOMAIN view: grouped by domain with small uppercase labels
+- GEO view: hero above GeoAccordion, no other change
+- TrackerRow collapsed branch delegates to FeedRow"
+```
+
+---
+
+## Task 6: Manual verification + follow-up polish
+
+**Files:** none (uses dev server + browser)
+
+- [ ] **Step 6.1: Start the dev server**
+
+Run: `npm run dev`
+
+Wait for Astro to print the local URL (typically `http://localhost:4321/`).
+
+- [ ] **Step 6.2: Open the homepage at 1440×900**
+
+Open `http://localhost:4321/`. Default sidebar state after PR #115: expanded (~440 px).
+
+**Verify:**
+- Hero card visible near the top, below search + tabs.
+- Thumbnail renders (event image OR gradient+icon fallback).
+- Tracker name is uppercase, bold, monospace; LIVE pulse badge appears when the hero tracker is currently broadcast-featured.
+- Headline clamps to 3 lines.
+- Below the hero: followed trackers first (if any), then a faint divider, then recent rows, then another divider, then dim older rows.
+- No tier chips, no colored left borders, no freshness dots on rows.
+- Tabs row shows OPS / GEO / DOMAIN as text with an underline under the active tab.
+
+- [ ] **Step 6.3: Click tabs — verify view transitions**
+
+- Click `GEO`: hero remains at top; below it, the `GeoAccordion` renders with expandable region groups.
+- Click `DOMAIN`: hero remains at top; below it, rows are grouped by domain with small `CULTURE`, `CONFLICT`, etc. labels.
+- Click `OPS`: back to the divided layout.
+
+- [ ] **Step 6.4: Type in search — verify hero + tabs hide**
+
+Press `/` to focus search. Type `ir` (or any query).
+
+**Verify:**
+- Hero card disappears.
+- Tabs remain visible (they're part of the chrome; the spec's "hide tabs during search" line was a design draft — keeping tabs visible is the pragmatic choice because filter still applies within the current tab). If you prefer hiding tabs during search, simply wrap the `<ViewModeToggle>` in `{!isSearching && (...)}`. **Your call in this step — pick one and proceed.**
+- Feed shows only matching rows.
+
+- [ ] **Step 6.5: Click the hero — verify navigation**
+
+Click anywhere on the hero card. It should set the hero's tracker as `activeTracker`, which causes the corresponding `TrackerRow` expanded view to appear inline in the list below. Then click "Open Dashboard →" in that expanded view — verify it navigates to `/mencho-cjng/` (or whatever tracker slug the hero picked).
+
+- [ ] **Step 6.6: Broadcast cycle — verify hero stays put**
+
+Wait ~10 seconds. The lower-third on the globe should cycle through trackers. The LIVE pulse dot should move between feed rows (and the hero's LIVE badge should flash off/on when the hero tracker coincides with the broadcast-featured tracker). **The hero card itself must NOT change tracker** — that's the "static hero" contract from the spec.
+
+- [ ] **Step 6.7: Hover a row — verify follow/compare buttons appear**
+
+Hover a feed row. The ☆ follow and ◇ compare buttons should fade in at the right edge. Click ☆ — the row moves to the "followed" section at the top (above the first divider).
+
+- [ ] **Step 6.8: Narrow viewport — 800×800**
+
+Resize to 800×800.
+
+**Verify:**
+- Hero thumbnail shrinks from 96 px to 64 px.
+- Headline clamp is 2 lines instead of 3.
+- Feed rows remain readable.
+
+- [ ] **Step 6.9: Mobile viewport — 375×812**
+
+Resize to 375×812.
+
+**Verify:**
+- `MobileStoryCarousel` and existing mobile tabs behavior unchanged.
+- No visual regressions.
+
+- [ ] **Step 6.10: Console check**
+
+DevTools console should be clean of errors related to these new components. Pre-existing THREE.Clock deprecation warnings and unrelated 500s can be ignored.
+
+- [ ] **Step 6.11: Run Vitest suite**
+
+Run: `npm test -- --run 2>&1 | tail -10`
+
+Expected: all tests pass, including the 8 new `selectHeroTracker` tests. Pre-existing i18n translation test failures (accent assertions) are unrelated.
+
+- [ ] **Step 6.12: Final polish commit (if needed)**
+
+If steps 6.4's tabs-during-search decision went the "hide tabs" way, or step 6.5 revealed an ordering issue, commit a focused fix:
+
+```bash
+git add -A
+git commit -m "fix(home): polish after manual verification"
+```
+
+Skip if no tweaks required.
+
+---
+
+## Post-implementation checklist
+
+- [ ] `npm run build` passes
+- [ ] `npm test -- --run` passes (except pre-existing i18n failures on accented characters — unrelated)
+- [ ] All Task 6 manual checks pass
+- [ ] Commits are clean and incremental (5 feature commits + maybe 1 polish)
+- [ ] GEO view and mobile layout unchanged from user perspective
+- [ ] Lighthouse Performance score within ±3 points of main
+
+## Rollback plan
+
+If the design regresses in production:
+- Revert the full set of commits
+- No data layer or workflow changes — revert is safe
+- `TrackerRow` expanded branch, `GeoAccordion`, `GeoPanel`, and `SidebarPanel`'s outer chrome (header, search, footer) are preserved. Only the middle rendering region changes.

--- a/docs/superpowers/specs/2026-04-22-right-panel-hero-minimal-design.md
+++ b/docs/superpowers/specs/2026-04-22-right-panel-hero-minimal-design.md
@@ -1,0 +1,248 @@
+# Right Panel — Hero + Minimal Feed
+
+**Date:** 2026-04-22
+**Status:** Design
+**Scope:** Desktop sidebar panel (`SidebarPanel`) on the homepage, viewport ≥ 768px.
+
+## Problem
+
+The sidebar today is a flat list where every tracker row looks identical — same size, same typography, same decorations. On a wide screen, this produces a dense strip of roughly similar rows with no visual anchor and a lot of incidental ornament:
+
+- Each row carries a tracker-colored left border, a freshness dot, a status pill, a follow star, a hover-revealed compare dot, and a dateline
+- Groups use loud `★ FOLLOWING` / `● LATEST INTEL` monospace labels
+- Two parallel sort/filter surfaces (OPS/GEO/DOMAIN tabs plus a search input plus implicit group-by) compete for attention at the top
+
+The user's feedback: "looks like shit" and "lots of empty space + no tabs to search by geo etc." — the panel's real job (**efficient directory**) is obscured by ornament, while its secondary job (**editorial / activity signal**) has no dedicated surface.
+
+## Goal
+
+Give the panel a clear two-part structure:
+
+1. **Hero card** (top, ~180 px) — the single most-significant tracker right now, rendered editorially (thumbnail + full headline + small meta). Static while the user browses; does not cycle with broadcast.
+2. **Minimal feed** (rest) — every other tracker as a two-line row (name + truncated headline + time). No chips, no dots, no colored borders. Information density comes from the *content*, not from decoration.
+
+Tabs (OPS / GEO / DOMAIN) stay inline and always visible but become text-only with a thin underline indicator. Group labels are replaced by faint 1 px dividers and opacity changes.
+
+Not in scope: mobile layout (<768 px), globe, broadcast lower-third, story strip, command-center state machine.
+
+## Architecture
+
+The panel has five vertical regions:
+
+```
+┌──────────────────────────────────┐
+│ HEADER                           │  brand + collapse/settings
+│ SEARCH (underline input)         │
+│ TABS (inline, text-only)         │
+│ HERO CARD (hidden if empty)      │
+│ FEED (scrolling rows)            │
+└──────────────────────────────────┘
+```
+
+State that drives rendering:
+
+- `trackers: TrackerCardData[]` — full directory (existing prop)
+- `broadcast.featuredTracker` — drives per-row LIVE pulse (existing, from `useBroadcastMode`)
+- `activeTracker` — user-selected tracker (existing)
+- `searchQuery: string` — filters feed; when non-empty, hero + tabs hide
+- `viewMode: 'operations' | 'geographic' | 'domain'` — tab state (existing)
+- `activeDomain` (domain view) — existing
+- `heroTracker`: derived — see selection rule below
+
+All other existing state remains unchanged.
+
+## Components
+
+### `HeroCard` (new)
+
+Single-tracker showcase component. Props:
+
+```ts
+interface HeroCardProps {
+  tracker: TrackerCardData;
+  isBroadcastFeatured: boolean;
+  basePath: string;
+  locale: Locale;
+  onSelect: (slug: string) => void;
+}
+```
+
+Layout: thumbnail on the left (96 × 96 px, rounded, covers `latestEventMedia.url` if present, domain gradient otherwise), text block on the right.
+
+Text block:
+- Top: `Day {dayCount} · {domain.toUpperCase()}` — small monospace, muted
+- Middle: `tracker.shortName` in uppercase bold monospace + a `● LIVE` pulse badge when `isBroadcastFeatured` is true
+- Below thumb row: headline (Inter, 0.82 rem, 3-line clamp)
+- Footer: `T{tier} · {source}` on the left, `relativeTime(lastUpdated)` on the right
+
+Click anywhere → `onSelect(slug)`. Hover → subtle border highlight.
+
+### `FeedRow` (new, collapsed state only)
+
+Replaces the existing `TrackerRow` collapsed branch. Props:
+
+```ts
+interface FeedRowProps {
+  tracker: TrackerCardData;
+  isActive: boolean;
+  isHovered: boolean;
+  isFollowed: boolean;
+  isCompared: boolean;
+  isLive: boolean;            // featured by broadcast
+  isDimmed: boolean;          // older than 48h
+  onSelect: (slug: string | null) => void;
+  onHover: (slug: string | null) => void;
+  onToggleFollow: (slug: string) => void;
+  onToggleCompare: (slug: string) => void;
+  locale: Locale;
+}
+```
+
+Two-line layout:
+- Top line: `{icon} {SHORTNAME}` on the left, `{relativeTime}` on the right
+- Bottom line: truncated headline (single line, ellipsis), Inter small
+
+When `isLive`: a 3 px green accent bar on the left edge, a small pulsing dot next to the name. No other decoration.
+
+When `isDimmed`: icon + name at 70 % opacity; headline at 60 %.
+
+When `isActive`: row does NOT render — `TrackerRowExpanded` takes over (see below).
+
+On hover: background tint (`#0e1015`); a follow star (★) and compare icon (◇) fade in at the far right; both are 0.6 rem muted mono, accent color when active.
+
+### `TrackerRowExpanded` (reused)
+
+Keep the existing expanded-row markup from `SidebarPanel.TrackerRow` (the `if (isActive)` branch). No visual changes to the expanded state — it already has a KPI strip, follow/compare buttons, and an "Open Dashboard" link.
+
+### `SidebarPanel` (modified)
+
+The main component gains:
+
+1. A `heroTracker` selection memo (see rule below)
+2. A search-active branch that hides hero + tabs and renders only filtered `FeedRow`s
+3. In OPS view: a two-divider layout (followed / recent / older) with no text labels
+4. In GEO view: the existing `GeoAccordion` renders **below** the hero card
+5. In DOMAIN view: existing `DOMAIN_COLORS` grouping, hero above
+
+Remove: the existing `groupTrackers` → `groupHeader(type)` rendering, the per-row colored left border, the freshness dot, and the collapsed status pill.
+
+Keep: search input (styled as underline), the existing `ViewModeToggle` (restyled as inline underline tabs), keyboard nav (↑/↓/Enter/`/`), `handleToggleFollow`, `handleToggleCompare`, `featuredSlug` auto-scroll effect from PR #106.
+
+## Data flow
+
+### Hero selection rule
+
+Compute `heroTracker` via `useMemo` whenever `trackers`, `followedSlugs`, or `broadcast.featuredTracker` changes:
+
+```ts
+function selectHeroTracker(trackers, followedSlugs): TrackerCardData | null {
+  const eligible = trackers.filter(t =>
+    t.status === 'active' &&
+    t.headline &&
+    (t.latestEventMedia || t.eventImages?.length)
+  );
+  if (eligible.length === 0) return null;
+  const sorted = sortByRelevance(eligible, followedSlugs);
+  return sorted[0];
+}
+```
+
+The hero is **static across a session** — it only changes when `trackers` mutates (rare) or `followedSlugs` changes (user follows/unfollows). Broadcast cycling does NOT change the hero — motion lives in the lower-third overlay and the LIVE-row pulse only.
+
+### Feed ordering
+
+OPS view:
+
+```
+[HERO]
+─── (followed trackers, in sortByRelevance order) ───
+(faint 1px divider)
+─── (unfollowed trackers, recent ≤48h) ───
+(faint 1px divider)
+─── (unfollowed trackers, older >48h, dimmed) ───
+```
+
+If no trackers are followed: no first divider; feed starts with recent/older split only.
+
+GEO and DOMAIN views: hero renders above; below, existing grouped markup (`GeoAccordion` / `groupTrackers`) with the new `FeedRow` used for leaf rows. The dim-older rule applies within each group.
+
+### Search
+
+When `searchQuery.trim().length > 0`:
+- Hide hero card
+- Hide tabs
+- Replace feed with flat filtered list (`filterTrackers` existing util) using `FeedRow`
+- Show a "Clear" button inside the search input if non-empty
+
+## Error handling
+
+- No eligible hero tracker (e.g. no headlines yet, freshly-seeded repo) → hero card silently omitted; feed still renders
+- `latestEventMedia.url` fails to load → `onError` sets `display: none` on the `<img>`, gradient backdrop remains (matches existing behavior in `DesktopStoryStrip`)
+- Search with zero results → feed shows a single muted row: "No trackers match `{query}`" + "Clear search" link (matches existing empty-state in `SidebarPanel`)
+- `trackers` array empty → entire panel renders a skeleton (existing behavior)
+
+## Testing
+
+Automated (pure-function Vitest tests against `selectHeroTracker` in `src/lib/hero-selection.test.ts` — the project has no React Testing Library / jsdom setup today, so avoid component-level tests):
+
+1. `selectHeroTracker` returns the highest-relevance eligible tracker
+2. `selectHeroTracker` excludes trackers without a headline
+3. `selectHeroTracker` excludes trackers without any `latestEventMedia` and empty `eventImages`
+4. `selectHeroTracker` returns `null` when no tracker is eligible
+5. With two equal-relevance trackers, followed wins
+6. Changing `broadcast.featuredTracker` alone does NOT change `selectHeroTracker` output (stability)
+
+Manual (Playwright, extending the existing `/tmp/verify_final.py` pattern):
+
+1. Desktop 1440×900: hero card visible at top with correct tracker + LIVE badge when applicable
+2. Expand sidebar for first time → hero + feed render in <1s
+3. Click a feed row → expanded view takes over, hero still visible above
+4. Type in search → hero + tabs hide, only filtered rows render
+5. Clear search → hero + tabs return
+6. Switch to GEO view → hero remains, accordion below, dim-older rule still applies
+7. Broadcast cycle advances → LIVE row pulse moves, hero does NOT change
+8. Viewport 800×800: panel at 320 px, hero thumb 64 px, feed tighter
+9. Viewport 600×800: mobile carousel path unaffected
+
+## Edge cases
+
+- **Cycling hero could still make sense on a future "compact mode"**. Not this spec — design allows swapping `heroTracker` source later without component changes.
+- **Active tracker === hero tracker**: hero shows the tracker, feed row for it is replaced by the expanded row. No duplication.
+- **Active tracker exists but different from hero**: hero stays put, feed scrolls so the expanded row is visible (existing `TrackerRow` auto-scroll still applies).
+- **Search hides tabs → active tab state preserved**. Clearing search restores the previous `viewMode`.
+- **Follow a tracker that is currently the hero**: no immediate visual change (it was already top); followed-section divider simply appears below it when there's more than one followed tracker.
+- **Locale switch**: all text is via existing `t()` function; headlines fall back to `tracker.headline` when the locale-specific one isn't available (existing behavior).
+
+## File touch list
+
+Modified:
+- `src/components/islands/CommandCenter/SidebarPanel.tsx` — remove current group headers + row decoration, introduce `<HeroCard>` + `<FeedRow>` components, wire hero selection memo, rework view-mode rendering branches. This file is large (~1660 lines); as part of the work, pull `HeroCard` into its own file.
+- `src/styles/global.css` — new classes for hero card, minimal feed row, inline underline tabs (`.cc-feed-tabs`, `.cc-feed-row`, `.cc-hero-card`). Update the PR #106 `.cc-tracker-live` pulse rule to also target `.cc-feed-row.cc-tracker-live` (the new row class). Remove the obsolete `.cc-tracker-row` base rule once no row uses it.
+
+Created:
+- `src/components/islands/CommandCenter/HeroCard.tsx` — new
+- `src/components/islands/CommandCenter/FeedRow.tsx` — new
+- `src/lib/hero-selection.ts` — `selectHeroTracker` pure function (for easy unit testing)
+- `src/lib/hero-selection.test.ts` — Vitest tests against the pure function
+
+Deleted:
+- None — the expanded-row markup, `GeoAccordion`, `SeriesStrip`, and `ViewModeToggle` all stay, just restyled via CSS.
+
+## Risks
+
+- **Hero selection churn**: if the relevance algorithm produces unstable ordering under minor data changes, the hero will flicker between two trackers every time `lastUpdated` ticks. Mitigation: the selection is memoized on `trackers` identity; since `trackers` is built at build-time in Astro and only mutates on a page reload, flicker is impossible within a session.
+- **Row redesign regresses `TrackerRow` memoization**: the current `TrackerRow` is `memo`'d and critical for broadcast-tick re-render cost. The new `FeedRow` must also be `memo`'d with the same prop shape to preserve the `broadcastRef` stabilization from #106. Verified in the component spec above (all primitive props, no closure captures).
+- **Typography scale**: the new hero uses Inter 0.82 rem for the headline, which is larger than any current SidebarPanel text. On a 440 px panel this is right; on the 320 px mid-width panel, the clamp-to-3-lines may run short. Accept; easy to tune later.
+- **GeoAccordion + hero stacking**: GEO view has always started scrolling from the top; adding a hero above it means the accordion's first expanded group has to scroll below the hero. Acceptable — user scrolls naturally; GeoAccordion's own auto-scroll behavior still works.
+
+## Implementation order
+
+1. Add `src/lib/hero-selection.ts` + test, confirm pure function behavior
+2. Create `HeroCard.tsx` (styled, story-shot visual approval before wiring)
+3. Create `FeedRow.tsx` matching the spec
+4. Add CSS classes to `global.css`
+5. Rewrite `SidebarPanel.tsx` rendering — OPS view first, verify manually
+6. Port GEO and DOMAIN views, verify grouping still works
+7. Wire search hide-hero-and-tabs branch
+8. Manual verification via Playwright matrix (Sections 8.1–8.9)
+9. Lighthouse before/after on `/` — expect no regression (1 heavier hero img + many fewer DOM nodes in the feed)

--- a/src/components/islands/CommandCenter/FeedRow.tsx
+++ b/src/components/islands/CommandCenter/FeedRow.tsx
@@ -61,7 +61,7 @@ export default memo(function FeedRow({
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {
-        if (e.key === 'Enter') {
+        if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           onSelect(tracker.slug);
         }

--- a/src/components/islands/CommandCenter/FeedRow.tsx
+++ b/src/components/islands/CommandCenter/FeedRow.tsx
@@ -1,0 +1,105 @@
+import { memo, useRef, useEffect } from 'react';
+import type { TrackerCardData } from '../../../lib/tracker-directory-utils';
+import { relativeTime } from '../../../lib/event-utils';
+import { t, type Locale } from '../../../i18n/translations';
+
+interface Props {
+  tracker: TrackerCardData;
+  isHovered: boolean;
+  isFollowed: boolean;
+  isCompared: boolean;
+  isLive: boolean;
+  isDimmed: boolean;
+  basePath: string;
+  locale: Locale;
+  onSelect: (slug: string | null) => void;
+  onHover: (slug: string | null) => void;
+  onToggleFollow: (slug: string) => void;
+  onToggleCompare: (slug: string) => void;
+}
+
+export default memo(function FeedRow({
+  tracker,
+  isHovered,
+  isFollowed,
+  isCompared,
+  isLive,
+  isDimmed,
+  basePath: _basePath,
+  locale,
+  onSelect,
+  onHover,
+  onToggleFollow,
+  onToggleCompare,
+}: Props) {
+  const rowRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll into view when hovered (mirrors old TrackerRow behavior)
+  useEffect(() => {
+    if (isHovered && rowRef.current) {
+      rowRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }, [isHovered]);
+
+  const headline = (locale === 'es' && tracker.headlineEs) ? tracker.headlineEs : tracker.headline;
+
+  return (
+    <div
+      ref={rowRef}
+      className={`cc-feed-row${isLive ? ' cc-tracker-live' : ''}${isDimmed ? ' cc-feed-row-dim' : ''}`}
+      data-tracker-slug={tracker.slug}
+      onClick={(e) => {
+        if (e.shiftKey) {
+          onToggleCompare(tracker.slug);
+        } else {
+          onSelect(tracker.slug);
+        }
+      }}
+      onMouseEnter={() => onHover(tracker.slug)}
+      onMouseLeave={() => onHover(null)}
+      title={tracker.shortName}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          onSelect(tracker.slug);
+        }
+      }}
+    >
+      <span className="cc-feed-icon">{tracker.icon ?? ''}</span>
+      <div className="cc-feed-body">
+        <div className="cc-feed-top">
+          <span className="cc-feed-name">{tracker.shortName}</span>
+          {isLive && <span className="cc-feed-live-dot" role="status" aria-label="Live" />}
+        </div>
+        {headline && <div className="cc-feed-headline">{headline}</div>}
+      </div>
+      <div className="cc-feed-right">
+        <span className="cc-feed-time" suppressHydrationWarning>
+          {relativeTime(tracker.lastUpdated)}
+        </span>
+        <div className="cc-feed-actions">
+          <button
+            type="button"
+            className={`cc-feed-action cc-feed-follow${isFollowed ? ' is-on' : ''}`}
+            onClick={(e) => { e.stopPropagation(); onToggleFollow(tracker.slug); }}
+            title={isFollowed ? t('sidebar.unfollow', locale) : t('sidebar.follow', locale)}
+            aria-label={isFollowed ? t('sidebar.unfollow', locale) : t('sidebar.follow', locale)}
+          >
+            {isFollowed ? '★' : '☆'}
+          </button>
+          <button
+            type="button"
+            className={`cc-feed-action cc-feed-compare${isCompared ? ' is-on' : ''}`}
+            onClick={(e) => { e.stopPropagation(); onToggleCompare(tracker.slug); }}
+            title={isCompared ? t('sidebar.removeFromComparison', locale) : t('sidebar.addToComparison', locale)}
+            aria-label={isCompared ? t('sidebar.removeFromComparison', locale) : t('sidebar.addToComparison', locale)}
+          >
+            {isCompared ? '◆' : '◇'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/src/components/islands/CommandCenter/HeroCard.tsx
+++ b/src/components/islands/CommandCenter/HeroCard.tsx
@@ -1,0 +1,95 @@
+import { memo } from 'react';
+import type { TrackerCardData } from '../../../lib/tracker-directory-utils';
+import { relativeTime } from '../../../lib/event-utils';
+import { t, type Locale } from '../../../i18n/translations';
+
+const DOMAIN_GRADIENTS: Record<string, string> = {
+  military: 'linear-gradient(135deg, #1a0a0a, #2c1010, #0d1117)',
+  conflict: 'linear-gradient(135deg, #1a0a0a, #2c1010, #0d1117)',
+  politics: 'linear-gradient(135deg, #0a0a1a, #101030, #0d1117)',
+  sports: 'linear-gradient(135deg, #0a1a0a, #102010, #0d1117)',
+  crisis: 'linear-gradient(135deg, #1a0f00, #2c1a05, #0d1117)',
+  culture: 'linear-gradient(135deg, #1a0a1a, #2c102c, #0d1117)',
+  default: 'linear-gradient(135deg, #12141a, #181b23, #0d1117)',
+};
+
+interface Props {
+  tracker: TrackerCardData;
+  isBroadcastFeatured: boolean;
+  basePath: string;
+  locale: Locale;
+  onSelect: (slug: string) => void;
+}
+
+export default memo(function HeroCard({
+  tracker,
+  isBroadcastFeatured,
+  basePath: _basePath,
+  locale,
+  onSelect,
+}: Props) {
+  const thumbUrl = tracker.latestEventMedia?.url ?? tracker.eventImages?.[0]?.url ?? null;
+  const gradient = DOMAIN_GRADIENTS[tracker.domain ?? 'default'] ?? DOMAIN_GRADIENTS.default;
+  const headline = (locale === 'es' && tracker.headlineEs) ? tracker.headlineEs : tracker.headline;
+  const source = tracker.latestEventMedia?.source;
+  const tier = tracker.latestEventMedia?.tier;
+
+  const handleClick = () => onSelect(tracker.slug);
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onSelect(tracker.slug);
+    }
+  };
+
+  return (
+    <div
+      className={`cc-hero-card${isBroadcastFeatured ? ' cc-hero-card-live' : ''}`}
+      role="button"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      aria-label={`Open ${tracker.shortName} dashboard`}
+    >
+      <div
+        className="cc-hero-thumb"
+        style={thumbUrl ? undefined : { background: gradient }}
+      >
+        {thumbUrl ? (
+          <img
+            src={thumbUrl}
+            alt=""
+            loading="lazy"
+            referrerPolicy="no-referrer"
+            onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+          />
+        ) : (
+          <span className="cc-hero-thumb-icon">{tracker.icon ?? '?'}</span>
+        )}
+      </div>
+      <div className="cc-hero-body">
+        <div className="cc-hero-context">
+          {tracker.dayCount > 0 && `${t('hero.day', locale)} ${tracker.dayCount} · `}
+          {(tracker.domain ?? '').toUpperCase()}
+        </div>
+        <div className="cc-hero-name-row">
+          <span className="cc-hero-name">{tracker.shortName}</span>
+          {isBroadcastFeatured && (
+            <span className="cc-hero-live" role="status" aria-label="Currently featured by broadcast">
+              <span className="cc-hero-live-dot" />LIVE
+            </span>
+          )}
+        </div>
+        {headline && <div className="cc-hero-headline">{headline}</div>}
+        <div className="cc-hero-meta">
+          {source && tier != null && (
+            <span className="cc-hero-source">T{tier} · {source}</span>
+          )}
+          <span className="cc-hero-time" suppressHydrationWarning>
+            {relativeTime(tracker.lastUpdated).toUpperCase()}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/src/components/islands/CommandCenter/SidebarPanel.tsx
+++ b/src/components/islands/CommandCenter/SidebarPanel.tsx
@@ -481,11 +481,27 @@ export default function SidebarPanel({
     [trackers, followedSlugs],
   );
 
-  // Flat list of all visible tracker slugs for keyboard nav
-  const flatSlugs = useMemo(
-    () => groups.flatMap(g => g.trackers.map(t => t.slug)),
-    [groups],
-  );
+  // Match FeedList's visible order so arrow-key nav lands on adjacent rows:
+  // followed → recent (≤48h) → older (>48h). In geographic view, arrow nav is
+  // already disabled by handleKeyDown's early return.
+  const flatSlugs = useMemo(() => {
+    const followed = new Set(followedSlugs);
+    const OLDER_MS = 48 * 3600 * 1000;
+    const now = Date.now();
+    const followedArr: string[] = [];
+    const recent: string[] = [];
+    const older: string[] = [];
+    for (const t of sortedFiltered) {
+      if (followed.has(t.slug)) {
+        followedArr.push(t.slug);
+      } else if (now - new Date(t.lastUpdated).getTime() > OLDER_MS) {
+        older.push(t.slug);
+      } else {
+        recent.push(t.slug);
+      }
+    }
+    return [...followedArr, ...recent, ...older];
+  }, [sortedFiltered, followedSlugs]);
 
   // Auto-scroll the broadcast-featured tracker row into view when it changes
   useEffect(() => {
@@ -813,88 +829,10 @@ const S = {
     scrollbarColor: 'var(--border) transparent',
   } as CSSProperties,
 
-  groupHeader: (type: string): CSSProperties => ({
-    display: 'flex',
-    alignItems: 'center',
-    gap: '6px',
-    padding: '8px 12px 4px',
-    fontFamily: "'JetBrains Mono', monospace",
-    fontSize: '0.52rem',
-    fontWeight: 600,
-    letterSpacing: '0.12em',
-    color: type === 'live' ? 'var(--accent-green)' : type === 'historical' ? 'var(--accent-amber)' : 'var(--text-muted)',
-    marginTop: type === 'live' ? 0 : 8,
-  }),
-
-  groupIcon: (type: string): CSSProperties => ({
-    fontSize: '0.6rem',
-    color: type === 'live' ? 'var(--accent-green)' : type === 'historical' ? 'var(--accent-amber)' : 'var(--text-muted)',
-  }),
-
-  // Collapsed row
-  collapsedRow: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    padding: '8px 12px',
-    borderLeft: '2px solid transparent',
-    cursor: 'pointer',
-    transition: 'background 0.15s, transform 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
-    userSelect: 'none' as const,
-    minHeight: 44, // ensure minimum touch target
-  } as CSSProperties,
-
-  collapsedLeft: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '6px',
-    minWidth: 0,
-  } as CSSProperties,
-
   icon: {
     fontSize: '0.9rem',
     lineHeight: 1,
     flexShrink: 0,
-  } as CSSProperties,
-
-  collapsedName: {
-    fontFamily: "'DM Sans', sans-serif",
-    fontSize: '0.78rem',
-    color: 'var(--text-primary)',
-    whiteSpace: 'nowrap' as const,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  } as CSSProperties,
-
-  collapsedThumb: {
-    width: 24,
-    height: 24,
-    borderRadius: 4,
-    objectFit: 'cover' as const,
-    flexShrink: 0,
-    border: '1px solid var(--border)',
-    opacity: 0.85,
-  } as CSSProperties,
-
-  collapsedRight: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '6px',
-    flexShrink: 0,
-  } as CSSProperties,
-
-  collapsedStatus: {
-    fontFamily: "'JetBrains Mono', monospace",
-    fontSize: '0.48rem',
-    fontWeight: 600,
-    letterSpacing: '0.06em',
-  } as CSSProperties,
-
-  collapsedDay: {
-    fontFamily: "'JetBrains Mono', monospace",
-    fontSize: '0.52rem',
-    color: 'var(--text-muted)',
-    opacity: 0.7,
   } as CSSProperties,
 
   freshDot: {
@@ -905,13 +843,6 @@ const S = {
     flexShrink: 0,
     boxShadow: '0 0 4px rgba(46,204,113,0.5)',
     animation: 'pulse 2s ease-in-out infinite',
-  } as CSSProperties,
-
-  freshnessDot: {
-    width: 6,
-    height: 6,
-    borderRadius: '50%',
-    flexShrink: 0,
   } as CSSProperties,
 
   // Expanded row
@@ -1058,23 +989,6 @@ const S = {
     userSelect: 'none' as const,
   } as CSSProperties,
 
-  followStar: {
-    color: '#f39c12',
-    fontSize: '0.55rem',
-    flexShrink: 0,
-  } as CSSProperties,
-
-  collapsedFollowBtn: {
-    fontSize: '0.7rem',
-    cursor: 'pointer',
-    flexShrink: 0,
-    opacity: 0,
-    transition: 'opacity 0.2s, color 0.2s',
-    userSelect: 'none' as const,
-    padding: '0 2px',
-    lineHeight: 1,
-  } as CSSProperties,
-
   compareBtn: {
     fontFamily: "'JetBrains Mono', monospace",
     fontSize: '0.52rem',
@@ -1083,14 +997,6 @@ const S = {
     transition: 'color 0.2s',
     letterSpacing: '0.04em',
     userSelect: 'none' as const,
-  } as CSSProperties,
-
-  compareDot: {
-    width: 5,
-    height: 5,
-    background: 'var(--accent-blue, #58a6ff)',
-    borderRadius: 2,
-    flexShrink: 0,
   } as CSSProperties,
 
   compareBadge: {
@@ -1222,123 +1128,6 @@ const S = {
     color: 'var(--accent-blue)',
     border: '1px solid rgba(52,152,219,0.3)',
     flexShrink: 0,
-  } as CSSProperties,
-
-  // Recent events feed
-  feedWrap: {
-    padding: '6px 12px 8px',
-    borderBottom: '1px solid var(--border)',
-    marginBottom: 4,
-  } as CSSProperties,
-
-  feedHeader: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '6px',
-    fontFamily: "'JetBrains Mono', monospace",
-    fontSize: '0.48rem',
-    fontWeight: 600,
-    letterSpacing: '0.12em',
-    color: 'var(--accent-green)',
-    marginBottom: 6,
-  } as CSSProperties,
-
-  feedDot: {
-    width: 5,
-    height: 5,
-    background: 'var(--accent-green)',
-    borderRadius: '50%',
-    boxShadow: '0 0 4px rgba(46,204,113,0.5)',
-    animation: 'pulse 2s ease-in-out infinite',
-  } as CSSProperties,
-
-  feedItem: {
-    padding: '4px 6px',
-    marginBottom: 3,
-    borderRadius: 4,
-    cursor: 'pointer',
-    transition: 'background 0.15s',
-    background: 'rgba(255,255,255,0.02)',
-  } as CSSProperties,
-
-  feedItemHeader: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '4px',
-  } as CSSProperties,
-
-  feedItemName: {
-    fontFamily: "'DM Sans', sans-serif",
-    fontSize: '0.65rem',
-    fontWeight: 600,
-    color: 'var(--text-primary)',
-  } as CSSProperties,
-
-  feedItemAge: {
-    fontFamily: "'JetBrains Mono', monospace",
-    fontSize: '0.42rem',
-    marginLeft: 'auto',
-  } as CSSProperties,
-
-  feedItemText: {
-    fontFamily: "'DM Sans', sans-serif",
-    fontSize: '0.6rem',
-    color: 'var(--text-muted)',
-    lineHeight: 1.4,
-    marginTop: 2,
-    paddingLeft: 18,
-  } as CSSProperties,
-
-  feedExpandedContent: {
-    paddingLeft: 18,
-    paddingTop: 6,
-    paddingBottom: 4,
-  } as CSSProperties,
-
-  feedDigestSummary: {
-    fontFamily: "'DM Sans', sans-serif",
-    fontSize: '0.6rem',
-    color: 'var(--text-secondary)',
-    lineHeight: 1.5,
-    marginBottom: 6,
-  } as CSSProperties,
-
-  feedBadgeRow: {
-    display: 'flex',
-    flexWrap: 'wrap' as const,
-    gap: '3px',
-    marginBottom: 6,
-  } as CSSProperties,
-
-  feedSectionBadge: {
-    fontFamily: "'JetBrains Mono', monospace",
-    fontSize: '0.45rem',
-    fontWeight: 600,
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.04em',
-    padding: '1px 5px',
-    borderRadius: 3,
-    whiteSpace: 'nowrap' as const,
-  } as CSSProperties,
-
-  feedOpenLink: {
-    fontFamily: "'JetBrains Mono', monospace",
-    fontSize: '0.5rem',
-    color: 'var(--accent-blue)',
-    textDecoration: 'none',
-    fontWeight: 600,
-    letterSpacing: '0.04em',
-    display: 'inline-block',
-    marginTop: 2,
-  } as CSSProperties,
-
-  noResults: {
-    textAlign: 'center' as const,
-    padding: '2rem 1rem',
-    fontFamily: "'JetBrains Mono', monospace",
-    fontSize: '0.65rem',
-    color: 'var(--text-muted)',
-    opacity: 0.6,
   } as CSSProperties,
 
   footer: {

--- a/src/components/islands/CommandCenter/SidebarPanel.tsx
+++ b/src/components/islands/CommandCenter/SidebarPanel.tsx
@@ -322,7 +322,8 @@ const FeedList = memo(function FeedList({
   isSearching,
 }: FeedListProps) {
   const now = Date.now();
-  const followed = new Set(followedSlugs);
+  const followed = useMemo(() => new Set(followedSlugs), [followedSlugs]);
+  const compared = useMemo(() => new Set(compareSlugs), [compareSlugs]);
 
   const renderOne = (tracker: TrackerCardData, isDimmed: boolean) => {
     const isActive = activeTracker === tracker.slug;
@@ -335,7 +336,7 @@ const FeedList = memo(function FeedList({
           isActive
           isHovered={hoveredTracker === tracker.slug}
           isFollowed={followed.has(tracker.slug)}
-          isCompared={compareSlugs.includes(tracker.slug)}
+          isCompared={compared.has(tracker.slug)}
           isLive={featuredSlug === tracker.slug}
           onSelect={onSelectTracker}
           onHover={onHoverTracker}
@@ -351,7 +352,7 @@ const FeedList = memo(function FeedList({
         tracker={tracker}
         isHovered={hoveredTracker === tracker.slug}
         isFollowed={followed.has(tracker.slug)}
-        isCompared={compareSlugs.includes(tracker.slug)}
+        isCompared={compared.has(tracker.slug)}
         isLive={featuredSlug === tracker.slug}
         isDimmed={isDimmed && !isSearching}
         basePath={basePath}
@@ -502,6 +503,12 @@ export default function SidebarPanel({
       onSelectTracker(null);
       return;
     }
+    // Skip arrow-key nav in geographic mode — the geo tree's visible order
+    // differs from flatSlugs (OPS/DOMAIN grouping), so indexing would jump
+    // unpredictably. Leave nav to mouse/click in geo view.
+    if (viewMode === 'geographic' && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+      return;
+    }
     if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
       e.preventDefault();
       const currentIdx = activeTracker ? flatSlugs.indexOf(activeTracker) : -1;
@@ -516,7 +523,7 @@ export default function SidebarPanel({
     if (e.key === 'Enter' && activeTracker) {
       window.location.href = `${basePath}${activeTracker}/`;
     }
-  }, [activeTracker, flatSlugs, onSelectTracker, basePath]);
+  }, [activeTracker, flatSlugs, onSelectTracker, basePath, viewMode]);
 
   const isSearching = searchQuery.trim().length > 0;
 

--- a/src/components/islands/CommandCenter/SidebarPanel.tsx
+++ b/src/components/islands/CommandCenter/SidebarPanel.tsx
@@ -2,18 +2,19 @@ import { useState, useMemo, useCallback, useRef, useEffect, memo } from 'react';
 import type { CSSProperties } from 'react';
 import {
   type TrackerCardData,
-  DOMAIN_COLORS,
   filterTrackers,
   groupTrackers,
   computeFreshness,
   buildDateline,
-  computeDomainCounts,
-  getVisibleDomains,
 } from '../../../lib/tracker-directory-utils';
 import { t, SUPPORTED_LOCALES, type Locale } from '../../../i18n/translations';
 import ViewModeToggle from './ViewModeToggle';
 import type { ViewMode } from './ViewModeToggle';
 import GeoAccordion from './GeoAccordion';
+import FeedRow from './FeedRow';
+import HeroCard from './HeroCard';
+import { selectHeroTracker } from '../../../lib/hero-selection';
+import { sortByRelevance } from '../../../lib/relevance';
 
 interface Props {
   trackers: TrackerCardData[];
@@ -191,87 +192,22 @@ const TrackerRow = memo(function TrackerRow({
     );
   }
 
-  // Collapsed row
-  const freshDotInfo = getFreshnessDot(tracker.lastUpdated, locale);
-  const tooltipText = rawHeadline
-    ? `${tracker.shortName} — ${rawHeadline}`
-    : tracker.shortName;
-
+  // Collapsed: delegate to FeedRow
   return (
-    <div
-      ref={rowRef}
-      className={`cc-tracker-row${isLive && !isActive ? ' cc-tracker-live' : ''}`}
-      data-tracker-slug={tracker.slug}
-      style={{
-        ...S.collapsedRow,
-        borderLeftColor: color,
-        background: isHovered ? `${color}15` : 'transparent',
-        transform: isHovered ? 'translateX(2px)' : 'translateX(0)',
-      }}
-      onClick={e => {
-        if (e.shiftKey) {
-          onToggleCompare(tracker.slug);
-        } else {
-          onSelect(tracker.slug);
-        }
-      }}
-      onMouseEnter={() => onHover(tracker.slug)}
-      onMouseLeave={() => onHover(null)}
-      onDoubleClick={() => { window.location.href = href; }}
-      title={tooltipText}
-    >
-      <div style={S.collapsedLeft}>
-        <span
-          style={{
-            ...S.freshnessDot,
-            background: freshDotInfo.color,
-            boxShadow: freshDotInfo.shadow,
-          }}
-          title={freshDotInfo.label}
-          aria-label={freshDotInfo.label}
-          role="img"
-        >
-          <span className="sr-only">{freshDotInfo.label}</span>
-        </span>
-        <span style={S.icon}>{tracker.icon || ''}</span>
-        <span className="cc-tracker-name" style={S.collapsedName}>{tracker.shortName}</span>
-        {isLive && !isActive && (
-          <span className="cc-tracker-live-badge" role="status" aria-label="Currently featured by broadcast">
-            LIVE
-          </span>
-        )}
-        {isCompared && <span style={S.compareDot} />}
-        {tracker.latestEventMedia && (
-          <img
-            src={tracker.latestEventMedia.url}
-            alt={`${tracker.shortName} event thumbnail`}
-            style={S.collapsedThumb}
-            loading="lazy"
-            referrerPolicy="no-referrer"
-            onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
-          />
-        )}
-      </div>
-      <div style={S.collapsedRight}>
-        <span
-          className="cc-follow-toggle"
-          style={{
-            ...S.collapsedFollowBtn,
-            color: isFollowed ? '#f39c12' : 'var(--text-muted)',
-            opacity: isFollowed ? 1 : undefined,
-          }}
-          onClick={e => { e.stopPropagation(); onToggleFollow(tracker.slug); }}
-          title={isFollowed ? t('sidebar.unfollow', locale) : t('sidebar.follow', locale)}
-        >
-          {isFollowed ? '★' : '☆'}
-        </span>
-        {freshness.className === 'fresh' && <span style={S.freshDot} />}
-        <span className="cc-tracker-status" suppressHydrationWarning style={{ ...S.collapsedStatus, color: freshness.className === 'fresh' ? 'var(--accent-green)' : freshness.className === 'recent' ? 'var(--accent-amber)' : 'var(--text-muted)' }}>
-          {t(freshness.className === 'fresh' ? 'status.fresh' : freshness.className === 'recent' ? 'status.recent' : 'status.stale' as any, locale)}
-        </span>
-        <span style={S.collapsedDay} suppressHydrationWarning>{dateline}</span>
-      </div>
-    </div>
+    <FeedRow
+      tracker={tracker}
+      isHovered={isHovered}
+      isFollowed={isFollowed}
+      isCompared={isCompared}
+      isLive={isLive}
+      isDimmed={false}
+      basePath={basePath}
+      locale={locale}
+      onSelect={onSelect}
+      onHover={onHover}
+      onToggleFollow={onToggleFollow}
+      onToggleCompare={onToggleCompare}
+    />
   );
 });
 
@@ -348,240 +284,153 @@ const SeriesStrip = memo(function SeriesStrip({
   );
 });
 
-// ── Section badge color mapping ──
+// ── FeedList ──
 
-const SECTION_BADGE_COLORS: Record<string, { bg: string; fg: string }> = {
-  events: { bg: 'rgba(88,166,255,0.12)', fg: '#58a6ff' },
-  timeline: { bg: 'rgba(88,166,255,0.12)', fg: '#58a6ff' },
-  mapLines: { bg: 'rgba(46,204,113,0.12)', fg: '#2ecc71' },
-  mapPoints: { bg: 'rgba(46,204,113,0.12)', fg: '#2ecc71' },
-  'map-lines': { bg: 'rgba(46,204,113,0.12)', fg: '#2ecc71' },
-  'map-points': { bg: 'rgba(46,204,113,0.12)', fg: '#2ecc71' },
-  kpis: { bg: 'rgba(243,156,18,0.12)', fg: '#f39c12' },
-  casualties: { bg: 'rgba(231,76,60,0.12)', fg: '#e74c3c' },
-  econ: { bg: 'rgba(168,108,193,0.12)', fg: '#a86cc1' },
-};
+const OLDER_THRESHOLD_MS = 48 * 3600 * 1000;
 
-const DEFAULT_BADGE_COLOR = { bg: 'rgba(148,152,168,0.12)', fg: '#9498a8' };
-
-function sectionBadgeLabel(section: string, locale: Locale = 'en'): string {
-  const labelMap: Record<string, string> = {
-    events: t('sidebar.sectionEvents', locale),
-    timeline: t('sidebar.sectionTimeline', locale),
-    mapLines: t('sidebar.sectionMap', locale),
-    mapPoints: t('sidebar.sectionMap', locale),
-    'map-lines': t('sidebar.sectionMap', locale),
-    'map-points': t('sidebar.sectionMap', locale),
-    kpis: t('sidebar.sectionKpis', locale),
-    casualties: t('sidebar.sectionCasualties', locale),
-    econ: t('sidebar.sectionEcon', locale),
-    political: t('sidebar.sectionPolitical', locale),
-    claims: t('sidebar.sectionClaims', locale),
-    assets: t('sidebar.sectionAssets', locale),
-    meta: t('sidebar.sectionMeta', locale),
-    'strike-targets': t('sidebar.sectionStrikes', locale),
-    military: t('sidebar.sectionMilitary', locale),
-  };
-  return labelMap[section] ?? section.toUpperCase();
-}
-
-function deduplicateBadges(sections: string[]): string[] {
-  const seen = new Set<string>();
-  const result: string[] = [];
-  for (const s of sections) {
-    const label = sectionBadgeLabel(s);
-    if (!seen.has(label)) {
-      seen.add(label);
-      result.push(s);
-    }
-  }
-  return result;
-}
-
-// ── Recent Events Feed ──
-
-const RecentEventsFeed = memo(function RecentEventsFeed({
-  trackers,
-  basePath,
-  followedSlugs,
-  onSelect,
-  locale = 'en',
-}: {
+interface FeedListProps {
   trackers: TrackerCardData[];
-  basePath: string;
   followedSlugs: string[];
-  onSelect: (slug: string | null) => void;
-  locale?: Locale;
-}) {
-  const [expandedSlug, setExpandedSlug] = useState<string | null>(null);
+  activeTracker: string | null;
+  hoveredTracker: string | null;
+  compareSlugs: string[];
+  featuredSlug: string | null;
+  basePath: string;
+  locale: Locale;
+  viewMode: ViewMode;
+  onSelectTracker: (slug: string | null) => void;
+  onHoverTracker: (slug: string | null) => void;
+  onToggleFollow: (slug: string) => void;
+  onToggleCompare: (slug: string) => void;
+  isSearching: boolean;
+}
 
-  const withHeadlines = useMemo(
-    () => trackers.filter(t => t.headline && t.status === 'active'),
-    [trackers],
-  );
+const FeedList = memo(function FeedList({
+  trackers,
+  followedSlugs,
+  activeTracker,
+  hoveredTracker,
+  compareSlugs,
+  featuredSlug,
+  basePath,
+  locale,
+  viewMode,
+  onSelectTracker,
+  onHoverTracker,
+  onToggleFollow,
+  onToggleCompare,
+  isSearching,
+}: FeedListProps) {
+  const now = Date.now();
+  const followed = new Set(followedSlugs);
 
-  const followedTrackers = useMemo(
-    () => withHeadlines
-      .filter(t => followedSlugs.includes(t.slug))
-      .sort((a, b) => new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime()),
-    [withHeadlines, followedSlugs],
-  );
-
-  const recentTrackers = useMemo(
-    () => withHeadlines
-      .filter(t => !followedSlugs.includes(t.slug))
-      .sort((a, b) => new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime()),
-    [withHeadlines, followedSlugs],
-  );
-
-  const toggleExpand = useCallback((slug: string) => {
-    setExpandedSlug(prev => prev === slug ? null : slug);
-  }, []);
-
-  if (followedTrackers.length === 0 && recentTrackers.length === 0) return null;
-
-  const localePrefix = locale !== 'en' ? `${locale}/` : '';
-
-  const renderItem = (tracker: TrackerCardData, isFollowed: boolean) => {
-    const isExpanded = expandedSlug === tracker.slug;
-    const rawHeadline = locale === 'es' && tracker.headlineEs ? tracker.headlineEs : tracker.headline;
-    const truncatedHeadline = rawHeadline && rawHeadline.length > 80
-      ? rawHeadline.slice(0, 80) + '\u2026'
-      : rawHeadline;
-    const href = `${basePath}${localePrefix}${tracker.slug}/`;
-    const badges = deduplicateBadges(tracker.digestSectionsUpdated ?? []);
-
+  const renderOne = (tracker: TrackerCardData, isDimmed: boolean) => {
+    const isActive = activeTracker === tracker.slug;
+    if (isActive) {
+      return (
+        <TrackerRow
+          key={tracker.slug}
+          tracker={tracker}
+          basePath={basePath}
+          isActive
+          isHovered={hoveredTracker === tracker.slug}
+          isFollowed={followed.has(tracker.slug)}
+          isCompared={compareSlugs.includes(tracker.slug)}
+          isLive={featuredSlug === tracker.slug}
+          onSelect={onSelectTracker}
+          onHover={onHoverTracker}
+          onToggleFollow={onToggleFollow}
+          onToggleCompare={onToggleCompare}
+          locale={locale}
+        />
+      );
+    }
     return (
-      <div
+      <FeedRow
         key={tracker.slug}
-        className="cc-feed-item"
-        style={{
-          ...S.feedItem,
-          borderBottom: '1px solid var(--border)',
-        }}
-      >
-        <div
-          style={{ cursor: 'pointer' }}
-          onClick={() => toggleExpand(tracker.slug)}
-        >
-          <div style={S.feedItemHeader}>
-            <span style={{ fontSize: '0.7rem' }}>{tracker.icon || ''}</span>
-            <span style={S.feedItemName}>{tracker.shortName}</span>
-            {isFollowed && <span style={S.followStar}>★</span>}
-            <span style={{ ...S.feedItemAge, color: tracker.color || '#3498db' }}>
-              <span suppressHydrationWarning>{computeFreshness(tracker.lastUpdated).ageText}</span>
-            </span>
-          </div>
-          <div style={S.feedItemText}>{truncatedHeadline}</div>
-        </div>
-
-        {/* Expandable digest detail */}
-        <div
-          style={{
-            maxHeight: isExpanded ? 300 : 0,
-            opacity: isExpanded ? 1 : 0,
-            overflow: 'hidden',
-            transition: 'max-height 0.3s ease, opacity 0.2s ease',
-          }}
-        >
-          <div style={S.feedExpandedContent}>
-            {tracker.digestSummary && (
-              <div style={S.feedDigestSummary}>
-                {tracker.digestSummary}
-              </div>
-            )}
-            {badges.length > 0 && (
-              <div style={S.feedBadgeRow}>
-                {badges.map(section => {
-                  const colors = SECTION_BADGE_COLORS[section] ?? DEFAULT_BADGE_COLOR;
-                  return (
-                    <span
-                      key={section}
-                      style={{
-                        ...S.feedSectionBadge,
-                        background: colors.bg,
-                        color: colors.fg,
-                      }}
-                    >
-                      {sectionBadgeLabel(section)}
-                    </span>
-                  );
-                })}
-              </div>
-            )}
-            <a
-              href={href}
-              style={S.feedOpenLink}
-              onClick={e => e.stopPropagation()}
-            >
-              {t('sidebar.openDashboard', locale)}
-            </a>
-          </div>
-        </div>
-      </div>
+        tracker={tracker}
+        isHovered={hoveredTracker === tracker.slug}
+        isFollowed={followed.has(tracker.slug)}
+        isCompared={compareSlugs.includes(tracker.slug)}
+        isLive={featuredSlug === tracker.slug}
+        isDimmed={isDimmed && !isSearching}
+        basePath={basePath}
+        locale={locale}
+        onSelect={onSelectTracker}
+        onHover={onHoverTracker}
+        onToggleFollow={onToggleFollow}
+        onToggleCompare={onToggleCompare}
+      />
     );
   };
 
+  if (trackers.length === 0) {
+    return (
+      <div style={{
+        padding: '24px 12px',
+        textAlign: 'center',
+        fontFamily: "'JetBrains Mono', monospace",
+        fontSize: '0.62rem',
+        color: 'var(--text-muted)',
+      }}>
+        No trackers match.
+      </div>
+    );
+  }
+
+  // DOMAIN view: group by tracker.domain, no dim-older split.
+  if (viewMode === 'domain') {
+    const byDomain = new Map<string, TrackerCardData[]>();
+    for (const tr of trackers) {
+      const key = tr.domain ?? 'other';
+      const arr = byDomain.get(key) ?? [];
+      arr.push(tr);
+      byDomain.set(key, arr);
+    }
+    return (
+      <>
+        {Array.from(byDomain.entries()).map(([domain, list]) => (
+          <div key={domain}>
+            <div className="cc-feed-group-divider" aria-label={domain.toUpperCase()}>
+              {domain.toUpperCase()}
+            </div>
+            {list.map(tr => renderOne(tr, false))}
+          </div>
+        ))}
+      </>
+    );
+  }
+
+  // OPS view: followed first, then recent, then older (dimmed), separated by
+  // 1px dividers (no text labels).
+  const followedTrackers: TrackerCardData[] = [];
+  const recent: TrackerCardData[] = [];
+  const older: TrackerCardData[] = [];
+
+  for (const tr of trackers) {
+    if (followed.has(tr.slug)) {
+      followedTrackers.push(tr);
+      continue;
+    }
+    const age = now - new Date(tr.lastUpdated).getTime();
+    if (age > OLDER_THRESHOLD_MS) older.push(tr);
+    else recent.push(tr);
+  }
+
   return (
-    <div style={S.feedWrap}>
+    <>
       {followedTrackers.length > 0 && (
         <>
-          <div style={S.feedHeader}>
-            <span style={{ color: '#f39c12', fontSize: '0.6rem' }}>{'\u2605'}</span>
-            <span>{t('status.following', locale)}</span>
-          </div>
-          {followedTrackers.map(tracker => renderItem(tracker, true))}
+          {followedTrackers.map(tr => renderOne(tr, false))}
+          {(recent.length > 0 || older.length > 0) && <div className="cc-feed-divider" />}
         </>
       )}
-      {recentTrackers.length > 0 && (
-        <>
-          <div style={{ ...S.feedHeader, marginTop: followedTrackers.length > 0 ? 6 : 0 }}>
-            <span style={S.feedDot} />
-            <span>{t('cc.latestIntel', locale)}</span>
-          </div>
-          {recentTrackers.map(tracker => renderItem(tracker, false))}
-        </>
-      )}
-    </div>
+      {recent.map(tr => renderOne(tr, false))}
+      {older.length > 0 && <div className="cc-feed-divider" />}
+      {older.map(tr => renderOne(tr, true))}
+    </>
   );
 });
-
-// ── Sort options ──
-
-type SortKey = 'name' | 'lastUpdated' | 'domain';
-
-function getSortOptions(locale: Locale): { key: SortKey; label: string }[] {
-  return [
-    { key: 'name', label: t('sidebar.sortName', locale) },
-    { key: 'lastUpdated', label: t('sidebar.sortLastUpdated', locale) },
-    { key: 'domain', label: t('sidebar.sortDomain', locale) },
-  ];
-}
-
-function sortTrackers(trackers: TrackerCardData[], sortKey: SortKey): TrackerCardData[] {
-  const sorted = [...trackers];
-  switch (sortKey) {
-    case 'name':
-      return sorted.sort((a, b) => a.shortName.localeCompare(b.shortName));
-    case 'lastUpdated':
-      return sorted.sort((a, b) => new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime());
-    case 'domain':
-      return sorted.sort((a, b) => (a.domain || '').localeCompare(b.domain || '') || a.shortName.localeCompare(b.shortName));
-    default:
-      return sorted;
-  }
-}
-
-// ── Freshness dot helper ──
-
-function getFreshnessDot(lastUpdated: string, locale: Locale = 'en'): { color: string; shadow: string; label: string } {
-  const updated = new Date(lastUpdated);
-  const now = new Date();
-  const ageHrs = Math.floor((now.getTime() - updated.getTime()) / 3600000);
-  if (ageHrs < 24) return { color: 'var(--accent-green, #2ecc71)', shadow: '0 0 4px rgba(46,160,67,0.37)', label: t('sidebar.updatedToday', locale) };
-  if (ageHrs < 48) return { color: 'var(--accent-amber, #f39c12)', shadow: '0 0 4px rgba(210,153,34,0.37)', label: t('sidebar.updated1to2Days', locale) };
-  return { color: 'var(--accent-red, #e74c3c)', shadow: '0 0 4px rgba(231,76,60,0.37)', label: t('sidebar.notUpdatedIn2Days', locale) };
-}
 
 // ── Main SidebarPanel ──
 
@@ -612,24 +461,24 @@ export default function SidebarPanel({
   activeGeoPath,
   featuredSlug,
 }: Props) {
-  const [activeDomain, setActiveDomain] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
-  const [showAllTrackers, setShowAllTrackers] = useState(false);
-  const [sortKey, setSortKey] = useState<SortKey>('name');
 
   const filtered = useMemo(
-    () => filterTrackers(trackers, activeDomain, searchQuery),
-    [trackers, activeDomain, searchQuery],
+    () => filterTrackers(trackers, null, searchQuery),
+    [trackers, searchQuery],
   );
 
   const sortedFiltered = useMemo(
-    () => sortTrackers(filtered, sortKey),
-    [filtered, sortKey],
+    () => sortByRelevance(filtered, followedSlugs),
+    [filtered, followedSlugs],
   );
 
   const groups = useMemo(() => groupTrackers(sortedFiltered), [sortedFiltered]);
-  const domainCounts = useMemo(() => computeDomainCounts(trackers), [trackers]);
-  const visibleDomains = useMemo(() => getVisibleDomains(domainCounts), [domainCounts]);
+
+  const heroTracker = useMemo(
+    () => selectHeroTracker(trackers, followedSlugs),
+    [trackers, followedSlugs],
+  );
 
   // Flat list of all visible tracker slugs for keyboard nav
   const flatSlugs = useMemo(
@@ -669,7 +518,7 @@ export default function SidebarPanel({
     }
   }, [activeTracker, flatSlugs, onSelectTracker, basePath]);
 
-  const isSearching = activeDomain !== null || searchQuery.trim().length > 0;
+  const isSearching = searchQuery.trim().length > 0;
 
   return (
     <div className="cc-sidebar" style={S.sidebar} onKeyDown={handleKeyDown} tabIndex={-1}>
@@ -749,46 +598,15 @@ export default function SidebarPanel({
         <ViewModeToggle mode={viewMode || 'operations'} onChange={onChangeViewMode} />
       )}
 
-      {/* Sort dropdown */}
-      {(viewMode || 'operations') !== 'geographic' && (
-        <div style={S.sortWrap}>
-          <label style={S.sortLabel}>{t('sidebar.sortBy', locale)}</label>
-          <select
-            value={sortKey}
-            onChange={e => setSortKey(e.target.value as SortKey)}
-            style={S.sortSelect}
-            aria-label={t('sidebar.sortTrackersBy', locale)}
-          >
-            {getSortOptions(locale).map(opt => (
-              <option key={opt.key} value={opt.key}>{opt.label}</option>
-            ))}
-          </select>
-        </div>
-      )}
-
-      {/* Domain tabs — only in domain mode */}
-      {(viewMode || 'operations') === 'domain' && (
-        <div style={S.tabs}>
-          <button
-            type="button"
-            className="cc-domain-tab"
-            style={S.tab(!activeDomain)}
-            onClick={() => setActiveDomain(null)}
-          >
-            {t('sidebar.all', locale)} <span style={S.tabCount}>{trackers.length}</span>
-          </button>
-          {visibleDomains.map(d => (
-            <button
-              key={d}
-              type="button"
-              className="cc-domain-tab"
-              style={S.tab(activeDomain === d, DOMAIN_COLORS[d])}
-              onClick={() => setActiveDomain(activeDomain === d ? null : d)}
-            >
-              {d.toUpperCase()} <span style={S.tabCount}>{domainCounts[d]}</span>
-            </button>
-          ))}
-        </div>
+      {/* Hero — hidden during search */}
+      {!isSearching && heroTracker && (
+        <HeroCard
+          tracker={heroTracker}
+          isBroadcastFeatured={featuredSlug === heroTracker.slug}
+          basePath={basePath}
+          locale={locale}
+          onSelect={onSelectTracker}
+        />
       )}
 
       {/* Tracker list */}
@@ -808,99 +626,22 @@ export default function SidebarPanel({
             activeGeoPath={activeGeoPath}
           />
         ) : (
-          <>
-            {/* Recent events feed (only when not searching) */}
-            {!isSearching && <RecentEventsFeed trackers={trackers} basePath={basePath} followedSlugs={followedSlugs} onSelect={onSelectTracker} locale={locale} />}
-
-            {filtered.length === 0 ? (
-              <div style={S.noResults}>{t('cc.noResults', locale)}</div>
-            ) : (
-              (() => {
-                const MOBILE_LIMIT = 15;
-                let rowCount = 0;
-                const shouldLimit = isMobile && !showAllTrackers && !isSearching;
-                const totalRows = groups.reduce((sum, g) => sum + g.trackers.length, 0);
-
-                return (
-                  <>
-                    {groups.map(group => {
-                      if (shouldLimit && rowCount >= MOBILE_LIMIT) return null;
-
-                      // Render series groups as horizontal strips
-                      if (group.type === 'series') {
-                        rowCount += group.trackers.length;
-                        return (
-                          <SeriesStrip
-                            key={`series-${group.label}`}
-                            group={group}
-                            basePath={basePath}
-                            activeTracker={activeTracker}
-                            hoveredTracker={hoveredTracker}
-                            onSelect={onSelectTracker}
-                            onHover={onHoverTracker}
-                          />
-                        );
-                      }
-
-                      const trackersToRender = shouldLimit
-                        ? group.trackers.slice(0, MOBILE_LIMIT - rowCount)
-                        : group.trackers;
-                      rowCount += trackersToRender.length;
-
-                      return (
-                        <div key={`${group.type}-${group.label}`}>
-                          <div style={S.groupHeader(group.type)}>
-                            {group.labelIcon && <span style={S.groupIcon(group.type)}>{group.labelIcon}</span>}
-                            <span>{group.label.toUpperCase()}</span>
-                          </div>
-                          {trackersToRender.map(t => (
-                            <TrackerRow
-                              key={t.slug}
-                              tracker={t}
-                              basePath={basePath}
-                              isActive={activeTracker === t.slug}
-                              isHovered={hoveredTracker === t.slug}
-                              isFollowed={followedSlugs.includes(t.slug)}
-                              isCompared={compareSlugs.includes(t.slug)}
-                              isLive={featuredSlug === t.slug}
-                              onSelect={onSelectTracker}
-                              onHover={onHoverTracker}
-                              onToggleFollow={onToggleFollow}
-                              onToggleCompare={onToggleCompare}
-                              locale={locale}
-                            />
-                          ))}
-                        </div>
-                      );
-                    })}
-                    {shouldLimit && totalRows > MOBILE_LIMIT && (
-                      <button
-                        type="button"
-                        onClick={() => setShowAllTrackers(true)}
-                        style={{
-                          display: 'block',
-                          width: '100%',
-                          padding: '12px 0',
-                          margin: '8px 0',
-                          background: 'rgba(88,166,255,0.08)',
-                          border: '1px solid rgba(88,166,255,0.2)',
-                          borderRadius: '6px',
-                          color: 'var(--accent-blue, #58a6ff)',
-                          fontFamily: "'JetBrains Mono', monospace",
-                          fontSize: '0.72rem',
-                          fontWeight: 600,
-                          letterSpacing: '0.04em',
-                          cursor: 'pointer',
-                        }}
-                      >
-                        {t('sidebar.showAll', locale)} {totalRows} {t('sidebar.trackers', locale)}
-                      </button>
-                    )}
-                  </>
-                );
-              })()
-            )}
-          </>
+          <FeedList
+            trackers={sortedFiltered}
+            followedSlugs={followedSlugs}
+            activeTracker={activeTracker}
+            hoveredTracker={hoveredTracker}
+            compareSlugs={compareSlugs}
+            featuredSlug={featuredSlug ?? null}
+            basePath={basePath}
+            locale={locale}
+            viewMode={(viewMode || 'operations') as ViewMode}
+            onSelectTracker={onSelectTracker}
+            onHoverTracker={onHoverTracker}
+            onToggleFollow={onToggleFollow}
+            onToggleCompare={onToggleCompare}
+            isSearching={isSearching}
+          />
         )}
       </div>
 
@@ -1057,38 +798,6 @@ const S = {
     boxSizing: 'border-box' as const,
   } as CSSProperties,
 
-  tabs: {
-    display: 'flex',
-    gap: '3px',
-    flexWrap: 'wrap' as const,
-    padding: '0 12px 8px',
-    borderBottom: '1px solid var(--border)',
-    flexShrink: 0,
-  } as CSSProperties,
-
-  tab: (active: boolean, color?: string): CSSProperties => ({
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: '3px',
-    padding: '2px 6px',
-    borderRadius: 3,
-    border: `1px solid ${active ? (color || 'var(--accent-blue)') : 'var(--border)'}`,
-    background: active ? `${color || 'var(--accent-blue)'}18` : 'transparent',
-    color: active ? (color || 'var(--accent-blue)') : 'var(--text-muted)',
-    fontFamily: "'JetBrains Mono', monospace",
-    fontSize: '0.5rem',
-    fontWeight: 600,
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.06em',
-    cursor: 'pointer',
-    whiteSpace: 'nowrap' as const,
-  }),
-
-  tabCount: {
-    fontWeight: 400,
-    opacity: 0.7,
-  } as CSSProperties,
-
   list: {
     flex: 1,
     overflowY: 'auto' as const,
@@ -1196,37 +905,6 @@ const S = {
     height: 6,
     borderRadius: '50%',
     flexShrink: 0,
-  } as CSSProperties,
-
-  sortWrap: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '8px',
-    padding: '4px 12px 6px',
-    flexShrink: 0,
-  } as CSSProperties,
-
-  sortLabel: {
-    fontFamily: "'JetBrains Mono', monospace",
-    fontSize: '0.48rem',
-    fontWeight: 600,
-    letterSpacing: '0.08em',
-    color: 'var(--text-muted)',
-    textTransform: 'uppercase' as const,
-    flexShrink: 0,
-  } as CSSProperties,
-
-  sortSelect: {
-    fontFamily: "'JetBrains Mono', monospace",
-    fontSize: '0.55rem',
-    color: 'var(--text-primary)',
-    background: 'var(--bg-secondary)',
-    border: '1px solid var(--border)',
-    borderRadius: 4,
-    padding: '3px 6px',
-    cursor: 'pointer',
-    outline: 'none',
-    transition: 'border-color 0.2s',
   } as CSSProperties,
 
   // Expanded row

--- a/src/components/islands/CommandCenter/ViewModeToggle.tsx
+++ b/src/components/islands/CommandCenter/ViewModeToggle.tsx
@@ -1,5 +1,4 @@
 import { memo } from 'react';
-import type { CSSProperties } from 'react';
 
 export type ViewMode = 'operations' | 'geographic' | 'domain';
 
@@ -8,66 +7,27 @@ interface Props {
   onChange: (mode: ViewMode) => void;
 }
 
-const MODES: { id: ViewMode; label: string; icon: string }[] = [
-  { id: 'operations', label: 'OPS', icon: '◉' },
-  { id: 'geographic', label: 'GEO', icon: '🌍' },
-  { id: 'domain', label: 'DOMAIN', icon: '◫' },
+const MODES: { id: ViewMode; label: string }[] = [
+  { id: 'operations', label: 'OPS' },
+  { id: 'geographic', label: 'GEO' },
+  { id: 'domain', label: 'DOMAIN' },
 ];
 
 export default memo(function ViewModeToggle({ mode, onChange }: Props) {
   return (
-    <div style={S.wrap}>
+    <div className="cc-feed-tabs" role="tablist" aria-label="Tracker list view">
       {MODES.map(m => (
         <button
           key={m.id}
           type="button"
+          role="tab"
+          aria-selected={mode === m.id}
+          className={`cc-feed-tab${mode === m.id ? ' is-active' : ''}`}
           onClick={() => onChange(m.id)}
-          style={{
-            ...S.pill,
-            ...(mode === m.id ? S.pillActive : {}),
-          }}
         >
-          <span style={S.pillIcon}>{m.icon}</span>
-          <span>{m.label}</span>
+          {m.label}
         </button>
       ))}
     </div>
   );
 });
-
-const S = {
-  wrap: {
-    display: 'flex',
-    gap: '2px',
-    padding: '4px',
-    background: 'var(--bg-card, #161b22)',
-    borderRadius: '6px',
-    margin: '0 8px 6px',
-  } as CSSProperties,
-  pill: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '4px',
-    padding: '3px 8px',
-    border: 'none',
-    borderRadius: '4px',
-    background: 'transparent',
-    color: 'var(--text-muted, #8b949e)',
-    fontSize: '0.6rem',
-    fontFamily: "'DM Sans', sans-serif",
-    fontWeight: 600,
-    letterSpacing: '0.5px',
-    cursor: 'pointer',
-    transition: 'all 0.15s',
-    flex: 1,
-    justifyContent: 'center',
-  } as CSSProperties,
-  pillActive: {
-    background: 'rgba(31,111,235,0.15)',
-    color: 'var(--accent-blue, #58a6ff)',
-    border: '1px solid rgba(31,111,235,0.3)',
-  } as CSSProperties,
-  pillIcon: {
-    fontSize: '0.7rem',
-  } as CSSProperties,
-};

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -49,6 +49,9 @@ const en = {
   'cc.live': 'LIVE',
   'cc.hist': 'HIST',
 
+  // Hero Card
+  'hero.day': 'DAY',
+
   // Sections
   'section.timeline': 'Timeline',
   'section.map': 'Theater Map',
@@ -592,6 +595,8 @@ const es: TranslationKeys = {
   'cc.live': 'EN VIVO',
   'cc.hist': 'HIST',
 
+  'hero.day': 'DÍA',
+
   'section.timeline': 'Línea de Tiempo',
   'section.map': 'Mapa de Teatro',
   'section.military': 'Militar',
@@ -1114,6 +1119,8 @@ const fr: TranslationKeys = {
   'cc.live': 'DIRECT',
   'cc.hist': 'HIST',
 
+  'hero.day': 'JOUR',
+
   'section.timeline': 'Chronologie',
   'section.map': 'Carte du Théâtre',
   'section.military': 'Militaire',
@@ -1635,6 +1642,8 @@ const pt: TranslationKeys = {
   'cc.noResults': 'Nenhum tracker corresponde à sua busca.',
   'cc.live': 'AO VIVO',
   'cc.hist': 'HIST',
+
+  'hero.day': 'DIA',
 
   'section.timeline': 'Linha do Tempo',
   'section.map': 'Mapa do Teatro',

--- a/src/lib/hero-selection.test.ts
+++ b/src/lib/hero-selection.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { selectHeroTracker } from './hero-selection';
+import type { TrackerCardData } from './tracker-directory-utils';
+
+function makeTracker(overrides: Partial<TrackerCardData> & { slug: string }): TrackerCardData {
+  return {
+    slug: overrides.slug,
+    shortName: overrides.shortName ?? overrides.slug,
+    name: overrides.name ?? overrides.slug,
+    description: '',
+    icon: '',
+    color: '#3498db',
+    status: 'active',
+    temporal: 'live',
+    domain: 'conflict',
+    region: 'global',
+    startDate: '2024-01-01',
+    sections: [],
+    dayCount: 0,
+    lastUpdated: '2026-04-22T00:00:00Z',
+    topKpis: [],
+    headline: 'Default headline',
+    latestEventMedia: { url: 'https://example.com/a.jpg', source: 'Src', tier: 1 },
+    eventImages: [],
+    isBreaking: false,
+    recentEventCount: 0,
+    avgSourceTier: 2,
+    sectionsUpdatedCount: 0,
+    ...(overrides as TrackerCardData),
+  } as TrackerCardData;
+}
+
+describe('selectHeroTracker', () => {
+  it('returns null when the list is empty', () => {
+    expect(selectHeroTracker([], [])).toBeNull();
+  });
+
+  it('returns null when no tracker has a headline', () => {
+    const trackers = [
+      makeTracker({ slug: 'a', headline: undefined }),
+      makeTracker({ slug: 'b', headline: '' }),
+    ];
+    expect(selectHeroTracker(trackers, [])).toBeNull();
+  });
+
+  it('excludes trackers with no media and empty eventImages', () => {
+    const trackers = [
+      makeTracker({ slug: 'no-media', latestEventMedia: undefined, eventImages: [] }),
+      makeTracker({ slug: 'has-media', latestEventMedia: { url: 'x', source: 's', tier: 1 } }),
+    ];
+    expect(selectHeroTracker(trackers, [])?.slug).toBe('has-media');
+  });
+
+  it('accepts trackers with eventImages even if latestEventMedia is missing', () => {
+    const trackers = [
+      makeTracker({
+        slug: 'by-events',
+        latestEventMedia: undefined,
+        eventImages: [{ url: 'x', source: 's', tier: 1 }],
+      }),
+    ];
+    expect(selectHeroTracker(trackers, [])?.slug).toBe('by-events');
+  });
+
+  it('excludes archived trackers', () => {
+    const trackers = [
+      makeTracker({ slug: 'archived', status: 'archived' }),
+      makeTracker({ slug: 'active' }),
+    ];
+    expect(selectHeroTracker(trackers, [])?.slug).toBe('active');
+  });
+
+  it('prefers breaking > followed > editorial > recency', () => {
+    const trackers = [
+      makeTracker({
+        slug: 'breaking',
+        isBreaking: true,
+        lastUpdated: '2026-04-01T00:00:00Z',
+      }),
+      makeTracker({
+        slug: 'followed',
+        isBreaking: false,
+        lastUpdated: '2026-04-22T00:00:00Z',
+      }),
+    ];
+    expect(selectHeroTracker(trackers, ['followed'])?.slug).toBe('breaking');
+  });
+
+  it('returns the followed tracker when nothing is breaking', () => {
+    const trackers = [
+      makeTracker({ slug: 'a' }),
+      makeTracker({ slug: 'b' }),
+    ];
+    expect(selectHeroTracker(trackers, ['b'])?.slug).toBe('b');
+  });
+
+  it('is stable — same input, same output', () => {
+    const trackers = [
+      makeTracker({ slug: 'x', recentEventCount: 5 }),
+      makeTracker({ slug: 'y', recentEventCount: 2 }),
+    ];
+    const a = selectHeroTracker(trackers, []);
+    const b = selectHeroTracker(trackers, []);
+    expect(a?.slug).toBe(b?.slug);
+  });
+});

--- a/src/lib/hero-selection.test.ts
+++ b/src/lib/hero-selection.test.ts
@@ -3,10 +3,9 @@ import { selectHeroTracker } from './hero-selection';
 import type { TrackerCardData } from './tracker-directory-utils';
 
 function makeTracker(overrides: Partial<TrackerCardData> & { slug: string }): TrackerCardData {
-  return {
-    slug: overrides.slug,
-    shortName: overrides.shortName ?? overrides.slug,
-    name: overrides.name ?? overrides.slug,
+  const defaults: Omit<TrackerCardData, 'slug'> = {
+    shortName: overrides.slug,
+    name: overrides.slug,
     description: '',
     icon: '',
     color: '#3498db',
@@ -26,8 +25,8 @@ function makeTracker(overrides: Partial<TrackerCardData> & { slug: string }): Tr
     recentEventCount: 0,
     avgSourceTier: 2,
     sectionsUpdatedCount: 0,
-    ...(overrides as TrackerCardData),
-  } as TrackerCardData;
+  } as unknown as Omit<TrackerCardData, 'slug'>;
+  return { ...defaults, ...overrides } as TrackerCardData;
 }
 
 describe('selectHeroTracker', () => {

--- a/src/lib/hero-selection.ts
+++ b/src/lib/hero-selection.ts
@@ -1,0 +1,23 @@
+import type { TrackerCardData } from './tracker-directory-utils';
+import { sortByRelevance } from './relevance';
+
+/**
+ * Pick the hero tracker for the sidebar: the highest-relevance active tracker
+ * that has a headline and at least one usable image. Returns null if none qualify.
+ *
+ * Stable for a given (trackers, followedSlugs) pair.
+ */
+export function selectHeroTracker(
+  trackers: TrackerCardData[],
+  followedSlugs: string[],
+): TrackerCardData | null {
+  const eligible = trackers.filter(t =>
+    t.status === 'active' &&
+    typeof t.headline === 'string' &&
+    t.headline.length > 0 &&
+    (t.latestEventMedia != null || (t.eventImages?.length ?? 0) > 0)
+  );
+  if (eligible.length === 0) return null;
+  const sorted = sortByRelevance(eligible, followedSlugs);
+  return sorted[0] ?? null;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3379,9 +3379,9 @@ body::before {
     box-shadow: 0 0 0 4px rgba(46, 204, 113, 0);
   }
 }
-.cc-tracker-row.cc-tracker-live,
+.cc-feed-row.cc-tracker-live,
 .cc-tracker-expanded.cc-tracker-live {
-  animation: ccLivePulse 2s ease-in-out infinite;
+  animation: none; /* the inline live-dot pulses on its own; avoid pulsing the whole row */
 }
 .cc-tracker-live-badge {
   display: inline-flex;
@@ -3534,4 +3534,133 @@ body::before {
   .cc-hero-thumb { width: 64px; height: 64px; }
   .cc-hero-thumb-icon { font-size: 30px; }
   .cc-hero-headline { font-size: 0.74rem; -webkit-line-clamp: 2; }
+}
+
+/* ─── Sidebar Feed Row ─── */
+.cc-feed-row {
+  display: grid;
+  grid-template-columns: 22px 1fr auto;
+  gap: 4px 10px;
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: background 0.15s ease, opacity 0.2s ease;
+  align-items: start;
+  border-left: 2px solid transparent;
+}
+.cc-feed-row:hover {
+  background: var(--bg-card-hover, #1e2130);
+}
+.cc-feed-row:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: -2px;
+}
+.cc-feed-row.cc-tracker-live {
+  border-left-color: #3fb950;
+}
+.cc-feed-row.cc-feed-row-dim .cc-feed-icon,
+.cc-feed-row.cc-feed-row-dim .cc-feed-name {
+  opacity: 0.55;
+}
+.cc-feed-row.cc-feed-row-dim .cc-feed-headline {
+  opacity: 0.45;
+}
+
+.cc-feed-icon {
+  font-size: 1rem;
+  line-height: 1.2;
+  grid-row: 1 / span 2;
+  align-self: center;
+  text-align: center;
+}
+
+.cc-feed-body {
+  min-width: 0;
+}
+.cc-feed-top {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 2px;
+}
+.cc-feed-name {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--text-primary, #e8e9ed);
+  text-transform: uppercase;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cc-feed-live-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #3fb950;
+  box-shadow: 0 0 6px rgba(46, 204, 113, 0.6);
+  animation: ccLivePulse 1.6s ease-in-out infinite;
+  flex-shrink: 0;
+}
+.cc-feed-headline {
+  font-family: 'Inter', 'DM Sans', sans-serif;
+  font-size: 0.66rem;
+  line-height: 1.3;
+  color: var(--text-secondary, #9498a8);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cc-feed-right {
+  grid-row: 1 / span 2;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.cc-feed-time {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.5rem;
+  letter-spacing: 0.04em;
+  color: var(--text-muted, #8b8fa2);
+}
+.cc-feed-actions {
+  display: flex;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+.cc-feed-row:hover .cc-feed-actions {
+  opacity: 1;
+}
+.cc-feed-action {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 3px;
+  font-size: 0.6rem;
+  color: var(--text-muted, #8b8fa2);
+  line-height: 1;
+}
+.cc-feed-action.is-on {
+  opacity: 1;
+  color: #f39c12;
+}
+.cc-feed-compare.is-on {
+  color: var(--accent-blue, #58a6ff);
+}
+.cc-feed-follow:hover,
+.cc-feed-compare:hover {
+  color: var(--text-primary, #e8e9ed);
+}
+
+/* Follow star stays visible when followed, even without hover */
+.cc-feed-row .cc-feed-follow.is-on {
+  opacity: 1;
+}
+.cc-feed-row:not(:hover) .cc-feed-actions:has(.is-on) {
+  opacity: 1;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3698,3 +3698,23 @@ body::before {
   outline: 2px solid var(--accent-blue);
   outline-offset: 2px;
 }
+
+.cc-feed-divider {
+  height: 1px;
+  background: var(--border, #2a2d3a);
+  margin: 6px 10px;
+  opacity: 0.5;
+}
+.cc-feed-group-divider {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.5rem;
+  letter-spacing: 0.22em;
+  color: var(--text-muted, #8b8fa2);
+  padding: 14px 12px 4px;
+  border-top: 1px solid var(--border, #2a2d3a);
+  margin-top: 6px;
+}
+.cc-feed-group-divider:first-child {
+  border-top: none;
+  margin-top: 0;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3664,3 +3664,37 @@ body::before {
 .cc-feed-row:not(:hover) .cc-feed-actions:has(.is-on) {
   opacity: 1;
 }
+
+/* ─── Sidebar Inline Tabs ─── */
+.cc-feed-tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--border, #2a2d3a);
+  margin-bottom: 4px;
+}
+.cc-feed-tab {
+  background: none;
+  border: none;
+  padding: 8px 10px 6px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.55rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: var(--text-muted, #8b8fa2);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px; /* overlap the container's bottom border */
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.cc-feed-tab:hover {
+  color: var(--text-primary, #e8e9ed);
+}
+.cc-feed-tab.is-active {
+  color: var(--accent-blue, #58a6ff);
+  border-bottom-color: var(--accent-blue, #58a6ff);
+}
+.cc-feed-tab:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3408,3 +3408,130 @@ body::before {
   background: #3fb950;
   animation: ccLivePulse 1.5s ease-in-out infinite;
 }
+
+/* ─── Sidebar Hero Card ─── */
+.cc-hero-card {
+  display: flex;
+  gap: 12px;
+  padding: 14px;
+  margin: 8px 10px 4px;
+  background: var(--bg-card, #181b23);
+  border: 1px solid var(--border, #2a2d3a);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.cc-hero-card:hover {
+  border-color: var(--accent-blue, #58a6ff);
+  background: var(--bg-card-hover, #1e2130);
+}
+.cc-hero-card:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}
+.cc-hero-card.cc-hero-card-live {
+  border-color: rgba(46, 204, 113, 0.35);
+}
+
+.cc-hero-thumb {
+  width: 96px;
+  height: 96px;
+  border-radius: 6px;
+  flex-shrink: 0;
+  overflow: hidden;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.cc-hero-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.cc-hero-thumb-icon {
+  font-size: 42px;
+  opacity: 0.7;
+}
+
+.cc-hero-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.cc-hero-context {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.5rem;
+  letter-spacing: 0.15em;
+  color: var(--text-muted, #8b8fa2);
+  text-transform: uppercase;
+}
+.cc-hero-name-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.cc-hero-name {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--text-primary, #e8e9ed);
+  text-transform: uppercase;
+}
+.cc-hero-live {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 5px;
+  background: rgba(46, 204, 113, 0.15);
+  border: 1px solid rgba(46, 204, 113, 0.4);
+  border-radius: 3px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.45rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: #3fb950;
+}
+.cc-hero-live-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #3fb950;
+  animation: ccLivePulse 1.6s ease-in-out infinite;
+}
+.cc-hero-headline {
+  font-family: 'Inter', 'DM Sans', sans-serif;
+  font-size: 0.82rem;
+  font-weight: 500;
+  line-height: 1.35;
+  color: var(--text-primary, #e8e9ed);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin-top: 2px;
+}
+.cc-hero-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 4px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.5rem;
+  letter-spacing: 0.08em;
+  color: var(--text-muted, #8b8fa2);
+  text-transform: uppercase;
+}
+
+/* Mid-width (768-1279px): smaller thumb */
+@media (min-width: 768px) and (max-width: 1279px) {
+  .cc-hero-thumb { width: 64px; height: 64px; }
+  .cc-hero-thumb-icon { font-size: 30px; }
+  .cc-hero-headline { font-size: 0.74rem; -webkit-line-clamp: 2; }
+}


### PR DESCRIPTION
## Summary

Replaces the flat, decoration-heavy sidebar tracker list with a two-part layout:

- **Hero card** on top — editorial presentation of the single highest-relevance tracker (thumbnail, name with LIVE badge when broadcast-featured, headline, `T{tier} · source · time` footer). Static within a session; does not cycle with broadcast (motion lives in the lower-third).
- **Minimal feed** below — two-line rows: icon + UPPERCASE name + truncated headline + relative time. No tier chips, no colored borders, no freshness dots, no group-header labels. Follow/compare buttons fade in on hover.

**OPS view** now partitions rows into *followed / recent (≤48h) / older (>48h dimmed)* split by faint 1px dividers — no text labels. **DOMAIN view** groups by `tracker.domain` with small uppercase dividers. **GEO view** keeps `GeoAccordion` below the hero. **Search** hides the hero and shows only matching rows.

Tabs become text-only with an underline indicator on the active tab.

**Net change: 6 commits, ~300 fewer lines.**

## Design artifacts

- Spec: `docs/superpowers/specs/2026-04-22-right-panel-hero-minimal-design.md`
- Plan: `docs/superpowers/plans/2026-04-22-right-panel-hero-minimal.md`

## New files

- `src/lib/hero-selection.ts` — `selectHeroTracker` pure function (8 Vitest tests, all passing)
- `src/lib/hero-selection.test.ts`
- `src/components/islands/CommandCenter/HeroCard.tsx`
- `src/components/islands/CommandCenter/FeedRow.tsx`

## Modified files

- `src/components/islands/CommandCenter/SidebarPanel.tsx` — body rewritten, `FeedList` subcomponent added, arrow-nav updated, ~300 lines of orphaned inline styles removed
- `src/components/islands/CommandCenter/ViewModeToggle.tsx` — restyled to inline underline tabs
- `src/styles/global.css` — new `.cc-hero-*`, `.cc-feed-*`, `.cc-feed-tabs` rules; PR #106 `.cc-tracker-live` selector updated to target `.cc-feed-row`
- `src/i18n/translations.ts` — `hero.day` key in en/es/fr/pt

## Dropped functionality

- Sort dropdown (sort is now always `sortByRelevance`)
- Inline domain-tabs row (domain filtering still works via the DOMAIN view's groups; `activeDomain` state removed)
- `RecentEventsFeed` ~150-line component (superseded by the hero card as the "what's happening now" surface)
- `.cc-tracker-row.cc-tracker-live` box-shadow row pulse (replaced with a small inline live dot + left-edge border accent — addresses a perf concern flagged in PR #106's review)

## Perf / accessibility

- `FeedList` memoizes `followed` and `compared` Sets via `useMemo` (avoids rebuilding on every re-render, e.g. when `hoveredTracker` changes)
- Arrow-key navigation disabled in GEO view (the geo-tree visible order doesn't match `flatSlugs`); in OPS view, `flatSlugs` now matches the visible followed/recent/older partition so focus lands on adjacent rows
- `HeroCard` and `FeedRow` are both `memo`'d with all-primitive props (preserves the broadcast-tick re-render budget from PR #106)
- `role="button"` / `tabIndex={0}` / Enter + Space key support on both components
- LIVE badge uses `role="status"` for screen-reader announcements

## Test plan

- [ ] Desktop 1440×900: hero card visible with correct tracker, LIVE badge pulses when hero is the broadcast-featured tracker
- [ ] Click hero → tracker's expanded view appears in the feed below
- [ ] Broadcast cycle advances → lower-third changes, LIVE pulse follows to new row, **hero stays put** (static contract)
- [ ] Hover a row → follow/compare buttons fade in
- [ ] Click ★ on a row → row moves to "followed" section at top
- [ ] Type `/` then text → hero hides, feed filters; clear search → hero returns
- [ ] Switch to GEO → hero stays, `GeoAccordion` renders below
- [ ] Switch to DOMAIN → hero stays, rows grouped by domain with uppercase dividers
- [ ] Arrow-up/down in OPS → focus moves between adjacent visible rows (matches visual order)
- [ ] Mobile (<768px): unchanged — `MobileStoryCarousel` + globe still render
- [ ] `npm test` — all 8 `hero-selection` unit tests pass

## Notes for reviewer

- 7 pre-existing `i18n/translations.test.ts` accent-mismatch failures fail on `main` too — not introduced here.
- The `SeriesStrip` component still exists in `SidebarPanel.tsx` but isn't rendered there after the rewrite; its canonical copy lives in `TrackerDirectory.tsx`. Follow-up candidate: delete the duplicate from `SidebarPanel.tsx`.
- The legacy `.cc-tracker-live-badge` CSS block (from PR #106) is no longer referenced by any JSX in the new design; kept to avoid scope creep. Follow-up: CSS audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)