### PR TITLE
fix(pipeline): Bound GDELT sweep so a dead endpoint cannot starve hourly scan

### DIFF
--- a/scripts/hourly-scan.ts
+++ b/scripts/hourly-scan.ts
@@ -36,6 +36,13 @@ const GDELT_ENDPOINT = 'https://api.gdeltproject.org/api/v2/doc/doc';
 const GDELT_THEMES =
   'theme:TERROR OR theme:MILITARY OR theme:NATURAL_DISASTER OR theme:POLITICAL_VIOLENCE';
 
+/** Concurrent per-tracker GDELT queries. Kept modest — GDELT rate-limits. */
+const GDELT_BATCH_SIZE = 6;
+/** Wall-clock cap for the whole per-tracker GDELT phase. */
+const GDELT_PHASE_BUDGET_MS = 90_000;
+/** Consecutive failed queries after which the endpoint is treated as down. */
+const GDELT_FAILURE_STREAK_LIMIT = 8;
+
 /** High-quality general RSS feeds for broad coverage */
 const GENERAL_RSS_FEEDS = [
   // ── Tier 1: Major international wire services & broadsheets ──
@@ -326,11 +333,16 @@ function collectEventUrls(slug: string, daysBack: number): Set<string> {
 
 /**
  * Fetches a GDELT query and returns raw article data.
+ *
+ * Returns `null` when the request itself failed (network error, timeout,
+ * non-OK status) as opposed to succeeding with no articles. Callers use that
+ * distinction to trip a circuit breaker when the endpoint is unreachable —
+ * see the GDELT phase in `scan()`.
  */
 async function queryGdelt(
   query: string,
   maxRecords: number = 25,
-): Promise<RssItem[]> {
+): Promise<RssItem[] | null> {
   const params = new URLSearchParams({
     query,
     mode: 'ArtList',
@@ -347,7 +359,7 @@ async function queryGdelt(
       signal: AbortSignal.timeout(15_000),
       headers: { 'User-Agent': 'Watchboard/1.0 hourly-scan' },
     });
-    if (!resp.ok) return [];
+    if (!resp.ok) return null;
     const data = await resp.json();
     const articles = data?.articles ?? [];
     return articles.map(
@@ -366,7 +378,7 @@ async function queryGdelt(
       }),
     );
   } catch {
-    return [];
+    return null;
   }
 }
 
@@ -525,21 +537,69 @@ export async function scan(): Promise<{ candidates: Candidate[]; state: HourlySt
   }
 
   // 2. Per-tracker GDELT queries (using searchContext)
-  for (const t of trackers) {
-    if (!t.searchContext) continue;
-    const items = await queryGdelt(t.searchContext, 10);
-    for (const item of items) {
-      if (!item.title || !item.url) continue;
-      candidates.push(normalizeCandidate(item, t.slug, 'gdelt'));
+  //
+  // Bounded on purpose. This used to be a serial `for` loop over every tracker,
+  // which is fine while GDELT is healthy but catastrophic when it is not: a
+  // stalled endpoint burns its ~10s connect timeout per call, so ~96 trackers
+  // cost ~18 min and starved the rest of the job until it hit the workflow
+  // timeout. Batch the calls, cap the whole phase on wall-clock, and stop early
+  // once the endpoint looks dead rather than paying the timeout 96 times.
+  const gdeltTrackers = trackers.filter((t) => t.searchContext);
+  const gdeltStart = Date.now();
+  let failStreak = 0;
+  let gdeltDone = 0;
+
+  for (let i = 0; i < gdeltTrackers.length; i += GDELT_BATCH_SIZE) {
+    if (Date.now() - gdeltStart > GDELT_PHASE_BUDGET_MS) {
+      console.warn(
+        `[hourly-scan] GDELT phase budget (${GDELT_PHASE_BUDGET_MS / 1000}s) exhausted — ` +
+          `skipping ${gdeltTrackers.length - gdeltDone} of ${gdeltTrackers.length} tracker queries`,
+      );
+      break;
+    }
+    if (failStreak >= GDELT_FAILURE_STREAK_LIMIT) {
+      console.warn(
+        `[hourly-scan] GDELT endpoint unreachable (${failStreak} consecutive failures) — ` +
+          `skipping ${gdeltTrackers.length - gdeltDone} of ${gdeltTrackers.length} tracker queries`,
+      );
+      break;
+    }
+
+    const batch = gdeltTrackers.slice(i, i + GDELT_BATCH_SIZE);
+    console.log(
+      `[hourly-scan] GDELT per-tracker: batch ${Math.floor(i / GDELT_BATCH_SIZE) + 1}/` +
+        `${Math.ceil(gdeltTrackers.length / GDELT_BATCH_SIZE)} (${batch.length} items)`,
+    );
+
+    const settled = await Promise.all(
+      batch.map(async (t) => ({ slug: t.slug, items: await queryGdelt(t.searchContext!, 10) })),
+    );
+
+    for (const { slug, items } of settled) {
+      gdeltDone++;
+      if (items === null) {
+        failStreak++;
+        continue;
+      }
+      failStreak = 0;
+      for (const item of items) {
+        if (!item.title || !item.url) continue;
+        candidates.push(normalizeCandidate(item, slug, 'gdelt'));
+      }
     }
   }
 
-  // 3. GDELT global sweep (catches out-of-scope events)
-  const gdeltItems = await queryGdelt(GDELT_THEMES, 50);
-  for (const item of gdeltItems) {
-    if (!item.title || !item.url) continue;
-    const matched = matchTrackerByKeywords(item.title, trackerKeywordMap);
-    candidates.push(normalizeCandidate(item, matched, 'gdelt'));
+  // 3. GDELT global sweep (catches out-of-scope events).
+  // Skipped when the per-tracker phase already proved the endpoint is down.
+  if (failStreak < GDELT_FAILURE_STREAK_LIMIT) {
+    const gdeltItems = await queryGdelt(GDELT_THEMES, 50);
+    for (const item of gdeltItems ?? []) {
+      if (!item.title || !item.url) continue;
+      const matched = matchTrackerByKeywords(item.title, trackerKeywordMap);
+      candidates.push(normalizeCandidate(item, matched, 'gdelt'));
+    }
+  } else {
+    console.warn('[hourly-scan] Skipping GDELT global sweep — endpoint unreachable');
   }
 
   // 4. Dedup against seen URLs

--- a/tests/hourly-scan.test.ts
+++ b/tests/hourly-scan.test.ts
@@ -141,4 +141,44 @@ describe('hourly-scan', () => {
       expect(items[0].title).toBe('Atom Article');
     });
   });
+
+  describe('GDELT circuit breaker', () => {
+    // Regression: the per-tracker GDELT sweep was a serial loop over every
+    // tracker. When the endpoint stalls, each call burns its ~10s connect
+    // timeout, so ~96 trackers cost ~18 min and starved the rest of the
+    // hourly-scan job until it hit the 20-minute workflow timeout.
+    it('stops querying after consecutive failures instead of calling once per tracker', async () => {
+      const realFetch = globalThis.fetch;
+      let gdeltCalls = 0;
+
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('gdeltproject.org')) {
+          gdeltCalls++;
+          throw new TypeError('fetch failed'); // simulates UND_ERR_CONNECT_TIMEOUT
+        }
+        // Everything else (RSS) resolves as an empty feed.
+        return {
+          ok: true,
+          url,
+          status: 200,
+          text: async () => '<?xml version="1.0"?><rss><channel></channel></rss>',
+          json: async () => ({}),
+        } as unknown as Response;
+      }) as typeof fetch;
+
+      try {
+        const { scan } = await import('../scripts/hourly-scan.js');
+        await scan();
+
+        // Breaker trips at 8 consecutive failures, checked per batch of 6,
+        // so the sweep must abort within a couple of batches — nowhere near
+        // the ~96 active trackers it would otherwise hit.
+        expect(gdeltCalls).toBeGreaterThan(0);
+        expect(gdeltCalls).toBeLessThanOrEqual(20);
+      } finally {
+        globalThis.fetch = realFetch;
+      }
+    }, 30_000);
+  });
 });


