### PR TITLE
fix(home): sidebar content overlapped by fixed top navbar

### DIFF
--- a/src/components/static/CriticalCSS.astro
+++ b/src/components/static/CriticalCSS.astro
@@ -76,6 +76,7 @@
     border-left: 1px solid var(--border);
     overflow: hidden;
     background: var(--bg-primary);
+    padding-top: 48px; /* offset below fixed overlay navbar */
   }
 
   /* Overlay nav bar — visible immediately */

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -254,6 +254,14 @@ const breakingTrackers = [...serializedTrackers]
     border: 0;
   }
 
+  /* Desktop: offset sidebar content below the fixed overlay navbar so the
+     sidebar's own brand + search + tabs don't render underneath it */
+  @media (min-width: 768px) {
+    .cc-sidebar {
+      padding-top: 48px;
+    }
+  }
+
   /* Tablets/narrow desktops: stack globe + sidebar */
   @media (max-width: 767px) {
     .command-center-root {


### PR DESCRIPTION
## Problem

The overlay navbar (\`role=\"banner\"\`, fixed at top, 46px tall) was rendering on top of the sidebar's own brand, search input, and tabs. Measured on prod 1440×900:

- topnav: y=0, height=46
- sidebar brand: y=8 ❌ under navbar
- sidebar search: y=43 ❌ partially under navbar
- sidebar tabs: y=79 (just visible)
- hero card: y=119 (visible)

Visible symptom: \"61 trackers / 24 updated today / About / Telegram\" pills sit on top of where the sidebar's WATCHBOARD/OSINT brand should be.

## Fix

Add \`padding-top: 48px\` to \`.cc-sidebar\` on desktop (≥ 768px), matched in both:

- \`src/pages/index.astro\` (runtime CSS)
- \`src/components/static/CriticalCSS.astro\` (critical-path CSS, prevents flash-of-overlap on first paint)

Mobile unaffected — the existing \`@media (max-width: 767px)\` block resets sidebar layout, and the navbar is positioned absolutely (not fixed) there.

After fix on the same viewport: brand y=104, search y=139, tabs y=175, hero y=215. All clear of the navbar.

## Test plan

- [ ] Desktop ≥ 1280px: sidebar brand, search, and tabs visible below navbar
- [ ] Desktop 800-1279px: same (sidebar collapsed by default per PR #115; expand button at top still visible below navbar)
- [ ] Mobile (<768px): no extra padding, sidebar/carousel layout unchanged
- [ ] No flash of overlapping content on first page load (critical CSS covers it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)