### PR TITLE
fix(ci): Stop metrics commit from shipping invalid tracker JSON

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate tracker data (fail fast on bad JSON/schema)
+        # Runs in ~1s. Surfaces invalid tracker data with a precise file:line
+        # annotation in the Actions UI instead of waiting ~2 min for `astro build`
+        # to crash with a vite plugin stack trace.
+        run: npm run validate-data
+
       - name: Backfill missing digests
         run: npx tsx scripts/ensure-digests.ts
 

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -617,6 +617,23 @@ jobs:
         if: steps.fix_agent.outcome == 'success' && steps.validate.outputs.valid == 'false'
         run: |
           git add trackers/
+          # JSON syntax check first — the fix agent has occasionally produced files
+          # with stray commas or missing punctuation. Without this gate the next
+          # block does an uncaught JSON.parse and we get a noisy stack trace
+          # instead of a clear "invalid JSON" signal.
+          invalid=0
+          for f in $(find trackers -name '*.json' -path '*/data/*' -type f ! -name 'review-manifest.json'); do
+            if ! node -e "JSON.parse(require('fs').readFileSync('$f','utf8'))" 2>/dev/null; then
+              echo "::error file=$f::Fix agent produced invalid JSON"
+              invalid=$((invalid + 1))
+            fi
+          done
+          if [ "$invalid" -gt 0 ]; then
+            echo "valid=false" >> $GITHUB_OUTPUT
+            echo "error_count=$invalid" >> $GITHUB_OUTPUT
+            echo "$invalid file(s) have invalid JSON after fix agent — aborting"
+            exit 0
+          fi
           npx tsx -e "
           import { z } from 'zod';
           import * as S from './src/lib/schemas.js';
@@ -675,8 +692,20 @@ jobs:
             steps.revalidate.outputs.valid == 'true'
           )
         run: |
-          npm run build 2>&1 | tail -20
-          echo "build_ok=true" >> $GITHUB_OUTPUT
+          # Capture exit code explicitly — piping through `tail` (the old form)
+          # masked failures because tail always exits 0, so build_ok was set even
+          # when astro build crashed.
+          set +e
+          npm run build > /tmp/build.log 2>&1
+          BUILD_EXIT=$?
+          set -e
+          tail -50 /tmp/build.log
+          if [ "$BUILD_EXIT" -eq 0 ]; then
+            echo "build_ok=true" >> $GITHUB_OUTPUT
+          else
+            echo "build_ok=false" >> $GITHUB_OUTPUT
+            echo "::error::Build failed (exit $BUILD_EXIT) — data commit will be skipped"
+          fi
         continue-on-error: true
 
       - name: Validate media URLs
@@ -1114,8 +1143,14 @@ jobs:
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+          # Earlier steps (Check for changes, Re-validate after fix) run `git add trackers/`.
+          # If the data commit was skipped (validation/build gate failed) those files stay
+          # staged and would otherwise piggy-back into this metrics commit — that's how
+          # broken tracker JSON ended up tagged as `chore(metrics): ... [failure]` and
+          # silently shipped to main. Reset the index so this commit is metrics-only.
+          git reset HEAD -- . >/dev/null
           git add public/_metrics/ public/_social/
-          if git diff --cached --quiet public/_metrics/ public/_social/; then
+          if git diff --cached --quiet; then
             echo "No metrics changes"
             exit 0
           fi

--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -1,0 +1,46 @@
+name: Validate Tracker Data
+
+# Defense in depth: every push that touches tracker JSON gets a focused
+# green/red signal in <30s, independent of the full Astro build & deploy.
+# Catches issues like missing commas, bad enum values, or schema regressions
+# at the commit that introduced them — including bot commits.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'trackers/**/data/**/*.json'
+      - 'src/lib/schemas.ts'
+      - 'scripts/validate-tracker-data.ts'
+      - '.github/workflows/validate-data.yml'
+  pull_request:
+    paths:
+      - 'trackers/**/data/**/*.json'
+      - 'src/lib/schemas.ts'
+      - 'scripts/validate-tracker-data.ts'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-data-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate JSON syntax + Zod schemas
+        run: npm run validate-data

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "postbuild": "npx pagefind --site dist --glob '**/*.html'",
     "preview": "astro preview",
     "update-data": "tsx scripts/update-data.ts",
+    "validate-data": "tsx scripts/validate-tracker-data.ts",
     "backfill": "tsx scripts/backfill.ts",
     "backfill-gaps": "tsx scripts/backfill-gaps.ts",
     "backfill-osint": "tsx scripts/backfill-osint.ts",

