### PR TITLE
fix(social): add dynamic hashtags to Telegram video captions

### DIFF
--- a/.github/workflows/daily-video.yml
+++ b/.github/workflows/daily-video.yml
@@ -161,7 +161,8 @@ jobs:
             try {
               const d = require('./video/src/data/breaking.json');
               const names = d.trackers.map(t => '• ' + t.name).join('\n');
-              console.log('🔴 Watchboard Daily Brief — ${DATE}\n\n' + names + '\n\n🔗 watchboard.dev');
+              const hashtags = d.trackers.map(t => '#' + t.slug.replace(/-/g, '_')).join(' ') + ' #watchboard';
+              console.log('🔴 Watchboard Daily Brief — ${DATE}\n\n' + names + '\n\n🔗 watchboard.dev\n\n' + hashtags);
             } catch { console.log('🔴 Watchboard Daily Brief — ${DATE}\n\n🔗 watchboard.dev'); }
           ")
           
@@ -305,7 +306,8 @@ jobs:
             try {
               const d = require('./video/src/data/breaking.json');
               const names = d.trackers.map(t => '\u2705 ' + t.name).join('\n');
-              console.log('\uD83C\uDF31 Watchboard Progress Brief \u2014 ${DATE}\n\n' + names + '\n\nScience doesn\'t take days off.\n\uD83D\uDD17 watchboard.dev');
+              const hashtags = d.trackers.map(t => '#' + t.slug.replace(/-/g, '_')).join(' ') + ' #watchboard';
+              console.log('\uD83C\uDF31 Watchboard Progress Brief \u2014 ${DATE}\n\n' + names + '\n\nScience doesn\'t take days off.\n\uD83D\uDD17 watchboard.dev\n\n' + hashtags);
             } catch { console.log('\uD83C\uDF31 Watchboard Progress Brief \u2014 ${DATE}\n\n\uD83D\uDD17 watchboard.dev'); }
           ")
 


### PR DESCRIPTION
## Problem

Daily Brief and Progress Brief captions posted to Telegram were missing hashtags entirely.

## Root Cause

Caption generation in `daily-video.yml` was inline bash `node -e` — it built the tracker names list but never added hashtags.

## Fix

Hashtags are now generated dynamically from tracker slugs:
```js
const hashtags = d.trackers.map(t => '#' + t.slug.replace(/-/g, '_')).join(' ') + ' #watchboard';
```

This means hashtags always match the actual content of each video — no hardcoding.

## Result

**Before:**
```
🔴 Watchboard Daily Brief — 2026-04-25

• Sudan
• India-Pakistan
• Trump

🔗 watchboard.dev
```

**After:**
```
🔴 Watchboard Daily Brief — 2026-04-25

• Sudan
• India-Pakistan
• Trump

🔗 watchboard.dev

#sudan_conflict #india_pakistan_conflict #trump_presidencies #watchboard
```

Same pattern applied to Progress Brief.

## Files changed
- `.github/workflows/daily-video.yml` — 2 caption blocks updated (Daily + Progress)