### PR DESCRIPTION
## Summary

The hourly breaking-news scan has been timing out. `Poll news sources` consumed **17m52s of the job's 20-minute budget**, leaving `AI triage` two minutes before the timeout killed it — so `Commit state` never ran and **nothing was persisted**.

### Root cause

The per-tracker GDELT sweep was a serial `for` loop — one awaited request per tracker, no batching, no progress logging (hence a silent 17-minute gap in the logs between "Resolving Google News URLs" and the final write).

`api.gdeltproject.org` is currently **accepting TCP connections but stalling before responding**:

```
DNS         104.197.47.124            resolves fine
TCP connect 0.116s                    succeeds
HTTP        http=000, total=12.0s     never responds
undici                                UND_ERR_CONNECT_TIMEOUT @ ~10.5s
```

(`www.gdeltproject.org` returns 200 in 0.55s, so this is specific to the API host, not general reachability.)

So every call burns undici's ~10s connect timeout and returns nothing. With 96 active trackers that's ~97 sequential calls costing ~18 min and yielding **zero** candidates.

### Why this surfaced now

It was masked. `AI triage` used to fail in 11s on the revoked `CLAUDE_CODE_OAUTH_TOKEN`, so the job finished around 18 min and reported `failure`. With auth restored, triage needs real time — and there is none left, so the job now hits the timeout and reports `cancelled`.

## The fix

Bounds the phase three ways:

- **Batch** the queries — 6 concurrent, kept modest since GDELT rate-limits
- **Cap** the whole phase on wall-clock — 90s
- **Circuit breaker** — after 8 consecutive failures, stop; also skip the global sweep once the endpoint is known down

`queryGdelt` now returns `null` on request failure rather than `[]`, so the breaker can distinguish "endpoint dead" from "no articles". It's internal with only two call sites.

## Testing

Measured against the real tracker set with a stalled endpoint simulated:

| | GDELT calls | Est. CI time @ ~11s/call |
|---|---|---|
| Before | **97** | ~17.8 min (matches observed 17m35s) |
| After | **12** | ~22 s |

Adds a regression test that **fails on the previous implementation** (97 calls) and passes on this one (12). Full suite: 21/21 passing. No new `tsc` errors (91 pre-existing on `main`, 91 with this change, 0 in `hourly-scan.ts`).

## Note

GDELT being down is upstream and may recover on its own — this change is about the pipeline surviving it either way, and it self-heals when GDELT comes back. If GDELT stays down long-term, dropping the per-tracker sweep entirely is worth considering, since RSS already produced all 192 candidates in the last run. That's a product call, not made here.

Independent of #162 (nightly finalize timeout), though same underlying pattern: an unbounded network loop that scales with tracker count, inside a job with a fixed timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)