### PR TITLE
perf(home): defer Cesium parse+execute until after LCP

### DIFF
--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -4,7 +4,11 @@ import type { TrackerCardData } from '../../../lib/tracker-directory-utils';
 import { computeFreshness } from '../../../lib/tracker-directory-utils';
 import { computeCountryDensity } from '../../../lib/geo-utils';
 import { type Locale, SUPPORTED_LOCALES, getPreferredLocale, setPreferredLocale, t } from '../../../i18n/translations';
-const GlobePanel = lazy(() => import('./GlobePanel'));
+import { deferImport } from '../../../lib/defer-load';
+// Defer Cesium parse+execute (~5s of CPU on mid-tier mobile) past LCP so the
+// rest of the homepage can paint and hydrate first. Suspense fallback covers
+// the wait with the existing starfield skeleton.
+const GlobePanel = lazy(() => deferImport(() => import('./GlobePanel')));
 import SidebarPanel from './SidebarPanel';
 import type { ViewMode } from './ViewModeToggle';
 import MobileStoryCarousel from './MobileStoryCarousel';

--- a/src/lib/defer-load.ts
+++ b/src/lib/defer-load.ts
@@ -1,0 +1,24 @@
+/**
+ * Defer a dynamic import until the browser is idle, so heavy modules
+ * (Cesium, ~5s of CPU on mid-tier mobile) don't compete with the page's
+ * LCP for main-thread time. The Suspense fallback (already a starfield
+ * skeleton) covers the wait.
+ *
+ * Times out at 2s so the load is not delayed indefinitely on a busy page.
+ */
+export function deferImport<T>(factory: () => Promise<T>, timeoutMs = 2000): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const load = () => factory().then(resolve, reject);
+    if (typeof window === 'undefined') {
+      load();
+      return;
+    }
+    if ('requestIdleCallback' in window) {
+      window.requestIdleCallback(load, { timeout: timeoutMs });
+    } else {
+      // Safari < 16.4 lacks requestIdleCallback; setTimeout(0) yields the
+      // current task, which is enough to unblock the LCP paint.
+      setTimeout(load, 50);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Wrap the existing `lazy(() => import('./GlobePanel'))` in a `deferImport` helper that yields to `requestIdleCallback` (with a 2s timeout) before firing the dynamic import.
- The Cesium vendor chunk costs **~5 s of CPU on mid-tier mobile** to parse + execute. With `React.lazy` alone, the import fires inside CommandCenter's first render, so it lands in the same main-thread task as hydration and blocks LCP.
- After this change, Cesium loads only after the browser is idle, which means the page paints and the React UI hydrates first; the existing starfield/skeleton KPI Suspense fallback covers the brief wait.

## Expected Lighthouse impact (mobile)
- LCP: **5.9 s → ~2–3 s** (Cesium off the critical path)
- TTI: **6.3 s → ~3 s**
- Performance score: **67 → ~85+**
- The globe appears ~1–2 s after first paint, gracefully animated in.

## What changed
- New: `src/lib/defer-load.ts` — single tiny helper, uses `requestIdleCallback` with `setTimeout(50)` fallback for Safari < 16.4.
- Modified: `src/components/islands/CommandCenter/CommandCenter.tsx` — wraps the GlobePanel lazy import with `deferImport`.

## Why not also wrap MobileMapTab?
`MobileMapTab.tsx` already lazy-loads CesiumGlobe behind a user-initiated 2D→3D toggle (\"only imported when user confirms\"), so its parse cost is already off the LCP path.

## Test plan
- [x] `npx tsc --noEmit` — clean for touched files
- [x] `npm run build` — succeeds, all 6850 pages indexed
- [ ] Open https://watchboard.dev/ on a fresh browser → confirm the page paints first, globe appears ~1–2s later
- [ ] Re-run mobile Lighthouse against deployed version → confirm LCP < 3s
- [ ] Smoke-check broadcast mode (`B`), tracker click on globe, sidebar follow → still functional once globe loads
- [ ] Safari (lacks `requestIdleCallback` until 16.4) → falls back to `setTimeout(50)`, still loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)