--- a/scripts/validate-tracker-data.ts
+++ b/scripts/validate-tracker-data.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env tsx
+/**
+ * Tracker data validator — single source of truth.
+ *
+ * Usage:
+ *   tsx scripts/validate-tracker-data.ts             # JSON syntax + Zod schemas
+ *   tsx scripts/validate-tracker-data.ts --syntax    # JSON syntax only (fast)
+ *   tsx scripts/validate-tracker-data.ts --json      # machine-readable output
+ *
+ * Exit code:
+ *   0 — all data files valid
+ *   1 — at least one file invalid (full report on stderr)
+ *
+ * Called by:
+ *   - `npm run validate-data`                              (local dev)
+ *   - .github/workflows/deploy.yml                         (pre-build gate)
+ *   - .github/workflows/validate-data.yml                  (per-push check)
+ *   - .github/workflows/update-data.yml fix-agent loop     (re-check after fix)
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
+import * as S from '../src/lib/schemas.js';
+
+type Issue = {
+  tracker: string;
+  file: string;
+  kind: 'json' | 'schema';
+  line?: number;
+  field?: string;
+  message: string;
+};
+
+const SCHEMA_MAP: Record<string, z.ZodTypeAny> = {
+  'kpis.json': z.array(S.KpiSchema),
+  'timeline.json': z.array(S.TimelineEraSchema),
+  'map-points.json': z.array(S.MapPointSchema),
+  'map-lines.json': z.array(S.MapLineSchema),
+  'strike-targets.json': z.array(S.StrikeItemSchema),
+  'retaliation.json': z.array(S.StrikeItemSchema),
+  'assets.json': z.array(S.AssetSchema),
+  'casualties.json': z.array(S.CasualtyRowSchema),
+  'econ.json': z.array(S.EconItemSchema),
+  'claims.json': z.array(S.ClaimSchema),
+  'political.json': z.array(S.PolItemSchema),
+  'meta.json': S.MetaSchema,
+  'digests.json': z.array(S.DigestEntrySchema),
+};
+const EVENT_SCHEMA = z.array(S.TimelineEventSchema);
+
+const SKIP_FILES = new Set(['review-manifest.json', 'update-log.json']);
+
+function approxLineFromPosition(text: string, pos: number): number {
+  return text.slice(0, pos).split('\n').length;
+}
+
+function parseJsonWithLine(file: string, raw: string): { ok: true; value: unknown } | { ok: false; line: number; message: string } {
+  try {
+    return { ok: true, value: JSON.parse(raw) };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const match = message.match(/position (\d+)/);
+    const line = match ? approxLineFromPosition(raw, Number(match[1])) : 1;
+    return { ok: false, line, message };
+  }
+}
+
+async function main() {
+  const args = new Set(process.argv.slice(2));
+  const syntaxOnly = args.has('--syntax') || args.has('--syntax-only');
+  const jsonOutput = args.has('--json');
+
+  const issues: Issue[] = [];
+  const trackersDir = path.resolve('trackers');
+
+  if (!fs.existsSync(trackersDir)) {
+    console.error(`No trackers/ directory at ${trackersDir}`);
+    process.exit(1);
+  }
+
+  const slugs = fs
+    .readdirSync(trackersDir)
+    .filter((s) => fs.statSync(path.join(trackersDir, s)).isDirectory())
+    .sort();
+
+  let filesChecked = 0;
+
+  for (const slug of slugs) {
+    const dataDir = path.join(trackersDir, slug, 'data');
+    if (!fs.existsSync(dataDir)) continue;
+
+    const visit = (filePath: string) => {
+      const base = path.basename(filePath);
+      if (SKIP_FILES.has(base)) return;
+      filesChecked++;
+      const raw = fs.readFileSync(filePath, 'utf8');
+      const parsed = parseJsonWithLine(filePath, raw);
+      if (!parsed.ok) {
+        issues.push({
+          tracker: slug,
+          file: path.relative(process.cwd(), filePath),
+          kind: 'json',
+          line: parsed.line,
+          message: parsed.message,
+        });
+        return; // can't run Zod on unparseable JSON
+      }
+
+      if (syntaxOnly) return;
+
+      const rel = path.relative(dataDir, filePath); // e.g. "events/2026-05-01.json" or "kpis.json"
+      let schema: z.ZodTypeAny | undefined;
+      if (rel.startsWith('events' + path.sep)) {
+        schema = EVENT_SCHEMA;
+      } else {
+        schema = SCHEMA_MAP[base];
+      }
+      if (!schema) return; // no schema = ignore (e.g. tracker.json lives elsewhere)
+
+      const result = schema.safeParse(parsed.value);
+      if (!result.success) {
+        for (const err of result.error.errors.slice(0, 5)) {
+          issues.push({
+            tracker: slug,
+            file: path.relative(process.cwd(), filePath),
+            kind: 'schema',
+            field: err.path.join('.'),
+            message: err.message,
+          });
+        }
+      }
+    };
+
+    for (const f of fs.readdirSync(dataDir)) {
+      const fp = path.join(dataDir, f);
+      if (fs.statSync(fp).isFile() && f.endsWith('.json')) visit(fp);
+    }
+    const eventsDir = path.join(dataDir, 'events');
+    if (fs.existsSync(eventsDir)) {
+      for (const f of fs.readdirSync(eventsDir)) {
+        if (f.endsWith('.json')) visit(path.join(eventsDir, f));
+      }
+    }
+  }
+
+  if (jsonOutput) {
+    console.log(JSON.stringify({ ok: issues.length === 0, filesChecked, issues }, null, 2));
+  } else {
+    if (issues.length === 0) {
+      console.log(`✓ ${filesChecked} tracker data file(s) valid${syntaxOnly ? ' (JSON syntax only)' : ''}`);
+    } else {
+      console.error(`✗ ${issues.length} issue(s) across ${filesChecked} file(s):\n`);
+      for (const issue of issues) {
+        const loc = issue.line !== undefined ? `:${issue.line}` : '';
+        const field = issue.field ? ` [${issue.field}]` : '';
+        // GitHub Actions annotation format — picked up automatically by Actions UI.
+        console.error(`::error file=${issue.file},line=${issue.line ?? 1}::${issue.kind.toUpperCase()}${field}: ${issue.message}`);
+        console.error(`  ${issue.file}${loc}${field}`);
+        console.error(`    ${issue.message}\n`);
+      }
+    }
+  }
+
+  process.exit(issues.length === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('Validator crashed:', err);
+  process.exit(2);
+});

--- a/trackers/crispr-gene-therapy/data/econ.json
+++ b/trackers/crispr-gene-therapy/data/econ.json
@@ -97,7 +97,7 @@
     "color": "#9b59b6",
     "source": "Editas Medicine Q1 2026 Financial Results, May 5, 2026",
     "lastUpdated": "2026-05-06"
-  }
+  },
   {
     "id": "lilly-profluent-gene-editing-deal-2026",
     "label": "Eli Lilly / Profluent AI Gene Editing Partnership Value",


### PR DESCRIPTION
## Summary

The nightly **Update Data** workflow has been silently shipping broken tracker JSON to `main` for 5 days, blocking every **Build and Deploy** run since 2026-05-06. `trackers/crispr-gene-therapy/data/econ.json` lost a comma at line 100 (introduced by the fix agent), and the workflow plumbing then promoted that broken file to `main` once a day under a `chore(metrics): ... [failure]` subject — and continued to re-promote uncommitted local changes every nightly run after.

This PR fixes three nightly-workflow bugs that combined to cause the regression, restores the JSON, and adds layered validation so it cannot recur.

### Root cause: three workflow bugs in `update-data.yml`

**Bug A (critical) — leaky staged index in the metrics commit step**
The `Check for changes` and `Re-validate after fix` steps run `git add trackers/`. When validation or the build gate fails, the data commit is skipped — but the `trackers/` files stay staged. The metrics commit then runs `git add public/_metrics/ public/_social/` on top of the existing index and `git commit` ships the whole thing, smuggling invalid tracker JSON to `main`. Fix: `git reset HEAD -- .` before staging metrics-only paths.

**Bug B — build gate masked failures**
`npm run build 2>&1 | tail -20` always exited 0 because `tail` does. `build_ok=true` was being written regardless of whether `astro build` actually succeeded. Replaced with explicit exit-code capture.

**Bug C — re-validate skipped JSON syntax check**
The fix agent has historically produced invalid JSON. The re-validate step jumped straight into Zod and threw an uncaught `JSON.parse` exception instead of emitting a clear `file:line` error. Re-added the syntax pre-check.

### Prevention — multi-layer validation

- **`scripts/validate-tracker-data.ts`** (new) — single reusable validator. JSON syntax + Zod schemas in one pass, GitHub-Actions `::error file=...,line=...` annotations, `--syntax` fast mode, `--json` machine output. Exposed as `npm run validate-data`.
- **`deploy.yml`** — validates data **before** the expensive `astro build`. A bad comma now fails in ~5s with the exact file:line, instead of waiting 2 min for a vite-json stack trace.
- **`validate-data.yml`** (new) — dedicated ~30s workflow on every push touching `trackers/**/data`, `src/lib/schemas.ts`, or the validator itself. Gives a focused green/red signal on data health, independent of deploy noise.

### Immediate unblocker

`trackers/crispr-gene-therapy/data/econ.json:100` — restored the missing comma.

### Defense layers, earliest to latest

| Layer | Surface | Feedback time |
|---|---|---|
| Local | `npm run validate-data` | <2 s |
| CI push | `validate-data` workflow | ~30 s |
| CI deploy | `deploy.yml` pre-build gate | ~5 s |
| Nightly | fix agent JSON syntax recheck | inline |
| Nightly | metrics commit can't carry `trackers/` | inline |
| Nightly | build gate exit-code is honest | inline |

## Test plan

- [x] `node -e "JSON.parse(require('fs').readFileSync('trackers/crispr-gene-therapy/data/econ.json','utf8'))"` → ok
- [x] `npm run validate-data` → `✓ 3184 tracker data file(s) valid`
- [x] `npm run validate-data -- --syntax` → ok
- [x] Negative test: re-introduced the missing comma; validator exited 1 with `::error file=trackers/crispr-gene-therapy/data/econ.json,line=101::JSON: Expected ',' or ']' …`
- [x] YAML parse: `update-data.yml`, `deploy.yml`, `validate-data.yml` all parse
- [x] `npm run build` astro phase: all 95 tracker pages built (`✓ Completed in 748s`)
- [ ] On merge: confirm `Build and Deploy to GitHub Pages` goes green again
- [ ] Next nightly run (2026-05-11 14:00 UTC): no `chore(metrics): … [failure]` commit touches `trackers/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)