### PR TITLE
fix(video): increase font sizes and anchor text to bottom of frame

### DIFF
--- a/video/src/components/Intro.tsx
+++ b/video/src/components/Intro.tsx
@@ -67,7 +67,8 @@ export const Intro: React.FC<IntroProps> = ({ date, theme = 'dark' }) => {
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        justifyContent: 'center',
+        justifyContent: 'flex-end',
+        paddingBottom: 120,
       }}
     >
       {/* Logo */}
@@ -108,10 +109,10 @@ export const Intro: React.FC<IntroProps> = ({ date, theme = 'dark' }) => {
           opacity: subtitleOpacity,
           transform: `translateY(${subtitleY}px)`,
           fontFamily: "'JetBrains Mono', monospace",
-          fontSize: theme === 'day' ? 22 : 20,
+          fontSize: theme === 'day' ? 30 : 28,
           fontWeight: 600,
           color: theme === 'day' ? '#f0c060' : '#9498a8',
-          letterSpacing: theme === 'day' ? '8px' : '5px',
+          letterSpacing: theme === 'day' ? '6px' : '4px',
           marginBottom: 16,
         }}
       >
@@ -124,7 +125,7 @@ export const Intro: React.FC<IntroProps> = ({ date, theme = 'dark' }) => {
           opacity: dateOpacity,
           transform: `translateY(${dateY}px)`,
           fontFamily: "'JetBrains Mono', monospace",
-          fontSize: theme === 'day' ? 20 : 24,
+          fontSize: theme === 'day' ? 26 : 30,
           fontWeight: 500,
           color: theme === 'day' ? 'rgba(255,255,255,0.6)' : '#e8e9ed',
           letterSpacing: '3px',

--- a/video/src/components/Intro.tsx
+++ b/video/src/components/Intro.tsx
@@ -67,8 +67,7 @@ export const Intro: React.FC<IntroProps> = ({ date, theme = 'dark' }) => {
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        justifyContent: 'flex-end',
-        paddingBottom: 120,
+        justifyContent: 'center',
       }}
     >
       {/* Logo */}

--- a/video/src/components/Outro.tsx
+++ b/video/src/components/Outro.tsx
@@ -58,8 +58,7 @@ export const Outro: React.FC<{ theme?: 'dark' | 'day'; trackerCount?: number }> 
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        justifyContent: 'flex-end',
-        paddingBottom: 120,
+        justifyContent: 'center',
         gap: 32,
       }}
     >

--- a/video/src/components/Outro.tsx
+++ b/video/src/components/Outro.tsx
@@ -58,7 +58,8 @@ export const Outro: React.FC<{ theme?: 'dark' | 'day'; trackerCount?: number }> 
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        justifyContent: 'center',
+        justifyContent: 'flex-end',
+        paddingBottom: 120,
         gap: 32,
       }}
     >
@@ -95,7 +96,7 @@ export const Outro: React.FC<{ theme?: 'dark' | 'day'; trackerCount?: number }> 
           opacity: statsOpacity,
           transform: `translateY(${statsY}px)`,
           fontFamily: "'JetBrains Mono', monospace",
-          fontSize: 20,
+          fontSize: 28,
           fontWeight: 500,
           color: '#9498a8',
           letterSpacing: '2px',

--- a/video/src/components/TrackerSlide.tsx
+++ b/video/src/components/TrackerSlide.tsx
@@ -218,7 +218,7 @@ export const TrackerSlide: React.FC<TrackerSlideProps> = ({
           <div
             style={{
               fontFamily: "'JetBrains Mono', monospace",
-              fontSize: 24,
+              fontSize: 34,
               fontWeight: 600,
               color: accentColor,
               letterSpacing: '4px',
@@ -245,7 +245,7 @@ export const TrackerSlide: React.FC<TrackerSlideProps> = ({
             opacity: headlineOpacity,
             transform: `translateY(${headlineY}px)`,
             fontFamily: "'DM Sans', sans-serif",
-            fontSize: thumbnailBase64 ? 34 : 40,
+            fontSize: thumbnailBase64 ? 42 : 48,
             fontWeight: 700,
             color: '#e8e9ed',
             lineHeight: 1.25,
@@ -274,7 +274,7 @@ export const TrackerSlide: React.FC<TrackerSlideProps> = ({
           <div
             style={{
               fontFamily: "'JetBrains Mono', monospace",
-              fontSize: 18,
+              fontSize: 22,
               fontWeight: 500,
               color: '#9498a8',
               letterSpacing: '3px',


### PR DESCRIPTION
## Problems fixed

From screenshot review of the Intro and Outro frames:
1. Text too small — subtitle/date/tagline illegible on mobile (1080×1920)
2. Dead space in lower half — text centered vertically but globe dominates the top, leaving a visual void below

## Changes

**`Intro.tsx`**
- Subtitle ("DAILY INTELLIGENCE BRIEF"): 20 → 28px
- Date: 24 → 30px
- Layout: `justifyContent: center` → `flex-end` + `paddingBottom: 120px`

**`Outro.tsx`**
- Tagline ("64 TRACKERS · UPDATED BY AI..."): 20 → 28px
- Layout: same anchor-to-bottom fix

**`TrackerSlide.tsx`**
- Tracker name badge: 24 → 34px
- KPI label: 18 → 22px
- Headline: 34-40 → 42-48px

## Result

Text anchors to the bottom third of the frame — the clean space below the globe — instead of floating in the center behind it. All labels legible at mobile resolution.

## Not included (separate PR)
- Tier 3: kpiSuffix units from data pipeline (fetch-breaking.ts)