### PR TITLE
fix(video): Remove secrets context from step if: to fix workflow startup

### DIFF
--- a/.github/workflows/daily-video.yml
+++ b/.github/workflows/daily-video.yml
@@ -288,12 +288,19 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Download from the Artifacts section above." >> $GITHUB_STEP_SUMMARY
       - name: Post video to Telegram
-        if: ${{ secrets.TELEGRAM_BOT_TOKEN != '' && secrets.TELEGRAM_CHANNEL_ID != '' }}
         continue-on-error: true
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHANNEL_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
         run: |
+          # The `secrets` context is not available to step-level `if:`, so gate
+          # on the env vars here instead. Using it in `if:` made the whole
+          # workflow fail to start.
+          if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHANNEL_ID" ]; then
+            echo "Telegram secrets not configured — skipping"
+            exit 0
+          fi
+
           DATE=$(date -u +%Y-%m-%d)
           VIDEO="video/output/watchboard-${DATE}.mp4"
           
@@ -491,12 +498,19 @@ jobs:
           retention-days: 30
 
       - name: Post progress video to Telegram
-        if: ${{ secrets.TELEGRAM_BOT_TOKEN != '' && secrets.TELEGRAM_CHANNEL_ID != '' }}
         continue-on-error: true
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHANNEL_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
         run: |
+          # The `secrets` context is not available to step-level `if:`, so gate
+          # on the env vars here instead. Using it in `if:` made the whole
+          # workflow fail to start.
+          if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHANNEL_ID" ]; then
+            echo "Telegram secrets not configured — skipping"
+            exit 0
+          fi
+
           DATE=$(date -u +%Y-%m-%d)
           VIDEO="video/output/watchboard-${DATE}-progress.mp4"
           NARRATED="video/output/watchboard-${DATE}-progress-narrated-en.mp4"


### PR DESCRIPTION
## Summary

The daily video workflow has **failed to start on every run since 2026-06-11** — roughly 7.5 weeks with no daily brief video produced.

GitHub's own message: *"This run likely failed because of a workflow file issue."* The runs had **zero jobs** and were named by file path (`.github/workflows/daily-video.yml`) rather than by the workflow's `name:` — the signature of a startup failure, which is also why no logs exist for them.

### Cause

Two steps gated on the `secrets` context inside `if:`:

```yaml
if: ${{ secrets.TELEGRAM_BOT_TOKEN != '' && secrets.TELEGRAM_CHANNEL_ID != '' }}
```

`secrets` is **not an available context for step-level `if:`** — only `env`, `github`, `inputs`, `job`, `matrix`, `needs`, `runner`, `steps`, `strategy`, `vars` are. An invalid context there fails the entire file at parse time, so neither job ever ran and the scheduled 00:00 UTC runs stopped being generated at all.

The secrets were already exposed to these steps via `env:`, so the guard simply moves into the shell where the values are legitimately available. Both steps already had `continue-on-error: true` and an early-exit guard, so the behaviour when secrets are absent is unchanged — it just no longer breaks the file.

Introduced by 70b1b64e (#158). The last successful run was immediately before it.

## Testing

Verified with `actionlint` 1.7.12 against both versions:

```
before:  .github/workflows/daily-video.yml:291:17:
         context "secrets" is not allowed here. available contexts are
         "env", "github", "inputs", "job", "matrix", "needs", "runner",
         "steps", "strategy", "vars"
         (x4 — lines 291 and 494, two uses each)

after:   no errors
```

I did not trigger a live run to verify: `push` on this path would start the real job, which renders and **publishes to Telegram and Bluesky**. Worth watching the next scheduled 00:00 UTC run after merge.

## Related

Part of a sweep of failing workflows. Independent of #162 (nightly finalize timeout) and #163 (hourly scan GDELT timeout).

Two further findings from the same sweep, **not** addressed here:

- `tracker-lifecycle.yml:95,98` reference `steps.scout.outputs.result`, which `claude-code-action` does not expose (its outputs are `branch_name`, `execution_file`, `github_token`, `session_id`, `structured_output`). The condition is therefore always false, so **the scout burns Claude turns and never creates candidate issues**. Silent, not a hard failure.
- `deploy.yml` has not published since **2026-07-18**. Its only viable trigger is `workflow_run` on Nightly Data Update with `conclusion == 'success'`, and the nightly has been ending `cancelled`; bot pushes using `GITHUB_TOKEN` do not trigger the `push` trigger. #162 should unblock it, but the coupling is fragile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)