### PR TITLE
docs: sync README / CHANGELOG / roadmap with breaking-news pipeline (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — 2026-04-27
+- **Breaking-news pipeline redesign** (#131): two-tier scan cadence + per-tracker dynamic feeds + realtime sources + persistent audit log + public `/breaking-news-audit/` page. Targets latency (was 6 h gap), regional misses (CDMX-style stories now covered by `tracker.country`-keyed Mexican outlets), and low yield (deterministic keyword path means no LLM-rejection of obvious matches).
+  - **Light scan** (every 15 min, `.github/workflows/light-scan.yml` + `scripts/hourly-light-scan.ts`): polls Reuters/BBC/AP/Google News + Bluesky firehose + Telegram public channels. Scores via `src/lib/keyword-match.ts` (deterministic, no LLM). ≥ 0.85 → Telegram post. 0.5–0.85 → defers to `public/_hourly/pending-candidates.json`. < 0.5 → discards to audit log.
+  - **Heavy scan** (every 6 h, existing `update-data.yml` and `scripts/hourly-scan.ts`): now resolves per-tracker dynamic feeds via `src/lib/tracker-feeds.ts` (adding a Mexican tracker auto-pulls Animal Político / La Jornada / El Universal / Aristegui; Indian → The Hindu / Indian Express / Times of India; Middle East → Al Jazeera / Al Arabiya / Times of Israel / Haaretz; etc.). Polls the same realtime sources. Reads + clears `pending-candidates.json`. Sonnet triage writes every decision to `triage-log.json`.
+  - **Audit page** at `/breaking-news-audit/` (`src/components/islands/TriageLogBoard.tsx`): filters by decision / scan type / min score, expandable cards. Linked from About + footer. Reads `public/_hourly/triage-log.json` at runtime — no build dependency.
+  - **New `Candidate.feedOrigin`** values: `'rss' | 'gdelt' | 'bluesky' | 'telegram'`.
+  - **New libs**: `tracker-feeds.ts`, `keyword-match.ts`, `triage-log.ts`, `realtime-sources.ts` — each pure / well-bounded with unit tests (18 new tests, 181 total passing).
+  - Spec: `docs/superpowers/specs/2026-04-27-breaking-news-pipeline-redesign-design.md`
+  - Plan: `docs/superpowers/plans/2026-04-27-breaking-news-pipeline-redesign.md`
+
 ### Added — 2026-04-26
 - **Multi-step onboarding tour** (#122): replaces the single-toast welcome with a 6-step guided desktop tour (hero → globe → sidebar → broadcast ticker → source-tier explainer → closing) and a 3-step mobile bottom-sheet flow. Versioned localStorage keys (`watchboard-tour-{desktop,mobile}-v1`) with one-shot legacy migration. Replay button in the `?` shortcuts panel (with last-completed timestamp); mobile gets a small ↻ button on the carousel.
   - New: `src/components/islands/Onboarding/{OnboardingTour,MobileOnboarding,SpotlightStep,HeroStep}.tsx`

--- a/README.md
+++ b/README.md
@@ -258,18 +258,24 @@ Data is automatically refreshed at 6 AM UTC via GitHub Actions. Each tracker has
 
 All data workflows use `claude-code-action` with a Claude Max subscription OAuth token (`CLAUDE_CODE_OAUTH_TOKEN`) — no per-token API costs.
 
-### Hourly Breaking News Scan
+### Breaking News Pipeline (two-tier)
 
-In addition to the nightly deep updates, an hourly pipeline scans 24+ RSS feeds from international sources (Reuters, BBC, Al Jazeera, France24, SCMP, ReliefWeb, and more) for breaking developments. An AI triage agent classifies each headline and routes significant events to the appropriate tracker for immediate update.
+Two scheduled scans cover breaking news end-to-end:
 
-| Step | What happens |
-|------|-------------|
-| **Poll** | Fetch RSS feeds from 24+ international sources |
-| **Pre-filter** | Deduplicate against recent events, cap at 30 candidates |
-| **AI Triage** | Claude Sonnet classifies: update, new tracker suggestion, or discard |
-| **Data Update** | For each matched tracker: update events, KPIs, meta, maps |
-| **Validate** | Zod schema validation with auto-fix |
-| **Deploy** | Commit, push, trigger site rebuild |
+**Light scan** (every 15 min, no LLM cost): polls a curated set of high-signal wires (Reuters, BBC, AP top-stories, GDELT) plus public real-time sources (Bluesky firehose for select OSINT/news accounts, Telegram public channels). Scores each candidate against active trackers via deterministic keyword matching (`src/lib/keyword-match.ts`). Score ≥ 0.85 → posts to Telegram immediately. Score 0.5–0.85 → defers to `public/_hourly/pending-candidates.json` for the next heavy scan. Score < 0.5 → discards to the audit log.
+
+**Heavy scan** (every 6 h, Claude Sonnet triage): polls the wider RSS list (24+ sources) plus per-tracker dynamic feeds (`src/lib/tracker-feeds.ts` — adding a Mexican tracker auto-pulls Animal Político / La Jornada / El Universal / Aristegui; an Indian tracker auto-pulls The Hindu / Indian Express / Times of India; etc.) plus the same realtime sources. Reads `pending-candidates.json` from light scans and merges. Sonnet classifies each: update / new_tracker_suggestion / discard. Every decision is appended to `public/_hourly/triage-log.json`.
+
+**Audit page** (`/breaking-news-audit/`): public dashboard showing every triage decision in the last 14 days with filters by decision / scan type / score. Use this to spot rejected candidates that should have been accepted and tune thresholds.
+
+| Step | Light scan | Heavy scan |
+|---|---|---|
+| **Poll** | curated wires + Bluesky + Telegram | full RSS (24+) + per-tracker dynamic feeds + Bluesky + Telegram + pending-candidates.json |
+| **Score / triage** | keyword-match (deterministic, no LLM) | Claude Sonnet triage |
+| **Above threshold** | Telegram post (≥ 0.85) | tracker update workflow |
+| **Below threshold** | defer 0.5–0.85, discard < 0.5 | discard |
+| **Audit** | append to `triage-log.json` | append to `triage-log.json` (+ 14-day prune) |
+| **Cadence** | 15 min | 6 h |
 
 ### Setup
 

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -1,6 +1,6 @@
 # Watchboard Product Roadmap
 
-Last updated: 2026-04-26
+Last updated: 2026-04-27
 
 This is the **platform** roadmap — performance, growth, content, accessibility, infrastructure, UX. New tracker requests live in [`docs/tracker-roadmap.md`](./tracker-roadmap.md) and the community vote at `/vote`.
 
@@ -24,7 +24,7 @@ The interactive view is at **[/roadmap/](https://watchboard.dev/roadmap/)** (kan
 
 ## M1 — April 2026 ✅ shipped
 
-**Theme:** Onboarding + perf foundations.
+**Theme:** Onboarding + perf foundations + breaking-news pipeline.
 
 | Status | Title | Area | Priority | PRs |
 |---|---|---|---|---|
@@ -34,11 +34,15 @@ The interactive view is at **[/roadmap/](https://watchboard.dev/roadmap/)** (kan
 | ✅ | PostHog Web Vitals capture | Analytics | P1 | #125 |
 | ✅ | Fix globe double-spin on tracker click | UX | P2 | #127 |
 | ✅ | Documentation sync | Infrastructure | P2 | #128 |
+| ✅ | Public roadmap page | Growth | P2 | #129 |
+| ✅ | CI hygiene (action versions + nightly headroom) | Reliability | P2 | #130 |
+| ✅ | **Breaking-news pipeline redesign** (light scan + per-tracker feeds + realtime + audit) | Reliability / Growth | **P0** | #131 |
 
 **Verified outcomes:**
 - vendor-globe long-task: **5018 ms → 178 ms** (Lighthouse mobile post-deploy).
 - LCP element (`p.story-briefing-text`) now exists in initial HTML on mobile.
 - Real-user perf samples flowing into PostHog → Insights → Web Vitals.
+- Breaking-news cadence: **6 h → 15 min** for major-wire stories. Per-tracker feeds auto-extend coverage when a new tracker is added (no scan-script edits). Every triage decision now visible at `/breaking-news-audit/` for threshold tuning.
 
 ---
 

--- a/src/data/roadmap-items.ts
+++ b/src/data/roadmap-items.ts
@@ -117,6 +117,32 @@ export const ROADMAP_ITEMS: RoadmapItem[] = [
     status: 'shipped', area: 'infrastructure', priority: 'P2', effort: 'XS', milestone: 'M1',
     prs: [128], date: '2026-04-26',
   },
+  {
+    id: 'rm-public-roadmap-page',
+    title: 'Public /roadmap page',
+    description:
+      '33-item interactive roadmap (kanban + timeline + area filters + expandable cards) sourced from src/data/roadmap-items.ts and mirrored at docs/product-roadmap.md. Linked from About + footer.',
+    status: 'shipped', area: 'growth', priority: 'P2', effort: 'M', milestone: 'M1',
+    prs: [129], date: '2026-04-26',
+  },
+  {
+    id: 'rm-ci-hygiene',
+    title: 'CI hygiene: action versions + nightly headroom',
+    description:
+      'Bump actions/checkout v4 → v5 and actions/setup-node v4 → v5 across all 14 workflow files (Node 20 deprecation 2026-06-02). Bump nightly finalize timeout-minutes 20 → 45 (Astro build + social queue was hitting the wall). Drop invalid timeout_minutes input from claude-code-action.',
+    status: 'shipped', area: 'reliability', priority: 'P2', effort: 'S', milestone: 'M1',
+    prs: [130], date: '2026-04-27',
+  },
+  {
+    id: 'rm-breaking-news-pipeline',
+    title: 'Breaking-news pipeline redesign (light scan + per-tracker feeds + realtime + audit)',
+    description:
+      'Two-tier scan cadence (15-min light scan + 6h heavy scan) + per-tracker dynamic feeds (COUNTRY_FEEDS keyed by ISO codes + REGION_FEEDS + DOMAIN_FEEDS) + realtime sources (Bluesky firehose + Telegram public channels) + persistent triage audit log + public /breaking-news-audit/ page. Light scan uses deterministic keyword matching (no LLM cost); heavy scan keeps Sonnet triage. Adding a tracker auto-extends source coverage with no scan-script edits.',
+    status: 'shipped', area: 'reliability', priority: 'P0', effort: 'XL', milestone: 'M1',
+    prs: [131], date: '2026-04-27',
+    outcome:
+      'Major-wire breaking news cadence: 6h → 15min. Mexican/Indian/Israeli trackers automatically pull native-language outlets. Every triage decision visible for tuning at /breaking-news-audit/.',
+  },
 
   // ─── M2 — May 2026: Real-user perf + growth ─────────────────────────
   {


### PR DESCRIPTION
Documents PR #131 (and a couple stragglers) so README, CHANGELOG, the markdown product-roadmap, and the live /roadmap page all reflect what's deployed.

## Files
- **README.md** — \"Hourly Breaking News Scan\" section rewritten to describe the two-tier (15 min light + 6 h heavy) cadence, dynamic per-tracker feeds, Bluesky/Telegram realtime sources, and the new /breaking-news-audit/ page.
- **CHANGELOG.md** — new \`Added — 2026-04-27\` entry for #131 with file-level detail.
- **docs/product-roadmap.md** — breaking-news pipeline moved to M1 shipped (was implicit future); also adds #129 (public roadmap page) and #130 (CI hygiene) that were missing from the M1 table. Last-updated date bumped.
- **src/data/roadmap-items.ts** — adds 3 shipped items so the live \`/roadmap\` page stat counters and Kanban view include #129/#130/#131.

## Test plan
- [x] \`npx tsc --noEmit\` clean for touched files
- [x] \`npm run build\` succeeds, \`/roadmap/\` page rebuilds with the new items
- [ ] After deploy, /roadmap shows Shipped count = 9 (was 6), and #131 card visible in Kanban
- [ ] /breaking-news-audit/ link visible from About + footer (already shipped via #131; just verifying nothing got broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)