### PR TITLE
fix(video): progress caption reads breaking-data-progress.json instead of breaking.json

### DIFF
--- a/.github/workflows/daily-video.yml
+++ b/.github/workflows/daily-video.yml
@@ -327,8 +327,11 @@ jobs:
       - name: Render progress video
         run: cd video && npx tsx render.ts --mode positive
 
-      # Snapshot the progress caption immediately, same reason as breaking.
-      - name: Snapshot Telegram caption (progress) from breaking.json
+      # Snapshot the progress caption immediately after the progress render.
+      # Must read breaking-data-progress.json (written by render.ts --mode positive),
+      # NOT breaking.json which belongs to the conflict job and may carry stale
+      # or conflict-mode trackers. See: https://github.com/ArtemioPadilla/watchboard/issues/141
+      - name: Snapshot Telegram caption (progress) from breaking-data-progress.json
         run: |
           DATE=$(date -u +%Y-%m-%d)
           DATE="$DATE" node -e "
@@ -344,7 +347,11 @@ jobs:
             const fs = require('fs');
             const date = process.env.DATE;
             try {
-              const d = JSON.parse(fs.readFileSync('video/src/data/breaking.json', 'utf8'));
+              const progressPath = 'video/src/data/breaking-data-progress.json';
+              const fallbackPath = 'video/src/data/breaking.json';
+              const srcPath = fs.existsSync(progressPath) ? progressPath : fallbackPath;
+              if (srcPath === fallbackPath) console.warn('WARNING: breaking-data-progress.json not found, falling back to breaking.json');
+              const d = JSON.parse(fs.readFileSync(srcPath, 'utf8'));
               const lines = d.trackers.map(t => {
                 const head = (t.headline || t.name || '').trim();
                 return '✅ <b>' + escapeHtml(t.name) + '</b>: ' + escapeHtml(head);
@@ -385,7 +392,12 @@ jobs:
             exit 0
           fi
           DATE=$(date -u +%Y-%m-%d)
-          TRACKERS=$(node -e "const d=require('./video/src/data/breaking.json'); console.log(d.trackers.map(t=>t.name).join('. '))")
+          TRACKERS=$(node -e "
+            const fs = require('fs');
+            const p = fs.existsSync('./video/src/data/breaking-data-progress.json') ? './video/src/data/breaking-data-progress.json' : './video/src/data/breaking.json';
+            const d = require(p);
+            console.log(d.trackers.map(t=>t.name).join('. '));
+          ")
 
           aws polly synthesize-speech \
             --engine generative \


### PR DESCRIPTION
## Problem

The 🌱 Progress Brief was repeating the same Science/Space headlines every day.

**Root cause:** The `Snapshot Telegram caption (progress)` and `Generate narration (progress tone)` steps were reading `video/src/data/breaking.json`, which is the *conflict* job's output. `breaking.json` in the repo was also stale (dated 2026-04-18) with hardcoded trackers `cancer-breakthroughs`, `artemis-2`, `spacex-history` — exactly the three headlines that repeated daily.

## Fix

`render.ts` already writes the correct mode-specific snapshot when running with `--mode positive`:
```ts
// render.ts ~line 120 — already correct, untouched
const snapshotName = mode === 'positive' ? 'breaking-data-progress.json' : 'breaking-data-breaking.json';
```

This PR makes the two affected workflow steps use that file:

- **Caption step:** reads `video/src/data/breaking-data-progress.json` with fallback to `breaking.json` + warning if progress snapshot is missing
- **Narration step:** same fallback pattern

## Changes

Only `.github/workflows/daily-video.yml` — 2 steps in the `video-progress` job:

| Step | Before | After |
|------|--------|-------|
| Snapshot Telegram caption (progress) | `breaking.json` | `breaking-data-progress.json` (+ fallback) |
| Generate narration with Polly (progress) | `breaking.json` | `breaking-data-progress.json` (+ fallback) |

The `video` job (conflict/breaking) is **unchanged**.

## Testing

After merge, the next midnight UTC run will:
1. Render conflict video → write `breaking-data-breaking.json`
2. Render progress video → write `breaking-data-progress.json` with today's science/space trackers
3. Caption step reads `breaking-data-progress.json` ✅ — fresh headlines, no repeats

Closes #141