### PR TITLE
feat(scan): breaking-news pipeline redesign — light scan + dynamic feeds + realtime + audit page

### DIFF
--- a/.github/workflows/light-scan.yml
+++ b/.github/workflows/light-scan.yml
@@ -1,0 +1,43 @@
+name: Hourly Light Scan
+
+on:
+  schedule:
+    - cron: '0,15,30,45 * * * *'   # every 15 minutes
+  workflow_dispatch: {}
+
+concurrency:
+  group: hourly-light-scan
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+      - run: npm ci
+
+      - name: Run light scan
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID:   ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: npx tsx scripts/hourly-light-scan.ts
+
+      - name: Commit pending-candidates + triage-log + state
+        run: |
+          git config user.name  "watchboard-bot"
+          git config user.email "bot@watchboard.dev"
+          git add public/_hourly/pending-candidates.json public/_hourly/triage-log.json public/_hourly/state.json || true
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(light-scan): update pending + audit + state $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            for i in 1 2 3; do
+              if git pull --rebase origin main && git push origin main; then break; fi
+              echo "retry $i"; sleep 5
+            done
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ Metrics schemas: `MetricsRunSchema`, `MetricsIndexEntrySchema`, `MetricsInventor
 - `src/pages/[tracker]/about.astro` — about page per tracker
 - `src/pages/search.astro` — full-text search page (Pagefind UI, dark themed)
 - `src/pages/metrics.astro` — ingestion metrics dashboard (Salesforce-style status page)
+- `src/pages/breaking-news-audit.astro` — public audit page for the breaking-news pipeline (reads `public/_hourly/triage-log.json` at runtime)
 - `src/pages/rss.xml.ts` — global RSS feed (all tracker digests)
 - `src/pages/[tracker]/rss.xml.ts` — per-tracker RSS feed
 
@@ -207,6 +208,10 @@ AI-curated social media posting system. Replaces the old `generate-social-drafts
 - `onboarding.ts` — tour persistence (`getTourState`, `markTourComplete`, `resetTour`, `isTourCompleted`) backed by versioned localStorage keys + one-shot legacy migration. Also keeps the older `COACH_HINTS` queue for post-tour micro-discovery hints.
 - `onboarding-steps.ts` — pure step config: `DESKTOP_STEPS` (6) + `MOBILE_STEPS` (3) consumed by the Onboarding controllers.
 - `defer-load.ts` — `deferImport(factory)` wraps `React.lazy()` factories with `requestIdleCallback` (with `setTimeout(50)` fallback) so heavy chunks like Cesium are not parsed during the LCP/hydration window. Used at `CommandCenter.tsx` for `GlobePanel`.
+- `tracker-feeds.ts` — `REGION_FEEDS`/`DOMAIN_FEEDS` registry + `resolveFeedsForActiveTrackers()` so adding a tracker auto-extends the breaking-news source list.
+- `keyword-match.ts` — `buildKeywordIndex(tracker)` + `scoreCandidate(candidate, index)`. Pure deterministic scoring used by the light scan.
+- `triage-log.ts` — append + 14-day prune helpers backing the audit page.
+- `realtime-sources.ts` — `pollBluesky()` + `pollTelegram()` returning the same `Candidate` shape as RSS.
 
 ### Scripts (`scripts/`)
 
@@ -216,6 +221,7 @@ AI-curated social media posting system. Replaces the old `generate-social-drafts
 - `backfill-media.ts` — enriches existing events with `media` arrays by fetching `og:image` and `og:video` from source URLs. Walks both `data/events/*.json` partitions and `data/timeline.json` era-grouped events. Flags: `--dry-run`, `--tracker <slug>`.
 - `backfill-wikimedia.ts` — Wikipedia REST `page/summary` + full-text search fallback for events without source URLs (typical for pre-internet historical events). With `--videos`, switches to Wikimedia Commons `filetype:video` search and attaches `.webm/.ogv/.mp4` clips with still-frame thumbnails. Idempotent across re-runs.
 - `backfill-youtube.ts` — YouTube Data API v3 search scoped to a curated list of trustworthy news channels (Reuters, AP, BBC, AlJazeera, CNN, etc.). Only processes events dated 1990+. Requires `YOUTUBE_API_KEY` env var (free tier = 10k units/day = ~100 searches; budget per-tracker via `--max N`).
+- `hourly-light-scan.ts` — 15-min cron via `.github/workflows/light-scan.yml`. Polls a curated subset + realtime sources, scores via `keyword-match.ts`, posts to Telegram on score ≥ 0.85, defers 0.5–0.85 to `pending-candidates.json`, discards below 0.5. No LLM call.
 
 ### Tracker request voting (`/vote`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
-        "@atproto/api": "^0.15.0",
+        "@atproto/api": "^0.15.27",
         "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
         "@cloudflare/workers-types": "^4.20260410.1",
         "@playwright/test": "^1.58.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
-    "@atproto/api": "^0.15.0",
+    "@atproto/api": "^0.15.27",
     "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
     "@cloudflare/workers-types": "^4.20260410.1",
     "@playwright/test": "^1.58.2",

--- a/scripts/hourly-light-scan.ts
+++ b/scripts/hourly-light-scan.ts
@@ -134,7 +134,7 @@ async function main() {
       if (s > bestScore) { bestScore = s; bestSlug = tracker.slug; }
     }
 
-    if (bestScore >= HIGH_THRESHOLD) {
+    if (bestScore >= HIGH_THRESHOLD && bestSlug) {
       cand.matchedTracker = bestSlug;
       await postTelegram(cand, bestScore, bestSlug);
       posted++;

--- a/scripts/hourly-light-scan.ts
+++ b/scripts/hourly-light-scan.ts
@@ -1,0 +1,175 @@
+/**
+ * hourly-light-scan.ts
+ *
+ * Fast 15-min scan: polls a curated subset of high-signal feeds + Bluesky +
+ * Telegram, scores each candidate against active trackers via deterministic
+ * keyword matching, posts to Telegram on HIGH score (>= 0.85), defers
+ * MODERATE (0.5..0.85) to pending-candidates.json for the next heavy scan,
+ * and discards LOW (< 0.5) to the audit log.
+ *
+ * No LLM call — by design, this path is keyword-only.
+ */
+import { writeFileSync, readFileSync, existsSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
+import { XMLParser } from 'fast-xml-parser';
+import {
+  type Candidate,
+  type PendingCandidates,
+  type TriageLogEntry,
+  PATHS,
+  loadState,
+  saveState,
+  normalizeCandidate,
+} from './hourly-types.js';
+import { buildKeywordIndex, scoreCandidate } from '../src/lib/keyword-match.js';
+import { pollRealtimeSources } from '../src/lib/realtime-sources.js';
+import { appendTriageEntries } from '../src/lib/triage-log.js';
+import { loadAllTrackers } from '../src/lib/tracker-registry.js';
+
+const HIGH_THRESHOLD     = 0.85;
+const MODERATE_THRESHOLD = 0.50;
+
+/** Curated high-signal RSS feeds for the light scan only. The heavy scan
+ *  uses the wider list. */
+const LIGHT_RSS_FEEDS = [
+  { url: 'https://feeds.reuters.com/reuters/worldNews',                tier: 2 as const, source: 'reuters' },
+  { url: 'https://feeds.bbci.co.uk/news/world/rss.xml',                tier: 2 as const, source: 'bbc' },
+  { url: 'https://news.google.com/rss?hl=en-US&gl=US&ceid=US:en',      tier: 2 as const, source: 'google-news-en' },
+  { url: 'https://news.google.com/rss?hl=es-419&gl=MX&ceid=MX:es-419', tier: 2 as const, source: 'google-news-mx' },
+];
+
+async function pollLightFeeds(): Promise<Candidate[]> {
+  const out: Candidate[] = [];
+  const parser = new XMLParser({ ignoreAttributes: false });
+  for (const f of LIGHT_RSS_FEEDS) {
+    try {
+      const res = await fetch(f.url, { headers: { 'User-Agent': 'WatchboardLightScan/1.0' } });
+      if (!res.ok) continue;
+      const xml = await res.text();
+      const doc = parser.parse(xml);
+      const items: any[] = doc?.rss?.channel?.item ?? doc?.feed?.entry ?? [];
+      for (const item of items.slice(0, 25)) {
+        const title = item.title?.['#text'] ?? item.title ?? '';
+        const link  = item.link?.['#text'] ?? item.link ?? item.guid ?? '';
+        if (!title || !link || typeof link !== 'string') continue;
+        out.push(normalizeCandidate(
+          { title: String(title), url: link, source: f.source, timestamp: new Date().toISOString() },
+          null,
+          'rss',
+          { sourceTier: f.tier },
+        ));
+      }
+    } catch (err) {
+      console.warn(`[light-scan] rss fetch failed for ${f.url}:`, (err as Error).message);
+    }
+  }
+  return out;
+}
+
+function dedup(cands: Candidate[], seenUrls: Set<string>): Candidate[] {
+  const fresh: Candidate[] = [];
+  for (const c of cands) {
+    if (seenUrls.has(c.url)) continue;
+    seenUrls.add(c.url);
+    fresh.push(c);
+  }
+  return fresh;
+}
+
+function loadPending(path: string): PendingCandidates {
+  if (!existsSync(path)) return { version: 1, entries: [] };
+  try {
+    const raw = JSON.parse(readFileSync(path, 'utf8')) as PendingCandidates;
+    if (raw.version !== 1 || !Array.isArray(raw.entries)) return { version: 1, entries: [] };
+    return raw;
+  } catch { return { version: 1, entries: [] }; }
+}
+
+function savePending(p: PendingCandidates, path: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(p, null, 2), 'utf8');
+}
+
+async function postTelegram(candidate: Candidate, score: number, trackerSlug: string): Promise<void> {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  const chatId = process.env.TELEGRAM_CHAT_ID;
+  if (!token || !chatId) {
+    console.warn('[light-scan] TELEGRAM_BOT_TOKEN/CHAT_ID missing; skipping post');
+    return;
+  }
+  const text = `⚡ *Breaking* (${trackerSlug}, score ${score.toFixed(2)})\n${candidate.title}\n${candidate.url}`;
+  const res = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chat_id: chatId, text, parse_mode: 'Markdown', disable_web_page_preview: false }),
+  });
+  if (!res.ok) console.warn('[light-scan] telegram post failed:', await res.text());
+}
+
+async function main() {
+  const state = loadState();
+  const seenUrls = new Set(state.seen.map((s) => s.url));
+
+  const trackers = loadAllTrackers().filter((t) => t.status === 'active');
+  if (trackers.length === 0) { console.log('[light-scan] no active trackers'); return; }
+
+  const indexes = trackers.map((t) => ({
+    tracker: t,
+    index: buildKeywordIndex({ slug: t.slug, keywords: (t as any).keywords, searchContext: (t as any).searchContext }),
+  }));
+
+  const [rss, realtime] = await Promise.all([pollLightFeeds(), pollRealtimeSources()]);
+  const fresh = dedup([...rss, ...realtime], seenUrls);
+  console.log(`[light-scan] ${fresh.length} fresh candidates after dedup`);
+
+  const pending = loadPending(PATHS.pendingCandidates);
+  const logEntries: TriageLogEntry[] = [];
+  let posted = 0, deferred = 0, discarded = 0;
+
+  for (const cand of fresh) {
+    let bestScore = 0;
+    let bestSlug = '';
+    for (const { tracker, index } of indexes) {
+      const s = scoreCandidate(cand, index);
+      if (s > bestScore) { bestScore = s; bestSlug = tracker.slug; }
+    }
+
+    if (bestScore >= HIGH_THRESHOLD) {
+      cand.matchedTracker = bestSlug;
+      await postTelegram(cand, bestScore, bestSlug);
+      posted++;
+      logEntries.push({
+        timestamp: new Date().toISOString(), candidate: cand,
+        decision: 'update', reason: `light-scan posted directly (score ${bestScore.toFixed(2)})`,
+        confidence: bestScore, model: null, scanType: 'light',
+      });
+    } else if (bestScore >= MODERATE_THRESHOLD) {
+      cand.matchedTracker = bestSlug;
+      pending.entries.push({ candidate: cand, score: bestScore, recordedAt: new Date().toISOString() });
+      deferred++;
+      logEntries.push({
+        timestamp: new Date().toISOString(), candidate: cand,
+        decision: 'defer', reason: `deferred to next heavy scan (score ${bestScore.toFixed(2)})`,
+        confidence: bestScore, model: null, scanType: 'light',
+      });
+    } else {
+      discarded++;
+      logEntries.push({
+        timestamp: new Date().toISOString(), candidate: cand,
+        decision: 'discard', reason: `low score (${bestScore.toFixed(2)})`,
+        confidence: bestScore, model: null, scanType: 'light',
+      });
+    }
+
+    state.seen.push({ url: cand.url, tracker: bestSlug || '', eventId: '', ts: new Date().toISOString() });
+  }
+
+  savePending(pending, PATHS.pendingCandidates);
+  appendTriageEntries(logEntries, PATHS.triageLog);
+  state.lastScan = new Date().toISOString();
+  saveState(state);
+
+  console.log(`[light-scan] done: posted=${posted} deferred=${deferred} discarded=${discarded}`);
+}
+
+main().catch((err) => { console.error('[light-scan] fatal:', err); process.exit(1); });

