### PR TITLE
docs: sync README + roadmap with #134 + #135

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ All data workflows use `claude-code-action` with a Claude Max subscription OAuth
 
 Two scheduled scans cover breaking news end-to-end:
 
-**Light scan** (every 15 min, no LLM cost): polls a curated set of high-signal wires (Reuters, BBC, AP top-stories, GDELT) plus public real-time sources (Bluesky firehose for select OSINT/news accounts, Telegram public channels). Scores each candidate against active trackers via deterministic keyword matching (`src/lib/keyword-match.ts`). Score ≥ 0.85 → posts to Telegram immediately. Score 0.5–0.85 → defers to `public/_hourly/pending-candidates.json` for the next heavy scan. Score < 0.5 → discards to the audit log.
+**Light scan** (every 15 min, no LLM cost): polls a curated set of high-signal wires (Reuters, BBC, AP top-stories, GDELT) plus public real-time sources (Bluesky firehose for select OSINT/news accounts, Telegram public channels). Scores each candidate against active trackers via deterministic keyword matching (`src/lib/keyword-match.ts`). Score ≥ 0.85 → posts to Telegram **and** queues to `public/_hourly/pending-candidates.json` so the next heavy scan promotes it to AI triage and writes the tracker event. Score 0.5–0.85 → queue only. Score < 0.5 → discards to the audit log. Telegram is the realtime alert channel; only the heavy scan writes tracker JSON.
 
 **Heavy scan** (every 6 h, Claude Sonnet triage): polls the wider RSS list (24+ sources) plus per-tracker dynamic feeds (`src/lib/tracker-feeds.ts` — adding a Mexican tracker auto-pulls Animal Político / La Jornada / El Universal / Aristegui; an Indian tracker auto-pulls The Hindu / Indian Express / Times of India; etc.) plus the same realtime sources. Reads `pending-candidates.json` from light scans and merges. Sonnet classifies each: update / new_tracker_suggestion / discard. Every decision is appended to `public/_hourly/triage-log.json`.
 
@@ -296,8 +296,8 @@ Two scheduled scans cover breaking news end-to-end:
 |---|---|---|
 | **Poll** | curated wires + Bluesky + Telegram | full RSS (24+) + per-tracker dynamic feeds + Bluesky + Telegram + pending-candidates.json |
 | **Score / triage** | keyword-match (deterministic, no LLM) | Claude Sonnet triage |
-| **Above threshold** | Telegram post (≥ 0.85) | tracker update workflow |
-| **Below threshold** | defer 0.5–0.85, discard < 0.5 | discard |
+| **Above threshold** | Telegram post + queue to pending (≥ 0.85) | tracker update workflow |
+| **Below threshold** | queue 0.5–0.85, discard < 0.5 | discard |
 | **Audit** | append to `triage-log.json` | append to `triage-log.json` (+ 14-day prune) |
 | **Cadence** | 15 min | 6 h |
 

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -1,6 +1,6 @@
 # Watchboard Product Roadmap
 
