### PR TITLE
fix(home): defer localStorage seen-set read to avoid React hydration error #418

### DIFF
--- a/src/components/islands/CommandCenter/useStoryState.ts
+++ b/src/components/islands/CommandCenter/useStoryState.ts
@@ -63,40 +63,53 @@ export function useStoryState(options: UseStoryStateOptions): StoryState {
     onTrackerChange,
   } = options;
 
-  // Read initial seen set for ordering — resets when tracker has new data
-  const initialSeenSlugs = useMemo(() => {
-    try {
-      const stored = localStorage.getItem(SEEN_STORAGE_KEY);
-      if (!stored) return new Set<string>();
-      const parsed: Record<string, { seenAt: number; dataVersion: string } | number> = JSON.parse(stored);
-      const now = Date.now();
-      const valid = Object.entries(parsed)
-        .filter(([slug, entry]) => {
-          if (typeof entry === 'number') return now - entry < SEEN_TTL_MS; // backward compat
-          if (now - entry.seenAt > SEEN_TTL_MS) return false;
-          const tracker = trackers.find((t) => t.slug === slug);
-          if (tracker && tracker.lastUpdated && entry.dataVersion !== tracker.lastUpdated) return false;
-          return true;
-        })
-        .map(([slug]) => slug);
-      return new Set(valid);
-    } catch {
-      return new Set<string>();
-    }
-  }, [trackers]);
+  // Initial seen set is read from localStorage AFTER mount via useEffect, not
+  // synchronously — otherwise the SSR pass (no localStorage) and the first
+  // client render disagree on story order, throwing React error #418
+  // (hydration text mismatch) and forcing React to discard the SSR'd LCP
+  // element. Starting empty keeps server/client identical on first render.
+  const [initialSeenSlugs, setInitialSeenSlugs] = useState<Set<string>>(() => new Set());
 
   const eligible = useMemo(
     () => filterAndSort(trackers, followedSlugs, initialSeenSlugs),
     [trackers, followedSlugs, initialSeenSlugs],
   );
 
-  const [seenSlugs, setSeenSlugs] = useState<Set<string>>(initialSeenSlugs);
+  const [seenSlugs, setSeenSlugs] = useState<Set<string>>(() => new Set());
 
-  // Start at the first unseen story instead of always index 0
-  const [currentIndex, setCurrentIndex] = useState(() => {
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(SEEN_STORAGE_KEY);
+      if (!stored) return;
+      const parsed: Record<string, { seenAt: number; dataVersion: string } | number> = JSON.parse(stored);
+      const now = Date.now();
+      const valid = Object.entries(parsed)
+        .filter(([slug, entry]) => {
+          if (typeof entry === 'number') return now - entry < SEEN_TTL_MS;
+          if (now - entry.seenAt > SEEN_TTL_MS) return false;
+          const tracker = trackers.find((t) => t.slug === slug);
+          if (tracker && tracker.lastUpdated && entry.dataVersion !== tracker.lastUpdated) return false;
+          return true;
+        })
+        .map(([slug]) => slug);
+      if (valid.length === 0) return;
+      const next = new Set(valid);
+      setInitialSeenSlugs(next);
+      setSeenSlugs(next);
+    } catch {
+      // localStorage unavailable; stay with empty default
+    }
+  }, [trackers]);
+
+  // Start at index 0 to match SSR; jump to first unseen once seen-set loads
+  const [currentIndex, setCurrentIndex] = useState(0);
+  useEffect(() => {
+    if (seenSlugs.size === 0) return;
     const firstUnseen = eligible.findIndex((t) => !seenSlugs.has(t.slug));
-    return firstUnseen >= 0 ? firstUnseen : 0;
-  });
+    if (firstUnseen > 0) setCurrentIndex(firstUnseen);
+    // Only run once when seenSlugs populates from localStorage
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [seenSlugs.size > 0]);
   const [slideIndex, setSlideIndex] = useState(0);
   const slideIndexRef = useRef(0);
   const [paused, setPaused] = useState(false);


### PR DESCRIPTION
## Bug
Production console (https://watchboard.dev/) was throwing:
\`\`\`
Uncaught Error: Minified React error #418; visit https://react.dev/errors/418
\`\`\`
That's a text content hydration mismatch. After #124 SSR'd the MobileStoryCarousel, \`useStoryState\` was computing \`initialSeenSlugs\` via a synchronous \`useMemo\` that reads \`localStorage\`. Server returns empty (no localStorage); client returns persisted seen slugs for returning visitors. Different seen sets → different sort order in \`eligible\` → different first-rendered headline / briefing text → React 18 throws #418, discards the SSR'd subtree, re-renders on the client.

Net effect: console error + the SSR'd LCP element (the whole point of #124) is thrown away for any returning visitor.

## Fix
Move the localStorage read into a \`useEffect\` so first server and first client render both see an empty seen set → identical HTML → no hydration mismatch. After mount the effect populates the seen set, the carousel re-renders into the correct order, and \`currentIndex\` jumps to the first unseen story.

User-visible effect: a brief story reorder ~50ms after hydration. No console error. The SSR'd LCP element is no longer discarded for returning visitors.

\`suppressHydrationWarning\` is already on the slot div but only applies one level deep — it cannot silence text mismatches in nested children like \`p.story-briefing-text\`.

## Test plan
- [x] \`tsc\` clean
- [x] \`npm run build\` succeeds
- [ ] After deploy, open https://watchboard.dev/ on mobile + browser with seen-set in localStorage → confirm no #418 error, carousel renders, first unseen story shows after ~50ms reorder
- [ ] Fresh browser load → tour and carousel still work as before
- [ ] Verify in PostHog Web Vitals (after #125 deploy) that LCP samples for returning visitors stop dropping back to high values

🤖 Generated with [Claude Code](https://claude.com/claude-code)