--- a/scripts/hourly-light-scan.ts
+++ b/scripts/hourly-light-scan.ts
@@ -23,7 +23,7 @@ import {
 } from './hourly-types.js';
 import { buildKeywordIndex, scoreCandidate } from '../src/lib/keyword-match.js';
 import { pollRealtimeSources } from '../src/lib/realtime-sources.js';
-import { appendTriageEntries } from '../src/lib/triage-log.js';
+import { appendTriageEntries, pruneTriageLog } from '../src/lib/triage-log.js';
 import { loadAllTrackers } from '../src/lib/tracker-registry.js';
 
 const HIGH_THRESHOLD     = 0.85;
@@ -97,11 +97,15 @@ async function postTelegram(candidate: Candidate, score: number, trackerSlug: st
     console.warn('[light-scan] TELEGRAM_BOT_TOKEN/CHAT_ID missing; skipping post');
     return;
   }
-  const text = `⚡ *Breaking* (${trackerSlug}, score ${score.toFixed(2)})\n${candidate.title}\n${candidate.url}`;
+  // Use plain text instead of Markdown to avoid escaping headache — headlines
+  // routinely contain `_`, `*`, `[`, `]`, `(`, `)` which Telegram's Markdown
+  // parser treats as formatting. Plain text + URL preview gives the same UX
+  // without the breakage risk.
+  const text = `⚡ Breaking (${trackerSlug}, score ${score.toFixed(2)})\n${candidate.title}\n${candidate.url}`;
   const res = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ chat_id: chatId, text, parse_mode: 'Markdown', disable_web_page_preview: false }),
+    body: JSON.stringify({ chat_id: chatId, text, disable_web_page_preview: false }),
   });
   if (!res.ok) console.warn('[light-scan] telegram post failed:', await res.text());
 }
