### PR TITLE
perf(analytics): enable PostHog Web Vitals capture

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -122,6 +122,10 @@ const pushTrackers = loadAllTrackers()
           autocapture: true,
           capture_pageview: true,
           capture_pageleave: true,
+          // Capture LCP, FID/INP, CLS, FCP, TTFB on real user loads so we
+          // can track perf trends in PostHog Insights instead of trusting
+          // noisy single-run synthetic Lighthouse numbers.
+          capture_performance: { web_vitals: true },
         });
       });
     </script>


### PR DESCRIPTION
## Why
Synthetic Lighthouse runs against \`https://watchboard.dev/\` show wild variance (LCP from 3.8s to 7.9s on identical loads, 30-40% noise). That makes it hard to tell if the recent perf PRs (#123 defer-cesium, #124 SSR-carousel) actually moved real-user metrics — or if the regressions/improvements I'm reading are just noise.

This adds PostHog's built-in Web Vitals capture so we get actual user samples (Core Web Vitals: LCP, FID/INP, CLS, FCP, TTFB) and can make data-driven decisions about whether to roll back, double down, or try a different approach.

## What
One-line config addition to \`posthog.init()\`:
\`\`\`js
capture_performance: { web_vitals: true }
\`\`\`

PostHog auto-buffers these, sends them with each \`\$pageview\`, and surfaces them in the built-in **Web Vitals dashboard** under PostHog Insights. No new deps, no new code paths.

## Test plan
- [x] Build succeeds
- [ ] After deploy, open https://watchboard.dev/ once and verify in PostHog Insights → Web Vitals that LCP/FCP samples start appearing within a minute
- [ ] After 24h, check that we have enough samples (50+) per page to start drawing conclusions

🤖 Generated with [Claude Code](https://claude.com/claude-code)