### PR TITLE
docs: sync CLAUDE.md / CHANGELOG.md / BACKLOG.md / posthog-setup.md with 2026-04-26 changes

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,6 +1,6 @@
 # Feature Backlog
 
-Last updated: 2026-03-10
+Last updated: 2026-04-26
 
 Reviewed by: Prometeo (PM), Forja (Dev), Centinela (QA) — second-pass consensus applied
 
@@ -39,6 +39,9 @@ Reviewed by: Prometeo (PM), Forja (Dev), Centinela (QA) — second-pass consensu
 | BL-020 | API health indicator | Client-side data source status (green/yellow/red) for OpenSky, USGS, Open-Meteo, Cesium Ion. Pairs with BL-012 as trust signal | S | Dev + PM: moved earlier — trust signal, not polish |
 | BL-021 | Political section source chips | Every section has tier badges except Political — credibility consistency gap | XS | PM: low effort, closes visible inconsistency |
 | BL-024 | KPI trend deltas | Add optional `delta` field to `KpiSchema` showing change direction/magnitude on each KPI card | S | PM: flagged from March 4 assessment, was silently dropped |
+| BL-025 | Migrate from GitHub Pages to Cloudflare Pages | Lighthouse measured 1.8-2.5s TTFB on GH Pages; Cloudflare Pages typically 200-400ms + automatic Brotli (~15-25% smaller than gzip) + better LATAM/EU edge presence. No code changes — DNS swap. Highest ROI/hour of any remaining perf lever. | S | Dev: deferred 2026-04-26 after defer-cesium + SSR-carousel didn't move LCP enough. Confirms with PostHog Web Vitals before/after |
+| BL-026 | Cut homepage HTML payload | `serializedTrackers` includes all 95 trackers' headlines, KPIs, eventImages, digestSummary in initial HTML (157 KB document). Lazy-load detail fields per tracker; keep only what's needed for first paint of cards/sidebar. Estimated -500-800ms LCP via download-time savings. | M | Dev: highest-ROI single code change for perf. Touches `src/pages/index.astro` serialization + relevant island prop shapes |
+| BL-027 | Tree-shake Cesium bundle | Migrate from monolithic `cesium` package import to `@cesium/engine` + `@cesium/widgets` modular imports. Bundle 4.3 MB → ~1.5-2 MB; mobile parse 5s → 2s. Bigger refactor — affects every Cesium import site. | L | Dev: deferred until BL-025 + BL-026 are measured. Pairs with BL-018 (bundle analysis) for verification |
 
 ## P3 — Low Priority / Deferred
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — 2026-04-26
+- **Multi-step onboarding tour** (#122): replaces the single-toast welcome with a 6-step guided desktop tour (hero → globe → sidebar → broadcast ticker → source-tier explainer → closing) and a 3-step mobile bottom-sheet flow. Versioned localStorage keys (`watchboard-tour-{desktop,mobile}-v1`) with one-shot legacy migration. Replay button in the `?` shortcuts panel (with last-completed timestamp); mobile gets a small ↻ button on the carousel.
+  - New: `src/components/islands/Onboarding/{OnboardingTour,MobileOnboarding,SpotlightStep,HeroStep}.tsx`
+  - New: `src/lib/onboarding-steps.ts` + tests; `src/lib/onboarding.ts` extended with tour persistence API and legacy-key migration
+  - Spec: `docs/superpowers/specs/2026-04-25-onboarding-redesign-design.md`
+- **PostHog Web Vitals capture** (#125): `capture_performance: { web_vitals: true }` on `posthog.init` to collect real-user LCP/INP/CLS/FCP/TTFB samples. Surfaced in PostHog → Insights → Web Vitals.
+
+### Changed — 2026-04-26
+- **Defer Cesium parse+execute past LCP** (#123): wrap the lazy `GlobePanel` import in a `deferImport(() => ...)` helper that yields to `requestIdleCallback` (with `setTimeout(50)` fallback for Safari < 16.4). Cesium's ~5s of CPU on mid-tier mobile no longer competes with homepage paint and React hydration. Verified: vendor-globe long-task dropped from 5018 ms to 178 ms post-deploy.
+  - New: `src/lib/defer-load.ts`
+- **SSR mobile story carousel** (#124): render `<MobileStoryCarousel>` unconditionally in `CommandCenter` JSX so the LCP-critical text exists in initial HTML. Visibility now controlled purely by a `.cc-mobile-live-slot` CSS @media rule. Adds a `cc-mobile-tab-{live|trackers}` class on the root so the mobile sidebar is also CSS-driven (prevents pre-hydration desktop-sidebar flash). Wires the `enabled` prop on `useStoryState` so the carousel does not run rAF or write to localStorage when hidden.
+
+### Fixed — 2026-04-26
+- **React hydration error #418 on returning visitors** (#126): `useStoryState` was reading `localStorage.seenSlugs` synchronously in `useMemo`, which reorders eligible stories on the client and caused text mismatch with the SSR pass. Move the read into a `useEffect` so first server and first client render both see an empty seen set; the carousel re-renders into the correct order ~50 ms post-hydration.
+- **Globe double-spin on tracker click** (#127): `handleSelect` triggered two camera flights — `broadcast.jumpTo()` (distance-aware altitude) then `GlobePanel`'s `activeTracker` `useEffect` (altitude 1.8). Skip the latter when `broadcastMode` is on, mirroring the symmetric check on the deselect effect. Effect dep list updated to depend on `trackers` (stable prop) instead of the unmemoized `hubPoints`.
+
 ### Added
 - **Social Command Center — config and seed files**: `social-config.json` at project root (base URL, handle, budget, API costs, scheduling slots, judge thresholds, hashtag rules, languages, tweet types); `public/_social/budget.json` (monthly budget tracker, seeded at $0 spent for 2026-04); `public/_social/history.json` (empty array, seed for posted tweet log)
 - **SEO: Sitemap generation**: `@astrojs/sitemap` integration auto-generates `sitemap-index.xml` and `sitemap-0.xml` at build time with all page URLs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,8 @@ Client-hydrated interactive components:
 - **`MetricsDashboard.tsx`** — Salesforce-style ingestion status page with uptime calendar, KPI cards, per-tracker health table, expandable run log, error trend chart
 - **`CesiumGlobe/`** — 3D globe with missile animations, satellites, earthquakes, cinematic event mode (`useCinematicMode.ts`). Globe is fully parameterized — camera presets, categories, and initial view come from `tracker.json` props, not hardcoded.
 - **`BroadcastOverlay.tsx`** — TV news broadcast mode for homepage globe. Lower-third headlines, scrolling ticker, LIVE badge. Auto-cycles through trackers with smooth globe fly-tos. Uses `useBroadcastMode.ts` hook (state machine: idle → transitioning → dwelling). Toggle with `B` key.
-- **`MobileStoryCarousel.tsx`** — Instagram Stories-style carousel on mobile homepage. Circle avatar row, auto-advancing story cards (10s), 3-tier image fallback (verified event media → OSM map tile → domain gradient), swipe-up to open tracker.
+- **`MobileStoryCarousel.tsx`** — Instagram Stories-style carousel on mobile homepage. Circle avatar row, auto-advancing story cards (10s), 3-tier image fallback (verified event media → OSM map tile → domain gradient), swipe-up to open tracker. Always present in the SSR HTML (visibility via `.cc-mobile-live-slot` CSS @media); the `enabled` prop suppresses the rAF auto-advance and `localStorage` writes when hidden on desktop.
+- **`Onboarding/`** — first-visit guided tour. `OnboardingTour.tsx` (6-step desktop controller), `MobileOnboarding.tsx` (3-step bottom-sheet), `SpotlightStep.tsx` (SVG-mask spotlight + auto-positioned tooltip primitive), `HeroStep.tsx` (fullscreen hero / tier-explainer / closing variants). Triggers from `localStorage.watchboard-tour-{desktop,mobile}-v1` (versioned, with one-shot legacy migration). Replayable via the `?` shortcuts panel on desktop and the ↻ button on the mobile carousel.
 
 ### Nightly Update Pipeline
 
@@ -200,6 +201,9 @@ AI-curated social media posting system. Replaces the old `generate-social-drafts
 - `constants.ts` — `NAV_SECTIONS`, `MIL_TABS` (loaded from default tracker config)
 - `timeline-utils.ts` — `flattenTimelineEvents()`, `resolveEventDate()` (supports "Mon DD, YYYY" and "Mon DD" formats)
 - `cesium-config.ts` — `configureCesium()`, `CameraPreset` type, `CameraPresetsMap` type (presets come from tracker.json, not hardcoded)
+- `onboarding.ts` — tour persistence (`getTourState`, `markTourComplete`, `resetTour`, `isTourCompleted`) backed by versioned localStorage keys + one-shot legacy migration. Also keeps the older `COACH_HINTS` queue for post-tour micro-discovery hints.
+- `onboarding-steps.ts` — pure step config: `DESKTOP_STEPS` (6) + `MOBILE_STEPS` (3) consumed by the Onboarding controllers.
+- `defer-load.ts` — `deferImport(factory)` wraps `React.lazy()` factories with `requestIdleCallback` (with `setTimeout(50)` fallback) so heavy chunks like Cesium are not parsed during the LCP/hydration window. Used at `CommandCenter.tsx` for `GlobePanel`.
 
 ### Scripts (`scripts/`)
 

--- a/docs/posthog-setup.md
+++ b/docs/posthog-setup.md
@@ -56,11 +56,19 @@
 - [ ] Create retention insight: users who visited on Day 0 → returned on Day 1, 7, 30
 - [ ] Group by `tracker_slug` to see which trackers have the stickiest audience
 
-## 7. Web Vitals (Optional)
+## 7. Web Vitals (Enabled)
 
-- [ ] PostHog autocaptures Web Vitals if enabled
-- [ ] Check PostHog → Web Analytics → Web Vitals tab
-- [ ] Compare with Cloudflare Web Analytics Core Web Vitals data
+Watchboard collects Core Web Vitals from real users via PostHog's built-in capture. Configured in `src/layouts/BaseLayout.astro` as `capture_performance: { web_vitals: true }` on `posthog.init`.
+
+PostHog auto-buffers and sends LCP, INP (replaces FID), CLS, FCP, and TTFB samples with each `$pageview`. No additional client code required.
+
+- [ ] In PostHog → **Web Analytics** → **Web Vitals** tab, confirm samples are arriving (typically 1-2 hours of normal traffic for a meaningful baseline)
+- [ ] Filter by `$device_type` (desktop vs mobile) — perf budgets differ
+- [ ] Filter by `$current_url` to compare homepage vs tracker pages
+- [ ] Watch the **p75 LCP** trend over time as the canonical mobile perf metric
+- [ ] Cross-check against Cloudflare Web Analytics Core Web Vitals (independent measurement source)
+
+**Tip:** real-user metrics smooth out the variance that simulated Lighthouse runs suffer (~30-40% spread on the same site). Use these for go/no-go on perf changes; reserve Lighthouse for deep dives on individual loads.
 
 ## 8. Alerts (Optional)
 


### PR DESCRIPTION
Documents today's six PRs (#122-#127) so future agents/devs aren't reading stale docs.

## Changes

**CLAUDE.md**
- React Islands list: register the new \`Onboarding/\` folder (\`OnboardingTour\`, \`MobileOnboarding\`, \`SpotlightStep\`, \`HeroStep\`).
- \`MobileStoryCarousel.tsx\` entry updated to note the new SSR + CSS-driven visibility pattern and the \`enabled\` prop.
- Utilities (\`src/lib/\`) list: register \`onboarding.ts\`, \`onboarding-steps.ts\`, \`defer-load.ts\`.

**CHANGELOG.md**
- New \`Added — 2026-04-26\` / \`Changed — 2026-04-26\` / \`Fixed — 2026-04-26\` block covering all six PRs with file paths and verified perf numbers.

**BACKLOG.md**
- \`BL-025\` Cloudflare Pages migration (highest ROI/hour remaining lever).
- \`BL-026\` Cut homepage HTML payload (95-tracker serialization is 157 KB).
- \`BL-027\` Tree-shake Cesium bundle.
- Last-updated date bumped to 2026-04-26.

**docs/posthog-setup.md**
- Section 7 rewritten: was \"Web Vitals (Optional)\", now \"Web Vitals (Enabled)\" with concrete pointers (which metric to watch, why filter by device type, etc.).

## Test plan
- [x] Reads as accurate against the actual code on \`main\`
- [x] No broken markdown
- [ ] PR review for tone / completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)