-Last updated: 2026-04-28
+Last updated: 2026-04-28 (post-#135)
 
 This is the **platform** roadmap — performance, growth, content, accessibility, infrastructure, UX. New tracker requests live in [`docs/tracker-roadmap.md`](./tracker-roadmap.md) and the community vote at `/vote`.
 
@@ -39,6 +39,8 @@ The interactive view is at **[/roadmap/](https://watchboard.dev/roadmap/)** (kan
 | ✅ | **Breaking-news pipeline redesign** (light scan + per-tracker feeds + realtime + audit) | Reliability / Growth | **P0** | #131 |
 | ✅ | Docs sync — README / CHANGELOG / roadmap for the breaking-news pipeline | Infrastructure | P2 | #132 |
 | ✅ | Consolidated freshness indicator (Header + audit page) — implements the freshness slice of the 2026-03-04 P0 data-freshness-indicators spec | UX | P1 | #133 |
+| ✅ | Docs sync — extensive sync for #133 + #132 (README, CHANGELOG, roadmap, CLAUDE.md) | Infrastructure | P2 | #134 |
+| ✅ | **Light-scan high-score → tracker data** regression fix — high-confidence breaking news now reaches the heavy scan via pending queue (was Telegram-only); also fixes pending-dedup bug that silently dropped every queued candidate | Reliability | **P0** | #135 |
 
 **Verified outcomes:**
 - vendor-globe long-task: **5018 ms → 178 ms** (Lighthouse mobile post-deploy).

--- a/src/data/roadmap-items.ts
+++ b/src/data/roadmap-items.ts
@@ -161,6 +161,24 @@ export const ROADMAP_ITEMS: RoadmapItem[] = [
     outcome:
       '~38 lines of vanilla DOM mutation deleted. 9 unit tests lock down classifyFreshness boundaries + formatAgo buckets. Locale-aware "unknown" copy (en/es/fr/pt). Reusable for future pages that need at-a-glance freshness.',
   },
+  {
+    id: 'rm-docs-sync-freshness',
+    title: 'Docs sync — extensive sync for #133 (freshness) + #132',
+    description:
+      'README, CHANGELOG, product-roadmap.md, CLAUDE.md, and src/data/roadmap-items.ts updated so that documentation, the live /roadmap page stat counters, and the Kanban view all reflect PR #132 and #133 (freshness consolidation). Mirrors the FreshnessBadge React island into the islands catalog; documents TriageLogBoard\'s "Last scan:" mount.',
+    status: 'shipped', area: 'infrastructure', priority: 'P2', effort: 'XS', milestone: 'M1',
+    prs: [134], date: '2026-04-28',
+  },
+  {
+    id: 'rm-light-scan-pending-fix',
+    title: 'Light-scan high-score hits now reach tracker data',
+    description:
+      'Two bugs in the breaking-news pipeline silently swallowed every queued candidate. (1) hourly-light-scan.ts routed score ≥ 0.85 only to Telegram + audit log, never to pending-candidates.json — so the AI-triage heavy scan (which is what writes tracker JSON) never saw the candidate. The CJNG El Jardinero detention was the canary: detected 2× at 0.87 on 2026-04-27, posted to Telegram, but mencho-cjng/data/events/* unchanged. (2) hourly-scan.ts deduped pending entries against state.seen — but every pending URL was guaranteed to be in state.seen by the time the heavy scan ran, so all of them were filtered out. Fix: high-score branch also pushes to pending; pending-promotion extracted into testable helper that dedups only against the in-flight batch. 4 new unit tests, [hourly-scan] promoted N log line for observability.',
+    status: 'shipped', area: 'reliability', priority: 'P0', effort: 'S', milestone: 'M1',
+    prs: [135], date: '2026-04-28',
+    outcome:
+      'Closes the alert→triage→data-update loop the original two-tier redesign assumed but never wired. High-confidence breaking news now lands in tracker events files within ~6 h instead of being lost.',
+  },
 
   // ─── M2 — May 2026: Real-user perf + growth ─────────────────────────
   {


### PR DESCRIPTION
## Summary

Documentation lag from the last two PRs:

- **README** Breaking-News section: light scan ≥ 0.85 was described as Telegram-only. PR #135 made it Telegram + queue (so the heavy scan can promote it to AI triage and write tracker JSON). README now says so, and the cadence table cell updated.
- **`docs/product-roadmap.md`** M1 table: adds rows for #134 (docs sync for #133/#132) and #135 (light-scan high-score → tracker data fix). "Last updated" date bumped.
- **`src/data/roadmap-items.ts`** mirrors the same two cards (`rm-docs-sync-freshness` and `rm-light-scan-pending-fix`) so the live `/roadmap` page stat counters and Kanban view stay in sync with the markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)