### PR TITLE
fix(ci): bump action versions + give finalize headroom + drop bad input

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/batch-init-trackers.yml
+++ b/.github/workflows/batch-init-trackers.yml
@@ -24,10 +24,10 @@ jobs:
     timeout-minutes: 720
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/daily-video.yml
+++ b/.github/workflows/daily-video.yml
@@ -17,12 +17,12 @@ jobs:
     if: github.event_name != 'push'
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -200,12 +200,12 @@ jobs:
     if: github.event_name != 'push'
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/hourly-scan.yml
+++ b/.github/workflows/hourly-scan.yml
@@ -22,8 +22,8 @@ jobs:
       has_actions: ${{ steps.freshness.outputs.has_actions || steps.triage.outputs.has_actions || steps.triage-defaults.outputs.has_actions || 'false' }}
       plan_json: ${{ steps.freshness.outputs.plan_json || steps.triage.outputs.plan_json || steps.triage-defaults.outputs.plan_json || '[]' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
       - run: npm ci
@@ -321,10 +321,10 @@ jobs:
       matrix:
         entry: ${{ fromJSON(needs.scan.outputs.plan_json) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
       - run: npm ci

--- a/.github/workflows/init-tracker.yml
+++ b/.github/workflows/init-tracker.yml
@@ -55,10 +55,10 @@ jobs:
       built: ${{ steps.build_test.outputs.build }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -400,7 +400,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
 
@@ -414,7 +414,7 @@ jobs:
           echo "Tracker ${SLUG} found, proceeding with seed"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/post-social-queue.yml
+++ b/.github/workflows/post-social-queue.yml
@@ -17,9 +17,9 @@ jobs:
     if: github.event_name != 'push'
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/seed-tracker.yml
+++ b/.github/workflows/seed-tracker.yml
@@ -23,10 +23,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/tally-tracker-votes.yml
+++ b/.github/workflows/tally-tracker-votes.yml
@@ -22,10 +22,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 

--- a/.github/workflows/telegram-notify.yml
+++ b/.github/workflows/telegram-notify.yml
@@ -27,11 +27,11 @@ jobs:
     # Run on push (always) or workflow_run (only if succeeded)
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main  # Always read latest main (hourly-scan may have pushed)
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
 

--- a/.github/workflows/tracker-lifecycle.yml
+++ b/.github/workflows/tracker-lifecycle.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Extract existing tracker coverage
         id: coverage
@@ -172,7 +172,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Detect archive candidates
         env:

--- a/.github/workflows/translate-data.yml
+++ b/.github/workflows/translate-data.yml
@@ -33,10 +33,10 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -28,10 +28,10 @@ jobs:
       hourly_updates: ${{ steps.hourly.outputs.hourly_updates }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -166,10 +166,10 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -365,13 +365,16 @@ jobs:
     needs: [resolve, update]
     if: always()
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 20 min was hitting the wall — Astro build (95 trackers, ~6800 pages) is
+    # ~10-15 min on its own, then social-queue generation adds 1-3 min. Giving
+    # 45 min of headroom so the rare slow run doesn't get killed mid-push.
+    timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -972,7 +975,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
-          timeout_minutes: 5
+          # timeout_minutes is not a valid input for this action; the
+          # job-level timeout-minutes (above) bounds the run instead.
           prompt: |
             Read the file public/_social/prompt-latest.txt — it contains a complete prompt for generating a social media queue.
 

--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -18,9 +18,9 @@ jobs:
     env:
       NEWSLETTER_SECRET: ${{ secrets.NEWSLETTER_SECRET }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## What
Three CI hygiene fixes in one PR.

### 1. Bump \`actions/checkout@v4 → @v5\` and \`actions/setup-node@v4 → @v5\` across all 14 workflow files
GitHub deprecation warning visible in every workflow log: these v4 actions run on Node 20, which the runner will **force to Node 24 on 2026-06-02** and **fully remove on 2026-09-16**. Bumping puts us on Node 24 ahead of the deadline, no surprise breakage on June 2.

### 2. Bump nightly finalize \`timeout-minutes\` from 20 → 45
The 14:00 UTC nightly was getting marked **cancelled 4 of the last 5 runs** (Apr 22/23/24/26), even though the actual data update + push had **succeeded** (verified: \`1eb7ed1..e414a85 main -> main\` in the Apr 26 log).

The finalize step does:
- Apply tracker artifacts → JSON + Zod validation → optional fix agent
- **Astro build** (95 trackers, ~6800 pages = ~10-15 min)
- Generate social queue via Claude (1-3 min)
- Commit + push data and metrics

20 minutes was on the edge; one slow runner pushes it over. 45 min gives comfortable headroom without being absurd.

### 3. Drop invalid \`timeout_minutes: 5\` input from the social-queue Claude action step
Warning in every nightly log: \`Unexpected input(s) 'timeout_minutes'\`. The action does not accept that key (it's not in its inputs list). Job-level \`timeout-minutes\` already bounds it.

## Not in scope
- **Translate Tracker Data** has had no runs since Apr 14, but that's intentional — the schedule and workflow_run triggers are commented out (\"Disabled — translations done locally via OpenClaw Bedrock\" / Claude Max rate limit clash with nightly). Manual dispatch only. Not a regression.
- **\`oven-sh/setup-bun\` Node 20 warning** comes from inside \`anthropics/claude-code-action\`'s own deps, not from our workflows. Upstream's problem to fix.

## Test plan
- [x] All workflow files still YAML-valid (sed touched only \`@v4\` → \`@v5\` strings)
- [x] No remaining \`@v4\` for checkout / setup-node (verified by grep)
- [ ] After merge, watch the next nightly (14:00 UTC tomorrow) — expect: completes within 45 min, marked \`success\`, no \`Unexpected input(s)\` warning in the log
- [ ] Spot-check the deploy workflow on this PR's commit — should still be green

🤖 Generated with [Claude Code](https://claude.com/claude-code)