### PR TITLE
fix(home): replace hardcoded sidebar padding with measured nav height

### DIFF
--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -249,7 +249,10 @@ export default function CommandCenter({
     const el = navRef.current;
     if (!el) return;
     const publish = () => {
-      document.documentElement.style.setProperty('--cc-nav-h', `${el.offsetHeight}px`);
+      // getBoundingClientRect is sub-pixel precise; offsetHeight would round to int
+      // and can leave a 1px overlap/gap under fractional DPR or zoom.
+      const h = Math.ceil(el.getBoundingClientRect().height);
+      document.documentElement.style.setProperty('--cc-nav-h', `${h}px`);
     };
     publish();
     const ro = new ResizeObserver(publish);

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -139,6 +139,7 @@ export default function CommandCenter({
   const activeCountry = activeGeoPath && activeGeoPath.length >= 2 ? activeGeoPath[1] : null;
 
   const searchRef = useRef<HTMLInputElement>(null);
+  const navRef = useRef<HTMLDivElement>(null);
   const globeRef = useRef<{
     toggleRotation?: () => void;
     flyTo?: (lat: number, lng: number, altitude: number, durationMs: number) => void;
@@ -241,6 +242,20 @@ export default function CommandCenter({
     window.addEventListener('resize', check);
     return () => window.removeEventListener('resize', check);
   }, []);
+
+  // Publish overlay nav height as --cc-nav-h so the sidebar can offset by exactly
+  // that much without hardcoding a magic number that drifts as the nav changes.
+  useEffect(() => {
+    const el = navRef.current;
+    if (!el) return;
+    const publish = () => {
+      document.documentElement.style.setProperty('--cc-nav-h', `${el.offsetHeight}px`);
+    };
+    publish();
+    const ro = new ResizeObserver(publish);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [isMobile]);
 
   const handleToggleLocale = useCallback(() => {
     setLocale(prev => {
@@ -475,7 +490,7 @@ export default function CommandCenter({
       <NotificationManager trackers={trackers} followedSlugs={followedSlugs} />
 
       {/* Overlay Nav */}
-      <div style={{
+      <div ref={navRef} style={{
         ...styles.overlayNav,
         ...(isMobile ? { position: 'absolute' as const } : {}),
       }} role="banner" aria-label="Watchboard navigation">

--- a/src/components/islands/CommandCenter/SidebarPanel.tsx
+++ b/src/components/islands/CommandCenter/SidebarPanel.tsx
@@ -544,7 +544,7 @@ export default function SidebarPanel({
   const isSearching = searchQuery.trim().length > 0;
 
   return (
-    <div className="cc-sidebar" style={S.sidebar} onKeyDown={handleKeyDown} tabIndex={-1}>
+    <div className="cc-sidebar-inner" style={S.sidebar} onKeyDown={handleKeyDown} tabIndex={-1}>
       {!isMobile && (
         <div style={S.header}>
           <div style={S.headerLeft}>

--- a/src/components/static/CriticalCSS.astro
+++ b/src/components/static/CriticalCSS.astro
@@ -76,7 +76,7 @@
     border-left: 1px solid var(--border);
     overflow: hidden;
     background: var(--bg-primary);
-    padding-top: 48px; /* offset below fixed overlay navbar */
+    padding-top: var(--cc-nav-h, 40px); /* JS sets exact nav height post-hydration */
   }
 
   /* Overlay nav bar — visible immediately */

--- a/src/components/static/CriticalCSS.astro
+++ b/src/components/static/CriticalCSS.astro
@@ -76,7 +76,14 @@
     border-left: 1px solid var(--border);
     overflow: hidden;
     background: var(--bg-primary);
-    padding-top: var(--cc-nav-h, 40px); /* JS sets exact nav height post-hydration */
+  }
+
+  /* Desktop only: offset below the fixed overlay nav. Mobile positions the nav
+     absolutely over the globe, so the sidebar must not reserve space for it. */
+  @media (min-width: 768px) {
+    .cc-sidebar {
+      padding-top: var(--cc-nav-h, 40px); /* JS sets exact nav height post-hydration */
+    }
   }
 
   /* Overlay nav bar — visible immediately */

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -254,11 +254,13 @@ const breakingTrackers = [...serializedTrackers]
     border: 0;
   }
 
-  /* Desktop: offset sidebar content below the fixed overlay navbar so the
-     sidebar's own brand + search + tabs don't render underneath it */
+  /* Desktop: offset sidebar content below the fixed overlay navbar. The actual
+     nav height is published to --cc-nav-h by CommandCenter via ResizeObserver,
+     so this stays correct if the nav grows or shrinks. Fallback matches the
+     current rendered height for first paint before JS hydrates. */
   @media (min-width: 768px) {
     .cc-sidebar {
-      padding-top: 48px;
+      padding-top: var(--cc-nav-h, 40px);
     }
   }
 


### PR DESCRIPTION
## Summary
- The 48px padding shipped in #117 was both too large and brittle: `<nav class=\"cc-sidebar\">` (outer) and `<div class=\"cc-sidebar\">` (inner, in `SidebarPanel`) both matched the rule, stacking the offset to ~92px and pushing the brand far below the navbar.
- Now: `CommandCenter` measures the overlay nav's real `offsetHeight` via `ResizeObserver` and publishes it to `--cc-nav-h`. CSS uses `padding-top: var(--cc-nav-h, 40px)`, with a 40px fallback for first paint (matches the current rendered height pre-hydration).
- Inner wrapper renamed to `.cc-sidebar-inner` so layout rules apply only to the outer flex column. The descendant selector `.cc-sidebar .cc-search-input` still resolves through the outer nav.

## Why dynamic
- Locale switches (EN/ES/FR/PT) and badge wrap can change nav height. Density tweaks down the road won't silently regress this.
- ResizeObserver re-publishes on every change, so the offset always tracks the actual rendered nav.

## Result
Brand sits 7.6px below the navbar (the sidebar header's own 8px padding) — no empty band.

| Before (#117) | After |
|---|---|
| ~54px gap above brand | ~8px gap (= sidebar header padding) |

## Test plan
- [x] `npm run build` passes (typecheck + 6070-page build)
- [x] Playwright probe at 1440x900: `--cc-nav-h: 46px`, sidebar `padding-top: 46px`, brand `top: 54` (was 100)
- [ ] Verify on deploy that locale changes still keep the brand right under the navbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)