### PR TITLE
fix(lifecycle): Raise scout turn budget and read result from execution log

### DIFF
--- a/.github/workflows/tracker-lifecycle.yml
+++ b/.github/workflows/tracker-lifecycle.yml
@@ -57,7 +57,11 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
-          claude_args: "--max-turns 5 --dangerously-skip-permissions"
+          # 5 turns was not enough to run the web searches and emit the JSON
+          # array, so every run died on "Reached maximum number of turns".
+          # In line with the other research-style jobs in this repo (triage 20,
+          # nightly update 30) and bounded by the job's 15-minute timeout.
+          claude_args: "--max-turns 25 --dangerously-skip-permissions"
           prompt: |
             You are a news intelligence analyst for Watchboard, a multi-topic intelligence dashboard.
 
@@ -92,11 +96,28 @@ jobs:
             Max 5 candidates. Only include candidates with confidence >= 0.6.
 
       - name: Create GitHub Issues for candidates
-        if: steps.scout.outputs.result != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXECUTION_FILE: ${{ steps.scout.outputs.execution_file }}
         run: |
-          echo '${{ steps.scout.outputs.result }}' | node -e "
+          # claude-code-action exposes no `outputs.result` — its outputs are
+          # branch_name, execution_file, github_token, session_id and
+          # structured_output. Gating on the non-existent one made this step
+          # never run, so the scout burned turns and created nothing. The final
+          # assistant text lives in the JSON execution log instead.
+          if [ -z "$EXECUTION_FILE" ] || [ ! -f "$EXECUTION_FILE" ]; then
+            echo "No scout execution file — skipping issue creation"
+            exit 0
+          fi
+          node -e "
+            const fs = require('fs');
+            let raw;
+            try { raw = JSON.parse(fs.readFileSync(process.env.EXECUTION_FILE, 'utf8')); }
+            catch { process.exit(0); }
+            const events = Array.isArray(raw) ? raw : [raw];
+            const last = events.filter(e => e && e.type === 'result').pop();
+            process.stdout.write(last && typeof last.result === 'string' ? last.result : '');
+          " | node -e "
             const readline = require('readline');
             let input = '';
             process.stdin.on('data', d => input += d);


### PR DESCRIPTION
## Summary

`Tracker Lifecycle (Scout + Prune)` has failed on every run. Two bugs stacked — one hard, one silent.

### 1. Turn budget too low (hard failure)

```
##[error]Execution failed: Reached maximum number of turns (5)
```

`--max-turns 5` for a job that runs web searches and emits a structured JSON array. It was by far the lowest budget in the repo:

| Workflow | max-turns |
|---|---|
| batch-init-trackers | 200 |
| seed-tracker / init-tracker | 80 |
| translate-data | 50 |
| update-data | 30 |
| hourly-scan (triage) | 10 / 20 / 35 |
| **tracker-lifecycle** | **5** |

Raised to 25 — in line with the other research-style jobs and comfortably inside the job's existing 15-minute timeout.

Note this was previously masked: until the OAuth token was rotated, the job died on `401 OAuth access token has been revoked` before it could ever reach the turn limit.

### 2. Reading a non-existent output (silent failure)

```yaml
if: steps.scout.outputs.result != ''
```

`claude-code-action` exposes no `result` output — its outputs are `branch_name`, `execution_file`, `github_token`, `session_id`, `structured_output`. The condition was always false, so **even a successful scout created no issues**: turns spent, nothing produced. Caught by actionlint:

```
tracker-lifecycle.yml:95:13: property "result" is not defined in object type
  {branch_name, execution_file, github_token, session_id, structured_output}
```

Now reads the final assistant text from the JSON execution log. The downstream parsing script is unchanged — only how its stdin is fed.

## Testing

- `actionlint` 1.7.12: the two `property "result" is not defined` errors are gone; the file is clean.
- Extraction tested locally against fixtures in both log shapes (stream array and single result object) — correctly recovers the candidate JSON.
- Defensive: exits cleanly when the log is missing or unparseable, so a failed scout cannot make this step fail.

**Behaviour change worth knowing:** with both bugs fixed, this job will now actually open `[Scout] Proposed tracker: <slug>` issues (max 5/run, confidence >= 0.6, deduped against open issues). That is its intended design, but it has never once run to completion, so expect issues to start appearing on the weekly schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)