### PR TITLE
perf(home): SSR mobile story carousel so LCP element exists at first paint

### DIFF
--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -485,7 +485,7 @@ export default function CommandCenter({
       : { ...styles.sidebar };
 
   return (
-    <div className="command-center-root" role="application" aria-label="Watchboard Command Center" style={styles.container}>
+    <div className={`command-center-root cc-mobile-tab-${mobileTab}`} role="application" aria-label="Watchboard Command Center" style={styles.container}>
       <h1 className="sr-only">Watchboard — Intelligence Dashboard Platform</h1>
       <NotificationManager trackers={trackers} followedSlugs={followedSlugs} />
 
@@ -682,12 +682,24 @@ export default function CommandCenter({
       {/* Mobile story carousel — rendered unconditionally so SSR HTML
           contains the LCP-critical text without waiting for JS to detect
           viewport. Hidden on desktop and on mobile when mobileTab !== 'live'
-          via the cc-mobile-live-slot CSS class (see index.astro). */}
+          via the cc-mobile-live-slot CSS class (see index.astro).
+          suppressHydrationWarning: useStoryState reads localStorage seenSlugs
+          on the client which can reorder eligible stories vs the SSR pass.
+          The structure is identical, only the rendered text may differ;
+          React updates text in-place without unmounting, so the SSR'd LCP
+          element still satisfies LCP. */}
       <div
         className={`cc-mobile-live-slot ${mobileTab === 'live' ? 'cc-mobile-live-active' : ''}`}
         style={{ flex: '1 1 0%', overflow: 'hidden', position: 'relative' as const, minHeight: 0 }}
+        suppressHydrationWarning
       >
-        <MobileStoryCarousel trackers={trackers} basePath={basePath} followedSlugs={followedSlugs} onTrackerChange={handleStoryTrackerChange} />
+        <MobileStoryCarousel
+          trackers={trackers}
+          basePath={basePath}
+          followedSlugs={followedSlugs}
+          onTrackerChange={handleStoryTrackerChange}
+          enabled={isMobile && mobileTab === 'live'}
+        />
       </div>
       <nav id="tour-sidebar" className="cc-sidebar" style={sidebarStyle} aria-label="Tracker directory">
         {!isMobile && sidebarCollapsed ? (

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -679,11 +679,16 @@ export default function CommandCenter({
           </button>
         </div>
       )}
-      {isMobile && mobileTab === 'live' && (
-        <div style={{ flex: '1 1 0%', overflow: 'hidden', position: 'relative' as const, minHeight: 0 }}>
-          <MobileStoryCarousel trackers={trackers} basePath={basePath} followedSlugs={followedSlugs} onTrackerChange={handleStoryTrackerChange} />
-        </div>
-      )}
+      {/* Mobile story carousel — rendered unconditionally so SSR HTML
+          contains the LCP-critical text without waiting for JS to detect
+          viewport. Hidden on desktop and on mobile when mobileTab !== 'live'
+          via the cc-mobile-live-slot CSS class (see index.astro). */}
+      <div
+        className={`cc-mobile-live-slot ${mobileTab === 'live' ? 'cc-mobile-live-active' : ''}`}
+        style={{ flex: '1 1 0%', overflow: 'hidden', position: 'relative' as const, minHeight: 0 }}
+      >
+        <MobileStoryCarousel trackers={trackers} basePath={basePath} followedSlugs={followedSlugs} onTrackerChange={handleStoryTrackerChange} />
+      </div>
       <nav id="tour-sidebar" className="cc-sidebar" style={sidebarStyle} aria-label="Tracker directory">
         {!isMobile && sidebarCollapsed ? (
           <div style={styles.collapsedSidebarContent}>

--- a/src/components/islands/CommandCenter/MobileStoryCarousel.tsx
+++ b/src/components/islands/CommandCenter/MobileStoryCarousel.tsx
@@ -15,6 +15,9 @@ interface Props {
   basePath: string;
   followedSlugs?: string[];
   onTrackerChange?: (slug: string) => void;
+  /** When false, suppresses rAF auto-advance + localStorage writes. Used so
+   *  the SSR-rendered carousel doesn't waste CPU on desktop or hidden tabs. */
+  enabled?: boolean;
 }
 
 // ── Constants ──
@@ -61,10 +64,10 @@ function domainGradient(domain?: string): string {
 
 // ── Component ──
 
-export default function MobileStoryCarousel({ trackers, basePath, followedSlugs = [], onTrackerChange }: Props) {
+export default function MobileStoryCarousel({ trackers, basePath, followedSlugs = [], onTrackerChange, enabled = true }: Props) {
   const locale = getPreferredLocale();
 
-  const story = useStoryState({ trackers, followedSlugs, onTrackerChange });
+  const story = useStoryState({ trackers, followedSlugs, onTrackerChange, enabled });
 
   const touchStartY = useRef<number | null>(null);
   const touchStartX = useRef<number | null>(null);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -265,6 +265,14 @@ const breakingTrackers = [...serializedTrackers]
   }
 
   /* Tablets/narrow desktops: stack globe + sidebar */
+  /* Mobile story carousel slot — always in the React tree (so SSR HTML
+     has the LCP element), hidden on desktop, hidden on mobile until the
+     'live' tab is active. */
+  .cc-mobile-live-slot { display: none; }
+  @media (max-width: 767px) {
+    .cc-mobile-live-slot.cc-mobile-live-active { display: block; }
+  }
+
   @media (max-width: 767px) {
     .command-center-root {
       flex-direction: column !important;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -265,12 +265,20 @@ const breakingTrackers = [...serializedTrackers]
   }
 
   /* Tablets/narrow desktops: stack globe + sidebar */
-  /* Mobile story carousel slot — always in the React tree (so SSR HTML
-     has the LCP element), hidden on desktop, hidden on mobile until the
-     'live' tab is active. */
+  /* Mobile-tab visibility — drive layout from CSS (not JS) so the SSR
+     HTML matches the final rendered layout on mobile. The
+     CommandCenter root carries cc-mobile-tab-{live|trackers} (defaults
+     to 'live' so SSR matches a fresh visit). On mobile, this controls
+     which slot is visible without waiting for hydration to flip
+     isMobile. */
   .cc-mobile-live-slot { display: none; }
   @media (max-width: 767px) {
     .cc-mobile-live-slot.cc-mobile-live-active { display: block; }
+    /* Default mobile state: hide the desktop sidebar layout; show only
+       when the user picks the trackers tab. Without this, the SSR's
+       desktop sidebar (rendered because isMobile=false on server) flashes
+       on top of the carousel until hydration catches up. */
+    .cc-mobile-tab-live .cc-sidebar { display: none !important; }
   }
 
   @media (max-width: 767px) {


### PR DESCRIPTION
## Problem
Mobile Lighthouse on https://watchboard.dev/ shows LCP ~6.0s on a fresh load. The LCP element is \`p.story-briefing-text\` inside MobileStoryCarousel.

The breakdown showed **1.2s of element render delay** — i.e. the LCP element doesn't exist in the SSR HTML, it only appears after the React island hydrates and the resize \`useEffect\` flips \`isMobile\` to true.

This is because \`CommandCenter\`'s JSX gates the carousel with \`{isMobile && mobileTab === 'live' && (...)}\`, and \`isMobile\` defaults to \`false\` during SSR (since \`typeof window === 'undefined'\`).

## Fix
Render \`<MobileStoryCarousel />\` unconditionally in CommandCenter's JSX, wrapped in a \`.cc-mobile-live-slot\` div. Control visibility purely via CSS:

\`\`\`css
.cc-mobile-live-slot { display: none; }
@media (max-width: 767px) {
  .cc-mobile-live-slot.cc-mobile-live-active { display: block; }
}
\`\`\`

Now the SSR HTML always contains the carousel structure with the first eligible tracker baked in, and the LCP element is discoverable at first paint on mobile. Desktop is unaffected (always \`display: none\` at \`>= 768px\`).

Verified after build: \`grep story-briefing-text dist/index.html\` → 1 match (was 0 before).

## Expected mobile Lighthouse impact
- LCP: **6.0s → ~1.5-2s**
- Performance score: ~65 → ~85+

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` succeeds, indexed 6850 pages
- [x] SSR HTML contains \`p.story-briefing-text\` (verified via grep)
- [ ] Re-run mobile Lighthouse on https://watchboard.dev/ after deploy → confirm LCP < 3s
- [ ] Smoke check on mobile viewport: carousel renders at first paint, no flash
- [ ] Smoke check on desktop viewport: globe + sidebar layout unchanged, no carousel visible
- [ ] Smoke check on mobile: switching to TRACKERS tab still shows sidebar (carousel hides via \`.cc-mobile-live-active\` removed)

## Notes
- Adds ~5KB of mobile-only HTML to the desktop bundle (the hidden carousel skeleton). Acceptable trade for mobile LCP win.
- May see brief hydration mismatch on returning mobile users whose \`localStorage seenSlugs\` reorders the carousel — React 18 reconciles this without unmounting (just text update), so no LCP regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)