### PR TITLE
fix(pipeline): Bound media URL validation and move it off the critical path

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -714,6 +714,38 @@ jobs:
           fi
         continue-on-error: true
 
+      - name: Backfill missing digests
+        if: |
+          steps.build_check.outputs.build_ok == 'true'
+        run: npx tsx scripts/ensure-digests.ts
+
+      - name: Commit and push data
+        if: |
+          steps.build_check.outputs.build_ok == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add trackers/
+          git commit -m "chore(data): nightly AI update $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          pushed=false
+          for i in 1 2 3; do
+            if git pull --rebase origin main && git push; then
+              pushed=true
+              break
+            fi
+            echo "Push attempt $i failed, retrying..."
+            git rebase --abort || true
+            git reset --hard HEAD
+            sleep 2
+          done
+          if [ "$pushed" != "true" ]; then
+            echo "Failed to push nightly data commit after 3 attempts"
+            exit 1
+          fi
+
       - name: Validate media URLs
         id: media_check
         if: steps.build_check.outputs.build_ok == 'true'
@@ -816,15 +848,35 @@ jobs:
             console.log('');
             console.log('HEAD-checking ' + urlsToCheck.length + ' media URLs...');
 
-            let ok = 0, broken = 0;
+            // Bounded: a serial loop over every URL grew past the job timeout
+            // (5k+ URLs and climbing daily). Pool the requests and hard-stop on
+            // a wall-clock budget so this diagnostic can never starve the job.
+            const CONCURRENCY = 24;
+            const DEADLINE_MS = 5 * 60 * 1000;
+            const startedAt = Date.now();
+
+            let ok = 0, broken = 0, skipped = 0, cursor = 0;
             const failures = [];
-            for (const entry of urlsToCheck) {
-              const result = await headCheck(entry.url);
-              if (result.ok) { ok++; }
-              else { broken++; failures.push(entry.slug + '/' + entry.event + ': ' + entry.url + ' (' + result.status + ')'); }
+
+            async function worker() {
+              while (true) {
+                const i = cursor++;
+                if (i >= urlsToCheck.length) return;
+                if (Date.now() - startedAt > DEADLINE_MS) { skipped++; continue; }
+                const entry = urlsToCheck[i];
+                const result = await headCheck(entry.url);
+                if (result.ok) { ok++; }
+                else { broken++; failures.push(entry.slug + '/' + entry.event + ': ' + entry.url + ' (' + result.status + ')'); }
+              }
             }
+
+            await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+
             console.log('  Reachable: ' + ok + ' ✓');
             console.log('  Broken URLs: ' + broken + (broken > 0 ? ' ⚠️' : ''));
+            if (skipped > 0) {
+              console.warn('  Skipped (5m time budget exhausted): ' + skipped + ' of ' + urlsToCheck.length + ' ⚠️');
+            }
             if (failures.length > 0) {
               console.warn('');
               console.warn('Broken media URLs (non-blocking):');
@@ -866,38 +918,6 @@ jobs:
           if (pct < 50) console.warn('  ⚠️ Source URL coverage below 50% — consider backfilling');
           else console.log('  ✓ Coverage acceptable');
           "
-
-      - name: Backfill missing digests
-        if: |
-          steps.build_check.outputs.build_ok == 'true'
-        run: npx tsx scripts/ensure-digests.ts
-
-      - name: Commit and push data
-        if: |
-          steps.build_check.outputs.build_ok == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add trackers/
-          git commit -m "chore(data): nightly AI update $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          pushed=false
-          for i in 1 2 3; do
-            if git pull --rebase origin main && git push; then
-              pushed=true
-              break
-            fi
-            echo "Push attempt $i failed, retrying..."
-            git rebase --abort || true
-            git reset --hard HEAD
-            sleep 2
-          done
-          if [ "$pushed" != "true" ]; then
-            echo "Failed to push nightly data commit after 3 attempts"
-            exit 1
-          fi
 
       - name: Collect metrics
         id: metrics


### PR DESCRIPTION
## Summary

The nightly finalize job has been hitting its 45-minute `timeout-minutes` and dying **before `Commit and push data` ever ran** — silently discarding each night's tracker data. GitHub reports a job timeout as `cancelled`, not `failure`, which is why this ran unnoticed.

Two independent root causes, both fixed:

**1. Unbounded serial network check.** `Validate media URLs` HEAD-checks every media URL across all 95 trackers' full event history, one at a time, 5s timeout each. Measured against the real corpus:

| | URLs | Time |
|---|---|---|
| Serial (before) | 5,519 | ~37 min est. / **33.5 min observed** before timeout |
| Pooled 24-way (after) | 5,519 | **47 s** |

It also degrades daily as events accumulate. Now pooled with a hard 5-minute wall-clock budget.

**2. A diagnostic sat on the critical path.** The step is purely informational — its `media_check` id is referenced nowhere in the workflow — yet it ran *ahead* of the data commit. `continue-on-error: true` guards step failure but **not** the job-level timeout, so a slow audit could starve the commit. `Backfill missing digests` and `Commit and push data` now run before both diagnostics.

## Testing

Extracted the actual script from the workflow YAML (not a copy) and ran it against real repo data with stubbed network latency:

- **Full run** — 5,519 URLs in 47s vs 18.4 min serial baseline (23x, matching `CONCURRENCY = 24`), all checked, 0 skipped.
- **Deadline guard** — with an artificially tight 3s budget: hard-stops at 3.9s, checks exactly 360 (= 3s ÷ 200ms × 24), and logs `Skipped (5m time budget exhausted): 5159 of 5519` — no silent truncation.

Verified `finalize` still has 23 steps with no duplicates, correct ordering, and that all 16 workflow files still parse.

## Note — separate issue, not fixed here

The nightly pipeline was *also* fully down from **2026-07-20 to 2026-08-03** because `CLAUDE_CODE_OAUTH_TOKEN` was revoked (`401 OAuth access token has been revoked`), affecting 7 Claude-powered workflows. That secret has since been rotated. This PR is independent of it.

Also unaddressed: `notify-failure` is gated on `if: failure()`, which does not fire on `cancelled()` — so job timeouts produce no alert. That blind spot is why two weeks of failures went unreported. Widening it to `cancelled()` would also fire on manual cancels, so I left it as a judgment call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)