@@ -113,9 +117,20 @@ async function main() {
   const trackers = loadAllTrackers().filter((t) => t.status === 'active');
   if (trackers.length === 0) { console.log('[light-scan] no active trackers'); return; }
 
+  // Build keyword indexes from the actual tracker.json schema:
+  //  - tracker.tags: array of free-form keyword hints (e.g. "Mexico", "PRI")
+  //  - tracker.name: full display name as fallback signal
+  //  - tracker.ai.searchContext: prose context the nightly pipeline uses
   const indexes = trackers.map((t) => ({
     tracker: t,
-    index: buildKeywordIndex({ slug: t.slug, keywords: (t as any).keywords, searchContext: (t as any).searchContext }),
+    index: buildKeywordIndex({
+      slug: t.slug,
+      keywords: [
+        ...(Array.isArray(t.tags) ? t.tags : []),
+        ...(t.name ? [t.name] : []),
+      ],
+      searchContext: t.ai?.searchContext,
+    }),
   }));
 
   const [rss, realtime] = await Promise.all([pollLightFeeds(), pollRealtimeSources()]);
@@ -166,6 +181,10 @@ async function main() {
 
   savePending(pending, PATHS.pendingCandidates);
   appendTriageEntries(logEntries, PATHS.triageLog);
+  // Independent prune from the heavy scan so the audit log stays bounded
+  // even if the heavy pipeline is paused/failing.
+  const removedFromLog = pruneTriageLog(PATHS.triageLog, 14);
+  if (removedFromLog > 0) console.log(`[light-scan] pruned ${removedFromLog} log entries older than 14 days`);
   state.lastScan = new Date().toISOString();
   saveState(state);
 

--- a/scripts/hourly-scan.ts
+++ b/scripts/hourly-scan.ts
@@ -16,6 +16,9 @@ import {
   normalizeCandidate,
   PATHS,
 } from './hourly-types.js';
+import { resolveFeedsForActiveTrackers } from '../src/lib/tracker-feeds.js';
+import { pollRealtimeSources } from '../src/lib/realtime-sources.js';
+import { loadAllTrackers } from '../src/lib/tracker-registry.js';
 
 // --- Constants ---
 
@@ -66,6 +69,13 @@ const GENERAL_RSS_FEEDS = [
   'https://www.insightcrime.org/feed/',                       // Organized crime LatAm
   'https://www.borderreport.com/feed/',                       // US-Mexico border
 ];
+
+/** Union the static general feeds with dynamic per-tracker feeds. */
+function buildFeedList(): string[] {
+  const dynamic = resolveFeedsForActiveTrackers(loadAllTrackers());
+  const all = new Set<string>([...GENERAL_RSS_FEEDS, ...dynamic.map((d) => d.url)]);
+  return [...all];
+}
 
 const XML_PARSER = new XMLParser({
   ignoreAttributes: false,
@@ -504,7 +514,7 @@ export async function scan(): Promise<{ candidates: Candidate[]; state: HourlySt
   }
 
   // 1b. General RSS feeds (broad coverage — matched by keywords)
-  const generalFeedList = GENERAL_RSS_FEEDS.map((url) => ({ slug: '__general__', url }));
+  const generalFeedList = buildFeedList().map((url) => ({ slug: '__general__', url }));
   if (generalFeedList.length > 0) {
     const generalResults = await fetchRssFeeds(generalFeedList);
     for (const { item } of generalResults) {
@@ -566,6 +576,26 @@ if (
 ) {
   const { candidates, state } = await scan();
   saveState(state);
+
+  // Realtime: Bluesky + Telegram public channels.
+  const realtime = await pollRealtimeSources();
+  candidates.push(...realtime);
+
+  // Read deferred candidates the light scans accumulated since the last heavy run.
+  try {
+    const pendingPath = PATHS.pendingCandidates;
+    if (existsSync(pendingPath)) {
+      const pending = JSON.parse(readFileSync(pendingPath, 'utf8'));
+      if (pending?.entries?.length) {
+        candidates.push(...pending.entries.map((e: any) => e.candidate));
+        // Reset the pending file once consumed
+        writeFileSync(pendingPath, JSON.stringify({ version: 1, entries: [] }, null, 2));
+      }
+    }
+  } catch (err) {
+    console.warn('[hourly-scan] failed to read pending candidates:', (err as Error).message);
+  }
+
   if (candidates.length === 0) {
     console.log('[hourly-scan] No new candidates. Exiting.');
   } else {

--- a/scripts/hourly-scan.ts
+++ b/scripts/hourly-scan.ts
@@ -575,11 +575,24 @@ if (
   fileURLToPath(import.meta.url) === process.argv[1]
 ) {
   const { candidates, state } = await scan();
-  saveState(state);
+
+  // Add realtime + pending candidates BEFORE saving state, and dedup them
+  // against the same `seen` set scan() used + intra-batch URLs. Without
+  // this, URLs that landed via Bluesky/Telegram or earlier light scans
+  // would be re-triaged on every heavy run.
+  const seenUrls = new Set([
+    ...state.seen.map((s) => s.url),
+    ...candidates.map((c) => c.url),
+  ]);
 
   // Realtime: Bluesky + Telegram public channels.
   const realtime = await pollRealtimeSources();
-  candidates.push(...realtime);
+  for (const c of realtime) {
+    if (seenUrls.has(c.url)) continue;
+    seenUrls.add(c.url);
+    candidates.push(c);
+    state.seen.push({ url: c.url, tracker: c.matchedTracker ?? 'unknown', eventId: '', ts: new Date().toISOString() });
+  }
 
   // Read deferred candidates the light scans accumulated since the last heavy run.
   try {
@@ -587,7 +600,14 @@ if (
     if (existsSync(pendingPath)) {
       const pending = JSON.parse(readFileSync(pendingPath, 'utf8'));
       if (pending?.entries?.length) {
-        candidates.push(...pending.entries.map((e: any) => e.candidate));
+        for (const entry of pending.entries) {
+          const c: Candidate | undefined = entry?.candidate;
+          if (!c?.url) continue;
+          if (seenUrls.has(c.url)) continue;
+          seenUrls.add(c.url);
+          candidates.push(c);
+          state.seen.push({ url: c.url, tracker: c.matchedTracker ?? 'unknown', eventId: '', ts: new Date().toISOString() });
+        }
         // Reset the pending file once consumed
         writeFileSync(pendingPath, JSON.stringify({ version: 1, entries: [] }, null, 2));
       }
@@ -595,6 +615,10 @@ if (
   } catch (err) {
     console.warn('[hourly-scan] failed to read pending candidates:', (err as Error).message);
   }
+
+  // Persist state AFTER realtime + pending have been folded in so subsequent
+  // scans treat their URLs as already seen.
+  saveState(state);
 
   if (candidates.length === 0) {
     console.log('[hourly-scan] No new candidates. Exiting.');

--- a/scripts/hourly-triage.ts
+++ b/scripts/hourly-triage.ts
@@ -17,6 +17,7 @@ import {
   type ActionPlanNewTracker,
   PATHS,
 } from './hourly-types.js';
+import { appendTriageEntries, pruneTriageLog } from '../src/lib/triage-log.js';
 
 // --- Constants ---
 
@@ -357,6 +358,21 @@ export async function triage(
 
   // Build action plan
   const plan = buildActionPlan(candidates, triageResults);
+
+  // Persist every decision to the audit log so /breaking-news-audit/ can show
+  // what was discarded vs accepted.
+  const logEntries = triageResults.map((r) => ({
+    timestamp: new Date().toISOString(),
+    candidate: candidates[r.index],
+    decision: r.action as 'update' | 'new_tracker' | 'discard',
+    reason: r.reason,
+    confidence: r.confidence,
+    model: MODEL,
+    scanType: 'heavy' as const,
+  }));
+  appendTriageEntries(logEntries, PATHS.triageLog);
+  const removed = pruneTriageLog(PATHS.triageLog, 14);
+  if (removed > 0) console.log(`[triage] pruned ${removed} log entries older than 14 days`);
 
   // Write to disk
   writeFileSync(DEFAULT_ACTION_PLAN_PATH, JSON.stringify(plan, null, 2), 'utf8');

--- a/scripts/hourly-triage.ts
+++ b/scripts/hourly-triage.ts
@@ -360,16 +360,25 @@ export async function triage(
   const plan = buildActionPlan(candidates, triageResults);
 
   // Persist every decision to the audit log so /breaking-news-audit/ can show
-  // what was discarded vs accepted.
-  const logEntries = triageResults.map((r) => ({
-    timestamp: new Date().toISOString(),
-    candidate: candidates[r.index],
-    decision: r.action as 'update' | 'new_tracker' | 'discard',
-    reason: r.reason,
-    confidence: r.confidence,
-    model: MODEL,
-    scanType: 'heavy' as const,
-  }));
+  // what was discarded vs accepted. Skip results whose `index` doesn't map
+  // to a real candidate (rare LLM output error) so the audit JSON stays
+  // well-formed.
+  const logEntries = triageResults.flatMap((r) => {
+    const candidate = candidates[r.index];
+    if (!candidate) {
+      console.warn(`[triage] skipping audit log entry for invalid candidate index: ${r.index}`);
+      return [];
+    }
+    return [{
+      timestamp: new Date().toISOString(),
+      candidate,
+      decision: r.action as 'update' | 'new_tracker' | 'discard',
+      reason: r.reason,
+      confidence: r.confidence,
+      model: MODEL,
+      scanType: 'heavy' as const,
+    }];
+  });
   appendTriageEntries(logEntries, PATHS.triageLog);
   const removed = pruneTriageLog(PATHS.triageLog, 14);
   if (removed > 0) console.log(`[triage] pruned ${removed} log entries older than 14 days`);

--- a/scripts/hourly-types.ts
+++ b/scripts/hourly-types.ts
@@ -37,7 +37,11 @@ export interface Candidate {
   source: string;
   timestamp: string;
   matchedTracker: string | null;
-  feedOrigin: 'rss' | 'gdelt';
+  feedOrigin: 'rss' | 'gdelt' | 'bluesky' | 'telegram';
+  /** Source-tier hint propagated from the feed registry; 1 = official, 2 = major outlet, 3 = institutional. */
+  sourceTier?: 1 | 2 | 3;
+  /** ISO 639-1 language code from the source feed (informational; matching is language-agnostic). */
+  language?: 'en' | 'es' | 'fr' | 'pt' | 'ar' | 'zh' | 'ja' | 'hi';
 }
 
 export interface TriageResult {
@@ -74,6 +78,38 @@ export interface ActionPlanNewTracker {
   triggerEvent: { summary: string; sources: string[]; timestamp: string };
 }
 
+/** A candidate the light scan saw with moderate confidence. The next heavy
+ *  scan reads this file, merges with its own poll, and runs full triage. */
+export interface PendingCandidate {
+  candidate: Candidate;
+  /** Multi-signal score from the light scan: keyword + liveness + tier. 0-1. */
+  score: number;
+  /** When the light scan recorded it. */
+  recordedAt: string;
+}
+
+export interface PendingCandidates {
+  version: 1;
+  entries: PendingCandidate[];
+}
+
+/** One row in the audit log. Append-only; pruned at 14 days. */
+export interface TriageLogEntry {
+  timestamp: string;
+  candidate: Candidate;
+  decision: 'update' | 'new_tracker' | 'defer' | 'discard';
+  reason: string;
+  confidence: number;
+  model: string | null;       // null for keyword-only decisions
+  scanType: 'light' | 'heavy';
+}
+
+export interface TriageLog {
+  version: 1;
+  lastPruned: string;
+  entries: TriageLogEntry[];
+}
+
 // --- Paths ---
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -85,6 +121,9 @@ export const PATHS = {
   trackersDir: join(ROOT, 'trackers'),
   socialBudget: join(ROOT, 'public', '_social', 'budget.json'),
   socialHistory: join(ROOT, 'public', '_social', 'history.json'),
+  pendingCandidates: join(ROOT, 'public', '_hourly', 'pending-candidates.json'),
+  triageLog:         join(ROOT, 'public', '_hourly', 'triage-log.json'),
+  realtimeState:     join(ROOT, 'public', '_hourly', 'realtime-state.json'),
 };
 
 // --- State I/O ---
@@ -148,7 +187,8 @@ export function saveManifest(manifest: HourlyManifest, path: string = PATHS.mani
 export function normalizeCandidate(
   raw: { title: string; url: string; source: string; timestamp: string },
   matchedTracker: string | null,
-  feedOrigin: 'rss' | 'gdelt',
+  feedOrigin: Candidate['feedOrigin'],
+  extra: Pick<Candidate, 'sourceTier' | 'language'> = {},
 ): Candidate {
   return {
     title: raw.title,
@@ -157,5 +197,6 @@ export function normalizeCandidate(
     timestamp: raw.timestamp,
     matchedTracker,
     feedOrigin,
+    ...extra,
   };
 }

--- a/src/components/islands/TriageLogBoard.tsx
+++ b/src/components/islands/TriageLogBoard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
 import type { TriageLog, TriageLogEntry } from '../../../scripts/hourly-types';
 
 type Decision = TriageLogEntry['decision'];
@@ -107,7 +107,7 @@ export default function TriageLogBoard({ logUrl }: Props) {
   );
 }
 
-const selectStyle: React.CSSProperties = {
+const selectStyle: CSSProperties = {
   background: 'var(--bg-secondary, #0d1117)',
   color: 'var(--text-primary, #e6edf3)',
   border: '1px solid var(--border, #30363d)',
@@ -117,7 +117,7 @@ const selectStyle: React.CSSProperties = {
   fontSize: '0.75rem',
 };
 
-const badge: React.CSSProperties = {
+const badge: CSSProperties = {
   fontFamily: 'JetBrains Mono, monospace',
   fontSize: '0.6rem',
   fontWeight: 600,

--- a/src/components/islands/TriageLogBoard.tsx
+++ b/src/components/islands/TriageLogBoard.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { TriageLog, TriageLogEntry } from '../../../scripts/hourly-types';
+
+type Decision = TriageLogEntry['decision'];
+
+interface Props { logUrl: string }
+
+export default function TriageLogBoard({ logUrl }: Props) {
+  const [log, setLog] = useState<TriageLog | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [decisionFilter, setDecisionFilter] = useState<Decision | 'all'>('all');
+  const [scanFilter, setScanFilter] = useState<'all' | 'light' | 'heavy'>('all');
+  const [minScore, setMinScore] = useState(0);
+
+  useEffect(() => {
+    fetch(logUrl)
+      .then((r) => r.ok ? r.json() : Promise.reject(`HTTP ${r.status}`))
+      .then((j: TriageLog) => setLog(j))
+      .catch((e) => setError(String(e)));
+  }, [logUrl]);
+
+  const entries = useMemo(() => {
+    if (!log) return [];
+    return log.entries
+      .filter((e) => decisionFilter === 'all' || e.decision === decisionFilter)
+      .filter((e) => scanFilter === 'all' || e.scanType === scanFilter)
+      .filter((e) => e.confidence >= minScore)
+      .sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  }, [log, decisionFilter, scanFilter, minScore]);
+
+  if (error) return <div style={{ color: 'var(--accent-red)' }}>Error loading audit log: {error}</div>;
+  if (!log) return <div>Loading…</div>;
+
+  return (
+    <div style={{ fontFamily: 'DM Sans, sans-serif', color: 'var(--text-primary, #e6edf3)' }}>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 16 }}>
+        <select value={decisionFilter} onChange={(e) => setDecisionFilter(e.target.value as Decision | 'all')} style={selectStyle}>
+          <option value="all">All decisions</option>
+          <option value="update">Update</option>
+          <option value="new_tracker">New tracker</option>
+          <option value="defer">Defer</option>
+          <option value="discard">Discard</option>
+        </select>
+        <select value={scanFilter} onChange={(e) => setScanFilter(e.target.value as 'all' | 'light' | 'heavy')} style={selectStyle}>
+          <option value="all">Both scans</option>
+          <option value="light">Light scan only</option>
+          <option value="heavy">Heavy scan only</option>
+        </select>
+        <label style={{ fontSize: '0.7rem', display: 'flex', alignItems: 'center', gap: 6 }}>
+          Min score:
+          <input
+            type="range" min={0} max={1} step={0.05}
+            value={minScore} onChange={(e) => setMinScore(parseFloat(e.target.value))}
+          />
+          <span style={{ fontFamily: 'JetBrains Mono, monospace', minWidth: 36 }}>{minScore.toFixed(2)}</span>
+        </label>
+        <span style={{ marginLeft: 'auto', fontSize: '0.7rem', color: 'var(--text-muted, #8b949e)' }}>
+          {entries.length} of {log.entries.length} entries
+        </span>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {entries.length === 0 && <div style={{ opacity: 0.6 }}>No entries match these filters.</div>}
+        {entries.slice(0, 200).map((e, i) => (
+          <article key={`${e.timestamp}-${i}`} style={{
+            background: 'var(--bg-card, #161b22)',
+            border: '1px solid var(--border, #30363d)',
+            borderLeft: `3px solid ${decisionColor(e.decision)}`,
+            borderRadius: 6,
+            padding: '8px 10px',
+            fontSize: '0.78rem',
+          }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+              <span style={{ ...badge, color: decisionColor(e.decision), borderColor: decisionColor(e.decision) }}>
+                {e.decision}
+              </span>
+              <span style={badge}>{e.scanType}</span>
+              <span style={{ ...badge, color: 'var(--accent-blue, #58a6ff)' }}>
+                {e.confidence.toFixed(2)}
+              </span>
+              {e.candidate.matchedTracker && (
+                <span style={{ ...badge, color: 'var(--text-muted, #8b949e)' }}>
+                  → {e.candidate.matchedTracker}
+                </span>
+              )}
+              <span style={{ marginLeft: 'auto', fontFamily: 'JetBrains Mono, monospace', fontSize: '0.6rem', color: 'var(--text-muted, #8b949e)' }}>
+                {e.timestamp.replace('T', ' ').replace(/\..+/, '')}
+              </span>
+            </div>
+            <div style={{ marginBottom: 2 }}>
+              <a href={e.candidate.url} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--text-primary, #e6edf3)' }}>
+                {e.candidate.title}
+              </a>
+            </div>
+            <div style={{ fontSize: '0.7rem', color: 'var(--text-muted, #8b949e)' }}>
+              {e.candidate.source} · {e.candidate.feedOrigin} · {e.reason}
+            </div>
+          </article>
+        ))}
+        {entries.length > 200 && (
+          <div style={{ opacity: 0.6, padding: '8px', textAlign: 'center', fontSize: '0.7rem' }}>
+            Showing 200 of {entries.length}. Tighten filters to narrow.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const selectStyle: React.CSSProperties = {
+  background: 'var(--bg-secondary, #0d1117)',
+  color: 'var(--text-primary, #e6edf3)',
+  border: '1px solid var(--border, #30363d)',
+  borderRadius: 6,
+  padding: '4px 8px',
+  fontFamily: 'inherit',
+  fontSize: '0.75rem',
+};
+
+const badge: React.CSSProperties = {
+  fontFamily: 'JetBrains Mono, monospace',
+  fontSize: '0.6rem',
+  fontWeight: 600,
+  letterSpacing: '0.04em',
+  border: '1px solid var(--border, #30363d)',
+  borderRadius: 4,
+  padding: '1px 6px',
+  textTransform: 'uppercase',
+  color: 'var(--text-muted, #8b949e)',
+  background: 'transparent',
+};
+
+function decisionColor(d: Decision): string {
+  switch (d) {
+    case 'update':      return 'var(--accent-green,  #2ecc71)';
+    case 'new_tracker': return 'var(--accent-blue,   #58a6ff)';
+    case 'defer':       return 'var(--accent-amber,  #f39c12)';
+    case 'discard':     return 'var(--text-muted,    #8b949e)';
+  }
+}

--- a/src/lib/keyword-match.test.ts
+++ b/src/lib/keyword-match.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { buildKeywordIndex, scoreCandidate } from './keyword-match';
+import type { TrackerConfig } from './tracker-config';
+import type { Candidate } from '../../scripts/hourly-types';
+
+const mkTracker = (over: Partial<TrackerConfig> & { searchContext?: string; keywords?: string[] }): TrackerConfig => ({
+  slug: 'iran-conflict', name: 'Iran Conflict', shortName: 'Iran', icon: '🇮🇷',
+  status: 'active', domain: 'conflict', region: 'middle-east', sections: [],
+  searchContext: 'Iran-US/Israel conflict',
+  keywords: ['Iran', 'Tehran', 'Khamenei', 'IRGC'],
+  meta: { startDate: '2024-01-01' } as any,
+  ...over,
+});
+
+const mkCandidate = (title: string, source = 'reuters'): Candidate => ({
+  title, url: `https://x.com/${encodeURIComponent(title)}`, source,
+  timestamp: new Date().toISOString(), matchedTracker: null, feedOrigin: 'rss',
+  sourceTier: 2,
+});
+
+describe('keyword-match', () => {
+  it('high score for clear keyword match in title from a tier-2 source', () => {
+    const tr = mkTracker({});
+    const idx = buildKeywordIndex(tr);
+    const c = mkCandidate('Iran says it will respond to Israel strike on Tehran');
+    const s = scoreCandidate(c, idx);
+    expect(s).toBeGreaterThanOrEqual(0.85);
+  });
+
+  it('low score for unrelated headline', () => {
+    const tr = mkTracker({});
+    const idx = buildKeywordIndex(tr);
+    const c = mkCandidate('Local bake sale raises money for school library');
+    const s = scoreCandidate(c, idx);
+    expect(s).toBeLessThan(0.3);
+  });
+
+  it('moderate score for partial / single-keyword hits', () => {
+    const tr = mkTracker({});
+    const idx = buildKeywordIndex(tr);
+    const c = mkCandidate('Tehran weather: hot and dry');
+    const s = scoreCandidate(c, idx);
+    expect(s).toBeGreaterThan(0.3);
+    expect(s).toBeLessThan(0.85);
+  });
+
+  it('case insensitive and tolerant to punctuation', () => {
+    const tr = mkTracker({});
+    const idx = buildKeywordIndex(tr);
+    const c = mkCandidate('TEHRAN: Khamenei addresses parliament.');
+    const s = scoreCandidate(c, idx);
+    expect(s).toBeGreaterThanOrEqual(0.85);
+  });
+
+  it('boosts higher source tiers', () => {
+    const tr = mkTracker({});
+    const idx = buildKeywordIndex(tr);
+    const tier1 = { ...mkCandidate('Iran statement'), sourceTier: 1 as const };
+    const tier3 = { ...mkCandidate('Iran statement'), sourceTier: 3 as const };
+    expect(scoreCandidate(tier1, idx)).toBeGreaterThan(scoreCandidate(tier3, idx));
+  });
+
+  it('handles tracker with no keywords (uses searchContext words)', () => {
+    const tr = mkTracker({ keywords: undefined, searchContext: 'Mexico City protests AMLO' });
+    const idx = buildKeywordIndex(tr);
+    const c = mkCandidate('Mexico City protests turn violent');
+    expect(scoreCandidate(c, idx)).toBeGreaterThanOrEqual(0.6);
+  });
+
+  it('returns 0 when both keywords and searchContext are empty', () => {
+    const tr = mkTracker({ keywords: [], searchContext: '' });
+    const idx = buildKeywordIndex(tr);
+    const c = mkCandidate('Anything at all');
+    expect(scoreCandidate(c, idx)).toBe(0);
+  });
+});

--- a/src/lib/keyword-match.test.ts
+++ b/src/lib/keyword-match.test.ts
@@ -6,11 +6,12 @@ import type { Candidate } from '../../scripts/hourly-types';
 const mkTracker = (over: Partial<TrackerConfig> & { searchContext?: string; keywords?: string[] }): TrackerConfig => ({
   slug: 'iran-conflict', name: 'Iran Conflict', shortName: 'Iran', icon: '🇮🇷',
   status: 'active', domain: 'conflict', region: 'middle-east', sections: [],
+  description: '',
+  navSections: [],
   searchContext: 'Iran-US/Israel conflict',
   keywords: ['Iran', 'Tehran', 'Khamenei', 'IRGC'],
-  meta: { startDate: '2024-01-01' } as any,
   ...over,
-});
+} as unknown as TrackerConfig);
 
 const mkCandidate = (title: string, source = 'reuters'): Candidate => ({
   title, url: `https://x.com/${encodeURIComponent(title)}`, source,

--- a/src/lib/keyword-match.ts
+++ b/src/lib/keyword-match.ts
@@ -1,0 +1,88 @@
+import type { TrackerConfig } from './tracker-config';
+import type { Candidate } from '../../scripts/hourly-types';
+
+const STOPWORDS = new Set([
+  'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
+  'of', 'with', 'as', 'by', 'is', 'was', 'are', 'be', 'been', 'has', 'have',
+]);
+
+/**
+ * A pre-tokenized lookup index for one tracker. Keyword-matching is the
+ * deterministic path used by the light scan; no LLM call.
+ */
+export interface KeywordIndex {
+  trackerSlug: string;
+  /** Normalized (lowercased, deduped) tokens. Empty when tracker has no signal. */
+  tokens: Set<string>;
+  /** Multi-token phrases (e.g. "Mexico City") for higher-confidence matches. */
+  phrases: string[];
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s\u00C0-\u017F]/g, ' ')
+    .split(/\s+/)
+    .filter((w) => w.length >= 3 && !STOPWORDS.has(w));
+}
+
+export function buildKeywordIndex(
+  tracker: Pick<TrackerConfig, 'slug'> & { keywords?: string[]; searchContext?: string },
+): KeywordIndex {
+  const sources: string[] = [];
+  if (tracker.keywords && tracker.keywords.length > 0) sources.push(...tracker.keywords);
+  if (tracker.searchContext) sources.push(tracker.searchContext);
+
+  const tokens = new Set<string>();
+  const phrases: string[] = [];
+
+  for (const s of sources) {
+    const toks = tokenize(s);
+    toks.forEach((t) => tokens.add(t));
+    const norm = s.trim().toLowerCase();
+    if (norm.includes(' ')) phrases.push(norm);
+  }
+
+  return { trackerSlug: tracker.slug, tokens, phrases };
+}
+
+const TIER_WEIGHTS: Record<NonNullable<Candidate['sourceTier']> | 'unknown', number> = {
+  1: 1.0,
+  2: 0.85,
+  3: 0.65,
+  unknown: 0.55,
+};
+
+/**
+ * Score a candidate against a tracker's keyword index. Returns 0..1.
+ * Formula: keyword strength * 0.7 + phrase bonus * 0.1 + tier weight * 0.2
+ *  - keyword strength: hits / min(titleTokens.length, 2)
+ *  - phrase bonus: 1.0 if any registered phrase appears as a substring; else 0
+ *  - tier weight: TIER_WEIGHTS lookup
+ *
+ * Empty indexes (no keywords AND no searchContext) score 0 unconditionally.
+ */
+export function scoreCandidate(candidate: Candidate, index: KeywordIndex): number {
+  if (index.tokens.size === 0 && index.phrases.length === 0) return 0;
+  const titleTokens = tokenize(candidate.title);
+  if (titleTokens.length === 0) return 0;
+
+  const hits = titleTokens.filter((t) => index.tokens.has(t)).length;
+  // Divisor of 2 — the light scan should reward titles with at least two
+  // tracker keywords as a high-confidence signal, regardless of overall
+  // title length.
+  const keywordStrength = Math.min(1, hits / Math.min(titleTokens.length, 2));
+
+  const titleLower = candidate.title.toLowerCase();
+  const phraseHit = index.phrases.some((p) => titleLower.includes(p));
+  const phraseBonus = phraseHit ? 1 : 0;
+
+  const tierKey = candidate.sourceTier ?? 'unknown';
+  const tierWeight = TIER_WEIGHTS[tierKey];
+
+  // Weighting: keyword hits dominate (0.7) since the light scan's job is
+  // detecting tracker-relevant headlines fast; phrase match (0.1) is a
+  // mild bonus for matching the full searchContext string; tier (0.2)
+  // breaks ties between similar candidates from different sources.
+  return Math.min(1, keywordStrength * 0.7 + phraseBonus * 0.1 + tierWeight * 0.2);
+}

--- a/src/lib/realtime-sources.ts
+++ b/src/lib/realtime-sources.ts
@@ -1,0 +1,96 @@
+import type { Candidate } from '../../scripts/hourly-types';
+import { normalizeCandidate } from '../../scripts/hourly-types';
+import { AtpAgent } from '@atproto/api';
+
+/** Hand-curated public OSINT / breaking-news Bluesky accounts.
+ *  Adjust by editing this list — no other code changes required. */
+const BLUESKY_ACCOUNTS: { handle: string; tier: 1 | 2 | 3 }[] = [
+  { handle: 'bnonews.com',          tier: 2 },
+  { handle: 'reuters.com',          tier: 2 },
+  { handle: 'apnews.com',           tier: 2 },
+  { handle: 'theintercept.com',     tier: 2 },
+  { handle: 'aljazeera.com',        tier: 2 },
+  { handle: 'osinttechnical.bsky.social', tier: 3 },
+];
+
+/** Hand-curated public Telegram channels (read via the public preview;
+ *  no bot token required for read-only on public channels). */
+const TELEGRAM_CHANNELS: { slug: string; tier: 1 | 2 | 3 }[] = [
+  { slug: 'BNONews',          tier: 2 },
+  { slug: 'reuters',          tier: 2 },
+  { slug: 'insiderpaper',     tier: 3 },
+  { slug: 'disclosetv',       tier: 3 },
+  { slug: 'sentdefender',     tier: 3 },
+];
+
+/** Fetch the latest N posts from each Bluesky account and convert to Candidates.
+ *  Errors are isolated per-account; a single failure does not abort the rest. */
+export async function pollBluesky(perAccountLimit = 10): Promise<Candidate[]> {
+  const out: Candidate[] = [];
+  const agent = new AtpAgent({ service: 'https://public.api.bsky.app' });
+  for (const acct of BLUESKY_ACCOUNTS) {
+    try {
+      const res = await agent.app.bsky.feed.getAuthorFeed({ actor: acct.handle, limit: perAccountLimit });
+      for (const item of res.data.feed) {
+        const post = item.post;
+        const text = (post.record as { text?: string }).text;
+        if (!text) continue;
+        const ts = (post.record as { createdAt?: string }).createdAt ?? new Date().toISOString();
+        const url = `https://bsky.app/profile/${acct.handle}/post/${post.uri.split('/').pop()}`;
+        out.push(normalizeCandidate(
+          { title: text.slice(0, 280), url, source: `bsky:${acct.handle}`, timestamp: ts },
+          null,
+          'bluesky',
+          { sourceTier: acct.tier },
+        ));
+      }
+    } catch (err) {
+      console.warn(`[realtime] bluesky fetch failed for ${acct.handle}:`, (err as Error).message);
+    }
+  }
+  return out;
+}
+
+/** Fetch latest messages from each public Telegram channel via the
+ *  t.me/s/{slug} preview page (no bot token, public channels only).
+ *  Parse the inline message text by lightweight regex; not a full HTML parser. */
+export async function pollTelegram(perChannelLimit = 10): Promise<Candidate[]> {
+  const out: Candidate[] = [];
+  for (const ch of TELEGRAM_CHANNELS) {
+    try {
+      const res = await fetch(`https://t.me/s/${encodeURIComponent(ch.slug)}`, {
+        headers: { 'User-Agent': 'WatchboardHourlyScan/1.0' },
+      });
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      const html = await res.text();
+      const re = /<div class="tgme_widget_message_text[^>]*>([\s\S]*?)<\/div>/g;
+      const idRe = /data-post="([^"]+)"/g;
+      const ids: string[] = [];
+      for (const m of html.matchAll(idRe)) ids.push(m[1]);
+      let i = 0;
+      for (const m of html.matchAll(re)) {
+        if (i >= perChannelLimit) break;
+        const raw = m[1].replace(/<[^>]+>/g, ' ').replace(/&[a-z#0-9]+;/g, ' ').trim();
+        if (raw.length < 10) { i++; continue; }
+        const id = ids[i] ?? `${ch.slug}-${i}`;
+        const url = `https://t.me/${ch.slug}/${id.split('/').pop()}`;
+        out.push(normalizeCandidate(
+          { title: raw.slice(0, 280), url, source: `tg:${ch.slug}`, timestamp: new Date().toISOString() },
+          null,
+          'telegram',
+          { sourceTier: ch.tier },
+        ));
+        i++;
+      }
+    } catch (err) {
+      console.warn(`[realtime] telegram fetch failed for ${ch.slug}:`, (err as Error).message);
+    }
+  }
+  return out;
+}
+
+/** Convenience: poll both, return unified Candidate[]. */
+export async function pollRealtimeSources(): Promise<Candidate[]> {
+  const [bsky, tg] = await Promise.all([pollBluesky(), pollTelegram()]);
+  return [...bsky, ...tg];
+}

--- a/src/lib/tracker-feeds.test.ts
+++ b/src/lib/tracker-feeds.test.ts
@@ -3,6 +3,7 @@ import {
   resolveFeedsForTracker,
   resolveFeedsForActiveTrackers,
   REGION_FEEDS,
+  COUNTRY_FEEDS,
   DOMAIN_FEEDS,
   type FeedSpec,
 } from './tracker-feeds';
@@ -11,40 +12,45 @@ import type { TrackerConfig } from './tracker-config';
 const mkTracker = (overrides: Partial<TrackerConfig>): TrackerConfig => ({
   slug: 'x', name: 'X', shortName: 'X', icon: '?', status: 'active',
   domain: 'conflict', region: 'middle-east', sections: [],
-  meta: { startDate: '2024-01-01' } as any,
+  description: '',
+  navSections: [],
   ...overrides,
-});
+} as unknown as TrackerConfig);
 
 describe('tracker-feeds', () => {
-  it('returns combined region + domain feeds for a tracker', () => {
-    const tr = mkTracker({ region: 'mexico', domain: 'governance' });
+  it('returns country + region + domain feeds for a tracker', () => {
+    const tr = mkTracker({ country: 'MX', region: 'north-america', domain: 'economy' });
     const feeds = resolveFeedsForTracker(tr);
     const urls = feeds.map((f) => f.url);
+    // Country feeds present (the whole point of the registry — Mexico-specific outlets)
     expect(urls.some((u) => u.includes('animalpolitico'))).toBe(true);
+    // Domain feeds present (economy → reuters business)
+    expect(urls.some((u) => u.includes('businessNews'))).toBe(true);
     for (const f of feeds) {
       expect(f.url).toMatch(/^https?:\/\//);
       expect([1, 2, 3]).toContain(f.tier);
     }
   });
 
-  it('returns empty array when tracker has no region or domain', () => {
-    const tr = mkTracker({ region: undefined, domain: undefined });
+  it('returns empty array when tracker has no country, region, or domain', () => {
+    const tr = mkTracker({ country: undefined, region: undefined, domain: undefined });
     expect(resolveFeedsForTracker(tr)).toEqual([]);
   });
 
-  it('dedupes by URL when region and domain share a feed', () => {
-    const dup = REGION_FEEDS['mexico']?.[0];
-    if (!dup) return;
-    const tr = mkTracker({ region: 'mexico', domain: 'governance' });
+  it('dedupes within resolveFeedsForTracker if country, region, and domain share a feed', () => {
+    // south-america region and BR country share two URLs (Folha + G1). Verify dedup.
+    const tr = mkTracker({ country: 'BR', region: 'south-america', domain: undefined });
     const feeds = resolveFeedsForTracker(tr);
     const urls = feeds.map((f) => f.url);
     expect(new Set(urls).size).toBe(urls.length);
+    // Folha must appear exactly once even though it is in both buckets
+    expect(urls.filter((u) => u.includes('folha')).length).toBe(1);
   });
 
   it('resolveFeedsForActiveTrackers dedupes union across many trackers', () => {
     const trs = [
-      mkTracker({ slug: 'a', region: 'mexico' }),
-      mkTracker({ slug: 'b', region: 'mexico', domain: 'governance' }),
+      mkTracker({ slug: 'a', country: 'MX', region: 'north-america' }),
+      mkTracker({ slug: 'b', country: 'MX', region: 'north-america', domain: 'economy' }),
     ];
     const feeds = resolveFeedsForActiveTrackers(trs);
     const urls = feeds.map((f) => f.url);
@@ -52,19 +58,32 @@ describe('tracker-feeds', () => {
   });
 
   it('skips inactive trackers', () => {
-    const trs = [mkTracker({ slug: 'a', region: 'mexico', status: 'archived' })];
+    const trs = [mkTracker({ slug: 'a', country: 'MX', status: 'archived' })];
     const feeds = resolveFeedsForActiveTrackers(trs);
     expect(feeds).toEqual([]);
   });
 
-  it('REGION_FEEDS has well-formed entries', () => {
-    for (const [region, feeds] of Object.entries(REGION_FEEDS)) {
-      expect(typeof region).toBe('string');
+  it('all feed registries have well-formed entries', () => {
+    const all = { ...COUNTRY_FEEDS, ...REGION_FEEDS, ...DOMAIN_FEEDS };
+    for (const [key, feeds] of Object.entries(all)) {
+      expect(typeof key).toBe('string');
       expect(Array.isArray(feeds)).toBe(true);
       for (const f of feeds) {
         expect(f.url).toMatch(/^https?:\/\//);
         expect([1, 2, 3]).toContain(f.tier);
       }
+    }
+  });
+
+  it('REGION_FEEDS keys match the RegionSchema enum (no stray taxonomy)', () => {
+    // These are the values RegionSchema accepts in src/lib/tracker-config.ts.
+    const validRegions = new Set([
+      'africa', 'central-america', 'central-europe', 'east-asia', 'europe',
+      'global', 'middle-east', 'north-america', 'south-america', 'south-asia',
+      'southeast-asia',
+    ]);
+    for (const region of Object.keys(REGION_FEEDS)) {
+      expect(validRegions.has(region)).toBe(true);
     }
   });
 });

--- a/src/lib/tracker-feeds.test.ts
+++ b/src/lib/tracker-feeds.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveFeedsForTracker,
+  resolveFeedsForActiveTrackers,
+  REGION_FEEDS,
+  DOMAIN_FEEDS,
+  type FeedSpec,
+} from './tracker-feeds';
+import type { TrackerConfig } from './tracker-config';
+
+const mkTracker = (overrides: Partial<TrackerConfig>): TrackerConfig => ({
+  slug: 'x', name: 'X', shortName: 'X', icon: '?', status: 'active',
+  domain: 'conflict', region: 'middle-east', sections: [],
+  meta: { startDate: '2024-01-01' } as any,
+  ...overrides,
+});
+
+describe('tracker-feeds', () => {
+  it('returns combined region + domain feeds for a tracker', () => {
+    const tr = mkTracker({ region: 'mexico', domain: 'governance' });
+    const feeds = resolveFeedsForTracker(tr);
+    const urls = feeds.map((f) => f.url);
+    expect(urls.some((u) => u.includes('animalpolitico'))).toBe(true);
+    for (const f of feeds) {
+      expect(f.url).toMatch(/^https?:\/\//);
+      expect([1, 2, 3]).toContain(f.tier);
+    }
+  });
+
+  it('returns empty array when tracker has no region or domain', () => {
+    const tr = mkTracker({ region: undefined, domain: undefined });
+    expect(resolveFeedsForTracker(tr)).toEqual([]);
+  });
+
+  it('dedupes by URL when region and domain share a feed', () => {
+    const dup = REGION_FEEDS['mexico']?.[0];
+    if (!dup) return;
+    const tr = mkTracker({ region: 'mexico', domain: 'governance' });
+    const feeds = resolveFeedsForTracker(tr);
+    const urls = feeds.map((f) => f.url);
+    expect(new Set(urls).size).toBe(urls.length);
+  });
+
+  it('resolveFeedsForActiveTrackers dedupes union across many trackers', () => {
+    const trs = [
+      mkTracker({ slug: 'a', region: 'mexico' }),
+      mkTracker({ slug: 'b', region: 'mexico', domain: 'governance' }),
+    ];
+    const feeds = resolveFeedsForActiveTrackers(trs);
+    const urls = feeds.map((f) => f.url);
+    expect(new Set(urls).size).toBe(urls.length);
+  });
+
+  it('skips inactive trackers', () => {
+    const trs = [mkTracker({ slug: 'a', region: 'mexico', status: 'archived' })];
+    const feeds = resolveFeedsForActiveTrackers(trs);
+    expect(feeds).toEqual([]);
+  });
+
+  it('REGION_FEEDS has well-formed entries', () => {
+    for (const [region, feeds] of Object.entries(REGION_FEEDS)) {
+      expect(typeof region).toBe('string');
+      expect(Array.isArray(feeds)).toBe(true);
+      for (const f of feeds) {
+        expect(f.url).toMatch(/^https?:\/\//);
+        expect([1, 2, 3]).toContain(f.tier);
+      }
+    }
+  });
+});

--- a/src/lib/tracker-feeds.ts
+++ b/src/lib/tracker-feeds.ts
@@ -1,0 +1,90 @@
+import type { TrackerConfig } from './tracker-config';
+
+export type FeedLanguage = 'en' | 'es' | 'fr' | 'pt' | 'ar' | 'zh' | 'ja' | 'hi';
+
+export interface FeedSpec {
+  url: string;
+  tier: 1 | 2 | 3;
+  lang: FeedLanguage;
+  /** Reserved for v2 auto-disable behavior; not used in v1. */
+  toleranceDays?: number;
+}
+
+/**
+ * Region → native-language outlets covering that region. Adding a tracker
+ * with one of these regions auto-extends the scan's source list.
+ */
+export const REGION_FEEDS: Record<string, FeedSpec[]> = {
+  mexico: [
+    { url: 'https://www.animalpolitico.com/feed/',            tier: 2, lang: 'es' },
+    { url: 'https://www.jornada.com.mx/rss/edicion.xml',      tier: 2, lang: 'es' },
+    { url: 'https://aristeguinoticias.com/feed/',             tier: 2, lang: 'es' },
+    { url: 'https://www.eluniversal.com.mx/rss.xml',          tier: 2, lang: 'es' },
+  ],
+  india: [
+    { url: 'https://www.thehindu.com/news/national/feeder/default.rss', tier: 2, lang: 'en' },
+    { url: 'https://indianexpress.com/section/india/feed/',             tier: 2, lang: 'en' },
+    { url: 'https://timesofindia.indiatimes.com/rssfeedstopstories.cms',tier: 2, lang: 'en' },
+  ],
+  'middle-east': [
+    { url: 'https://www.aljazeera.com/xml/rss/all.xml',          tier: 2, lang: 'en' },
+    { url: 'https://english.alarabiya.net/.mrss/en/all.xml',     tier: 2, lang: 'en' },
+    { url: 'https://www.timesofisrael.com/feed/',                tier: 2, lang: 'en' },
+  ],
+  latam: [
+    { url: 'https://www.clarin.com/rss/lo-ultimo/',              tier: 2, lang: 'es' },
+    { url: 'https://feeds.folha.uol.com.br/folha/rss091.xml',    tier: 2, lang: 'pt' },
+    { url: 'https://g1.globo.com/rss/g1/',                       tier: 2, lang: 'pt' },
+  ],
+  africa: [
+    { url: 'https://allafrica.com/tools/headlines/rdf/latest/headlines.rdf', tier: 2, lang: 'en' },
+    { url: 'https://www.news24.com/rss/Section/News24Wire',      tier: 2, lang: 'en' },
+  ],
+  'east-asia': [
+    { url: 'https://www.scmp.com/rss/91/feed',                   tier: 2, lang: 'en' },
+    { url: 'https://www.japantimes.co.jp/feed/',                 tier: 2, lang: 'en' },
+  ],
+};
+
+export const DOMAIN_FEEDS: Record<string, FeedSpec[]> = {
+  space: [
+    { url: 'https://www.nasa.gov/news/all/feed/',                tier: 1, lang: 'en' },
+    { url: 'https://spacenews.com/feed/',                        tier: 2, lang: 'en' },
+    { url: 'https://www.esa.int/Newsroom/Highlights_RSS',        tier: 1, lang: 'en' },
+  ],
+  science: [
+    { url: 'https://www.nature.com/nature.rss',                  tier: 1, lang: 'en' },
+    { url: 'https://www.science.org/blogs/news-from-science/feed', tier: 1, lang: 'en' },
+  ],
+  economy: [
+    { url: 'https://feeds.reuters.com/reuters/businessNews',     tier: 2, lang: 'en' },
+  ],
+  disaster: [
+    { url: 'https://reliefweb.int/updates/rss.xml',              tier: 1, lang: 'en' },
+  ],
+};
+
+/** Resolve all feeds (region + domain) that apply to a single tracker. */
+export function resolveFeedsForTracker(tracker: Pick<TrackerConfig, 'region' | 'domain' | 'status'>): FeedSpec[] {
+  const out: FeedSpec[] = [];
+  if (tracker.region && REGION_FEEDS[tracker.region]) out.push(...REGION_FEEDS[tracker.region]);
+  if (tracker.domain && DOMAIN_FEEDS[tracker.domain]) out.push(...DOMAIN_FEEDS[tracker.domain]);
+  return out;
+}
+
+/** Walk all active trackers, union + dedupe their resolved feeds. */
+export function resolveFeedsForActiveTrackers(
+  trackers: Pick<TrackerConfig, 'region' | 'domain' | 'status'>[],
+): FeedSpec[] {
+  const seen = new Set<string>();
+  const out: FeedSpec[] = [];
+  for (const tr of trackers) {
+    if (tr.status !== 'active') continue;
+    for (const f of resolveFeedsForTracker(tr)) {
+      if (seen.has(f.url)) continue;
+      seen.add(f.url);
+      out.push(f);
+    }
+  }
+  return out;
+}

--- a/src/lib/tracker-feeds.ts
+++ b/src/lib/tracker-feeds.ts
@@ -11,30 +11,66 @@ export interface FeedSpec {
 }
 
 /**
- * Region → native-language outlets covering that region. Adding a tracker
- * with one of these regions auto-extends the scan's source list.
+ * Country (ISO-2 code) → native-language outlets. tracker.json carries
+ * `country` at the tracker root (e.g. `"country": "MX"`); adding a tracker
+ * with one of these codes auto-extends the scan's source list.
+ *
+ * Codes match the existing TrackerConfig.country field which is the same
+ * ISO-2 code used in `geoPath[0]`.
  */
-export const REGION_FEEDS: Record<string, FeedSpec[]> = {
-  mexico: [
-    { url: 'https://www.animalpolitico.com/feed/',            tier: 2, lang: 'es' },
-    { url: 'https://www.jornada.com.mx/rss/edicion.xml',      tier: 2, lang: 'es' },
-    { url: 'https://aristeguinoticias.com/feed/',             tier: 2, lang: 'es' },
-    { url: 'https://www.eluniversal.com.mx/rss.xml',          tier: 2, lang: 'es' },
+export const COUNTRY_FEEDS: Record<string, FeedSpec[]> = {
+  MX: [
+    { url: 'https://www.animalpolitico.com/feed/',                tier: 2, lang: 'es' },
+    { url: 'https://www.jornada.com.mx/rss/edicion.xml',          tier: 2, lang: 'es' },
+    { url: 'https://aristeguinoticias.com/feed/',                 tier: 2, lang: 'es' },
+    { url: 'https://www.eluniversal.com.mx/rss.xml',              tier: 2, lang: 'es' },
   ],
-  india: [
+  IN: [
     { url: 'https://www.thehindu.com/news/national/feeder/default.rss', tier: 2, lang: 'en' },
     { url: 'https://indianexpress.com/section/india/feed/',             tier: 2, lang: 'en' },
     { url: 'https://timesofindia.indiatimes.com/rssfeedstopstories.cms',tier: 2, lang: 'en' },
   ],
+  IL: [
+    { url: 'https://www.timesofisrael.com/feed/',                 tier: 2, lang: 'en' },
+    { url: 'https://www.haaretz.com/srv/htz---web---english-rss', tier: 2, lang: 'en' },
+  ],
+  AR: [
+    { url: 'https://www.clarin.com/rss/lo-ultimo/',               tier: 2, lang: 'es' },
+  ],
+  BR: [
+    { url: 'https://feeds.folha.uol.com.br/folha/rss091.xml',     tier: 2, lang: 'pt' },
+    { url: 'https://g1.globo.com/rss/g1/',                        tier: 2, lang: 'pt' },
+  ],
+  JP: [
+    { url: 'https://www.japantimes.co.jp/feed/',                  tier: 2, lang: 'en' },
+  ],
+  CN: [
+    { url: 'https://www.scmp.com/rss/91/feed',                    tier: 2, lang: 'en' },
+  ],
+  ZA: [
+    { url: 'https://www.news24.com/rss/Section/News24Wire',       tier: 2, lang: 'en' },
+  ],
+  // Trackers without a country-specific feed list still pick up region +
+  // domain feeds below.
+};
+
+/**
+ * Region → broad outlets covering the geography. Keys MUST match the values
+ * in `RegionSchema` (`src/lib/tracker-config.ts`): `africa`, `central-america`,
+ * `central-europe`, `east-asia`, `europe`, `global`, `middle-east`,
+ * `north-america`, `south-america`, `south-asia`, `southeast-asia`.
+ */
+export const REGION_FEEDS: Record<string, FeedSpec[]> = {
   'middle-east': [
     { url: 'https://www.aljazeera.com/xml/rss/all.xml',          tier: 2, lang: 'en' },
     { url: 'https://english.alarabiya.net/.mrss/en/all.xml',     tier: 2, lang: 'en' },
-    { url: 'https://www.timesofisrael.com/feed/',                tier: 2, lang: 'en' },
   ],
-  latam: [
-    { url: 'https://www.clarin.com/rss/lo-ultimo/',              tier: 2, lang: 'es' },
+  'south-america': [
     { url: 'https://feeds.folha.uol.com.br/folha/rss091.xml',    tier: 2, lang: 'pt' },
     { url: 'https://g1.globo.com/rss/g1/',                       tier: 2, lang: 'pt' },
+  ],
+  'central-america': [
+    { url: 'https://www.animalpolitico.com/feed/',               tier: 2, lang: 'es' },
   ],
   africa: [
     { url: 'https://allafrica.com/tools/headlines/rdf/latest/headlines.rdf', tier: 2, lang: 'en' },
@@ -43,6 +79,12 @@ export const REGION_FEEDS: Record<string, FeedSpec[]> = {
   'east-asia': [
     { url: 'https://www.scmp.com/rss/91/feed',                   tier: 2, lang: 'en' },
     { url: 'https://www.japantimes.co.jp/feed/',                 tier: 2, lang: 'en' },
+  ],
+  'south-asia': [
+    { url: 'https://www.thehindu.com/news/international/feeder/default.rss', tier: 2, lang: 'en' },
+  ],
+  'southeast-asia': [
+    { url: 'https://www.straitstimes.com/news/asia/rss.xml',     tier: 2, lang: 'en' },
   ],
 };
 
@@ -64,17 +106,31 @@ export const DOMAIN_FEEDS: Record<string, FeedSpec[]> = {
   ],
 };
 
-/** Resolve all feeds (region + domain) that apply to a single tracker. */
-export function resolveFeedsForTracker(tracker: Pick<TrackerConfig, 'region' | 'domain' | 'status'>): FeedSpec[] {
+/** Resolve all feeds (country + region + domain) that apply to a single
+ *  tracker. Dedupes by URL within the tracker; the union across many
+ *  trackers is deduped again by `resolveFeedsForActiveTrackers`. */
+export function resolveFeedsForTracker(
+  tracker: Pick<TrackerConfig, 'region' | 'domain' | 'status' | 'country'>,
+): FeedSpec[] {
+  const seen = new Set<string>();
   const out: FeedSpec[] = [];
-  if (tracker.region && REGION_FEEDS[tracker.region]) out.push(...REGION_FEEDS[tracker.region]);
-  if (tracker.domain && DOMAIN_FEEDS[tracker.domain]) out.push(...DOMAIN_FEEDS[tracker.domain]);
+  const push = (feeds?: FeedSpec[]) => {
+    if (!feeds) return;
+    for (const f of feeds) {
+      if (seen.has(f.url)) continue;
+      seen.add(f.url);
+      out.push(f);
+    }
+  };
+  if (tracker.country) push(COUNTRY_FEEDS[tracker.country]);
+  if (tracker.region)  push(REGION_FEEDS[tracker.region]);
+  if (tracker.domain)  push(DOMAIN_FEEDS[tracker.domain]);
   return out;
 }
 
 /** Walk all active trackers, union + dedupe their resolved feeds. */
 export function resolveFeedsForActiveTrackers(
-  trackers: Pick<TrackerConfig, 'region' | 'domain' | 'status'>[],
+  trackers: Pick<TrackerConfig, 'region' | 'domain' | 'status' | 'country'>[],
 ): FeedSpec[] {
   const seen = new Set<string>();
   const out: FeedSpec[] = [];

--- a/src/lib/triage-log.test.ts
+++ b/src/lib/triage-log.test.ts
@@ -46,9 +46,13 @@ describe('triage-log', () => {
     expect(log.entries[2].candidate.title).toMatch(/^t-2-/);
   });
 
-  it('pruneTriageLog removes entries older than 14 days', () => {
+  it('pruneTriageLog removes entries older than the cutoff (15+ days w/ 14-day retention)', () => {
     const path = join(tmp, 'test3.json');
-    appendTriageEntries([mkEntry(0), mkEntry(7), mkEntry(14), mkEntry(20)], path);
+    // Use 15/20 instead of 14/20 — 14 sits exactly at the cutoff boundary,
+    // so timing jitter between mkEntry() and pruneTriageLog() can flip whether
+    // the 14d entry is kept (>= cutoffMs) or dropped. Test the unambiguous
+    // case: clearly-old entries are removed, recent entries are kept.
+    appendTriageEntries([mkEntry(0), mkEntry(7), mkEntry(15), mkEntry(20)], path);
     const removed = pruneTriageLog(path, 14);
     const log = readTriageLog(path);
     const titles = log.entries.map((e) => e.candidate.title);

--- a/src/lib/triage-log.test.ts
+++ b/src/lib/triage-log.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { appendTriageEntries, pruneTriageLog, readTriageLog } from './triage-log';
+import type { TriageLogEntry, Candidate } from '../../scripts/hourly-types';
+
+let entryId = 0;
+const mkEntry = (daysAgo = 0): TriageLogEntry => {
+  const id = entryId++;
+  return {
+    timestamp: new Date(Date.now() - daysAgo * 24 * 3600_000).toISOString(),
+    candidate: {
+      title: `t-${daysAgo}-${id}`, url: `https://x/${id}`, source: 'r',
+      timestamp: new Date().toISOString(), matchedTracker: null, feedOrigin: 'rss',
+    } as Candidate,
+    decision: 'discard', reason: 'noise', confidence: 0.1,
+    model: null, scanType: 'light',
+  };
+};
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'triage-'));
+  entryId = 0;
+});
+afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+describe('triage-log', () => {
+  it('appendTriageEntries creates the file on first write', () => {
+    const path = join(tmp, 'test1.json');
+    appendTriageEntries([mkEntry()], path);
+    expect(existsSync(path)).toBe(true);
+    const raw = JSON.parse(readFileSync(path, 'utf8'));
+    expect(raw.version).toBe(1);
+    expect(raw.entries).toHaveLength(1);
+  });
+
+  it('appendTriageEntries appends to existing file in order', () => {
+    const path = join(tmp, 'test2.json');
+    appendTriageEntries([mkEntry(0)], path);
+    appendTriageEntries([mkEntry(1), mkEntry(2)], path);
+    const log = readTriageLog(path);
+    expect(log.entries).toHaveLength(3);
+    expect(log.entries[0].candidate.title).toMatch(/^t-0-/);
+    expect(log.entries[2].candidate.title).toMatch(/^t-2-/);
+  });
+
+  it('pruneTriageLog removes entries older than 14 days', () => {
+    const path = join(tmp, 'test3.json');
+    appendTriageEntries([mkEntry(0), mkEntry(7), mkEntry(14), mkEntry(20)], path);
+    const removed = pruneTriageLog(path, 14);
+    const log = readTriageLog(path);
+    const titles = log.entries.map((e) => e.candidate.title);
+    expect(titles.length).toBe(2);
+    expect(titles[0]).toMatch(/^t-0-/);
+    expect(titles[1]).toMatch(/^t-7-/);
+    expect(removed).toBe(2);
+    expect(log.lastPruned).toBeTruthy();
+  });
+
+  it('readTriageLog returns an empty log when the file is missing', () => {
+    const log = readTriageLog(join(tmp, 'nope.json'));
+    expect(log.entries).toEqual([]);
+    expect(log.version).toBe(1);
+  });
+
+  it('handles a corrupt file by treating it as empty', () => {
+    const path = join(tmp, 'bad.json');
+    writeFileSync(path, 'not json');
+    const log = readTriageLog(path);
+    expect(log.entries).toEqual([]);
+  });
+});

--- a/src/lib/triage-log.ts
+++ b/src/lib/triage-log.ts
@@ -1,0 +1,36 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
+import type { TriageLog, TriageLogEntry } from '../../scripts/hourly-types';
+
+export function readTriageLog(path: string): TriageLog {
+  if (!existsSync(path)) return { version: 1, lastPruned: '', entries: [] };
+  try {
+    const raw = JSON.parse(readFileSync(path, 'utf8')) as TriageLog;
+    if (raw.version !== 1 || !Array.isArray(raw.entries)) return { version: 1, lastPruned: '', entries: [] };
+    return raw;
+  } catch {
+    return { version: 1, lastPruned: '', entries: [] };
+  }
+}
+
+function writeTriageLog(log: TriageLog, path: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(log, null, 2), 'utf8');
+}
+
+export function appendTriageEntries(entries: TriageLogEntry[], path: string): void {
+  const current = readTriageLog(path);
+  current.entries.push(...entries);
+  writeTriageLog(current, path);
+}
+
+/** Prune entries older than `keepDays`. Returns number removed. */
+export function pruneTriageLog(path: string, keepDays: number): number {
+  const current = readTriageLog(path);
+  const cutoffMs = Date.now() - keepDays * 24 * 3600_000;
+  const before = current.entries.length;
+  current.entries = current.entries.filter((e) => new Date(e.timestamp).getTime() >= cutoffMs);
+  current.lastPruned = new Date().toISOString();
+  writeTriageLog(current, path);
+  return before - current.entries.length;
+}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -192,6 +192,9 @@ const basePath = base.endsWith('/') ? base : `${base}/`;
         <p>
           Watchboard's product roadmap is public and live. <a href={`${basePath}roadmap/`}>View the roadmap →</a> for what's shipped, in progress, planned, and captured as ideas — broken down by area (performance, growth, content, accessibility, infrastructure) with priority and effort estimates. The page is fed directly from the codebase, so it's never out of date with what's deployed.
         </p>
+        <p>
+          The <a href={`${basePath}breaking-news-audit/`}>breaking-news audit page</a> shows every triage decision the hourly + 6-hourly scans made in the last 14 days — useful when calibrating which headlines should reach Telegram.
+        </p>
       </section>
 
       <section>
@@ -279,6 +282,8 @@ const basePath = base.endsWith('/') ? base : `${base}/`;
       <a href={`${basePath}metrics/`}>Status</a>
       <span>&middot;</span>
       <a href={`${basePath}roadmap/`}>Roadmap</a>
+      <span>&middot;</span>
+      <a href={`${basePath}breaking-news-audit/`}>Audit</a>
       <span>&middot;</span>
       <a href={`${basePath}social/`}>Social</a>
       <span>&middot;</span>

--- a/src/pages/breaking-news-audit.astro
+++ b/src/pages/breaking-news-audit.astro
@@ -1,0 +1,40 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import TriageLogBoard from '../components/islands/TriageLogBoard.tsx';
+
+const base = import.meta.env.BASE_URL;
+const basePath = base.endsWith('/') ? base : `${base}/`;
+const logUrl = `${basePath}_hourly/triage-log.json`;
+---
+<BaseLayout title="Breaking News Audit" description="Every triage decision the breaking-news pipeline made in the last 14 days">
+  <main id="main-content">
+    <div class="audit-page">
+      <a class="audit-back" href={`${basePath}about/`}>&larr; About</a>
+      <h1>Breaking News Audit</h1>
+      <p class="audit-lede">
+        Every triage decision the breaking-news pipeline made in the last 14 days. Use this to spot rejected candidates that look like they should have been accepted, and tune thresholds in <code>scripts/hourly-triage.ts</code>.
+      </p>
+      <TriageLogBoard logUrl={logUrl} client:load />
+    </div>
+  </main>
+</BaseLayout>
+
+<style>
+  .audit-page { max-width: 1100px; margin: 0 auto; padding: 2rem 1.5rem 4rem; color: var(--text-primary, #e6edf3); }
+  .audit-back {
+    display: inline-block; margin-bottom: 2rem;
+    color: var(--text-muted, #8b949e); text-decoration: none;
+    font-size: 0.85rem; font-family: 'DM Sans', sans-serif;
+    border: 1px solid var(--border, #30363d); padding: 0.4rem 0.8rem; border-radius: 6px;
+    transition: all 0.2s;
+  }
+  .audit-back:hover { color: var(--text-primary); background: var(--bg-card); }
+  h1 { font-family: 'Cormorant Garamond', serif; font-size: 2rem; margin: 0 0 0.5rem; }
+  .audit-lede { color: var(--text-secondary, #8b949e); margin-bottom: 1.5rem; max-width: 640px; }
+  code {
+    font-family: 'JetBrains Mono', monospace; font-size: 0.85em;
+    background: var(--bg-secondary, #0d1117);
+    border: 1px solid var(--border, #30363d);
+    padding: 1px 6px; border-radius: 3px;
+  }
+</style>


### PR DESCRIPTION
## What
12-task redesign that addresses three user-reported pains:
- **Latency** — White House shooting took >6h to surface (current cron is 6h).
- **Misses on regional news** — CDMX protests not picked up; no native Mexican feeds.
- **Low yield** — only 1 update/day on a typical day.

## How

### 1. Two-tier scan cadence
- New **light scan** every 15 min (\`light-scan.yml\`) — curated wire feeds + Bluesky + Telegram, deterministic keyword match, no LLM. Posts to Telegram on score ≥ 0.85, defers 0.5–0.85 to \`pending-candidates.json\`, discards <0.5.
- Existing **heavy scan** (every 6h) unchanged in spirit, now consumes pending candidates from light scans + adds dynamic per-tracker feeds + realtime.

### 2. Per-tracker dynamic feeds (\`src/lib/tracker-feeds.ts\`)
Region/domain → feed registry. Mexican trackers auto-include Animal Político / La Jornada / El Universal / Aristegui. India trackers auto-include The Hindu / Indian Express / Times of India. Etc. **Adding a tracker auto-extends the source list** — no scan-script edits.

### 3. Realtime sources (\`src/lib/realtime-sources.ts\`)
Bluesky firehose for ~6 OSINT/news accounts (BNO, Reuters, AP, AlJazeera) via \`@atproto/api\`. Telegram via public \`t.me/s/{slug}\` for ~5 channels. Both errors-isolated per source.

### 4. Audit infrastructure
- \`public/_hourly/triage-log.json\` — append + 14-day prune of every decision.
- New \`/breaking-news-audit/\` page with React island: filter by decision / scan type / min score, expandable cards. Linked from About + footer.
- After 1 week of data, threshold tuning is data-driven instead of guesses.

## Files
- **New (12):** \`tracker-feeds.ts\`, \`keyword-match.ts\`, \`triage-log.ts\`, \`realtime-sources.ts\` + tests for first three; \`hourly-light-scan.ts\`; \`light-scan.yml\`; \`breaking-news-audit.astro\`; \`TriageLogBoard.tsx\`
- **Modified (4):** \`hourly-types.ts\` (widen Candidate, add Pending/Log types), \`hourly-scan.ts\` (dynamic feeds + realtime + pending consumption), \`hourly-triage.ts\` (writes to log), \`about.astro\` (links), \`CLAUDE.md\` (registers new pieces)
- **Dependency:** \`@atproto/api\`

## Cost
- Light scans: ~$0/day (no LLM)
- Heavy scans: ~$0.20/day (unchanged)
- Realtime polling: free (public APIs)
- **Total ~$1/month marginal** for the latency + coverage win.

## Test plan
- [x] \`npx vitest run\` — 180 pass (162 baseline + 18 new), 7 pre-existing French translation failures unchanged
- [x] \`npm run build\` — succeeds, \`/breaking-news-audit/\` indexed
- [x] Final cross-task code review pass (one defensive guard applied: empty bestSlug check on light scan)
- [ ] After merge, manually dispatch \`light-scan.yml\` to confirm a real run completes within 5 min
- [ ] Within 24h, audit page should show ≥50 triage decisions
- [ ] Within 1 week, review \`discard\` entries with \`confidence > 0.5\` for threshold tuning

## Spec / plan
- Spec: \`docs/superpowers/specs/2026-04-27-breaking-news-pipeline-redesign-design.md\`
- Plan: \`docs/superpowers/plans/2026-04-27-breaking-news-pipeline-redesign.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)