### PR TITLE
fix: correct time field format in ukraine-war map-lines.json

### DIFF
--- a/trackers/ukraine-war/data/map-lines.json
+++ b/trackers/ukraine-war/data/map-lines.json
@@ -7,7 +7,7 @@
     "label": "Ukraine strike — Volgograd industrial facility",
     "date": "2026-06-27",
     "weaponType": "drone",
-    "time": "2026-06-27T12:00:00Z",
+    "time": "12:00",
     "confidence": "high",
     "damage": "Industrial facility struck in Volgograd region",
     "notes": "Cross-border Ukrainian strike on Russian industrial target"
@@ -20,7 +20,7 @@
     "label": "Russian drone strike — Dnipropetrovsk region",
     "date": "2026-06-27",
     "weaponType": "drone",
-    "time": "2026-06-27T14:00:00Z",
+    "time": "14:00",
     "confidence": "high",
     "damage": "At least 1 killed, dozens wounded in Dnipropetrovsk region",
     "notes": "Part of mutual exchange; total 5 killed across both countries"


### PR DESCRIPTION
Fixes the failing `Build and Deploy to GitHub Pages` workflow.

**Root cause:** two entries in `trackers/ukraine-war/data/map-lines.json` had full ISO timestamps (`2026-06-27T12:00:00Z`) in the `time` field instead of the required `HH:MM` format, tripping `TimeFieldSchema` in `validate-tracker-data.ts`.

**Fix:** normalized both to `HH:MM` (`12:00`, `14:00`).

Verified locally: `npm run validate-data` now passes (4794 files valid).