### PR TITLE
ci(pipeline): Make failures visible — lint, real alert routing, credential canary

### DIFF
--- a/.github/workflows/credential-canary.yml
+++ b/.github/workflows/credential-canary.yml
@@ -1,0 +1,159 @@
+name: Credential Canary
+
+# Daily liveness check on every credential the pipeline depends on.
+#
+# Rationale: CLAUDE_CODE_OAUTH_TOKEN was revoked on 2026-07-20 and took seven
+# workflows down for two weeks before anyone noticed, and the X credentials had
+# been failing since roughly April. Both were found by chance while debugging
+# something else. A revoked secret is invisible until the thing that uses it
+# happens to run and someone happens to read the log.
+#
+# Each check is deliberately cheap and runs independently, so one dead
+# credential still reports on the others.
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # 06:00 UTC, well before the 14:00 nightly
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      # ── Telegram ──────────────────────────────────────────────────────────
+      - name: Check Telegram
+        id: telegram
+        continue-on-error: true
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHANNEL_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
+        run: |
+          if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHANNEL_ID" ]; then
+            echo "status=missing" >> "$GITHUB_OUTPUT"
+            echo "Telegram secrets not configured"
+            exit 1
+          fi
+          OK=$(curl -s --max-time 15 \
+            "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getMe" | jq -r '.ok // false')
+          if [ "$OK" = "true" ]; then
+            echo "status=ok" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=invalid" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+      # ── Bluesky ───────────────────────────────────────────────────────────
+      - name: Check Bluesky
+        id: bluesky
+        continue-on-error: true
+        env:
+          BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
+          BLUESKY_PASSWORD: ${{ secrets.BLUESKY_PASSWORD }}
+        run: |
+          if [ -z "$BLUESKY_HANDLE" ] || [ -z "$BLUESKY_PASSWORD" ]; then
+            echo "status=missing" >> "$GITHUB_OUTPUT"
+            echo "Bluesky secrets not configured"
+            exit 1
+          fi
+          CODE=$(curl -s -o /tmp/bsky.json -w '%{http_code}' --max-time 20 \
+            -X POST 'https://bsky.social/xrpc/com.atproto.server.createSession' \
+            -H 'Content-Type: application/json' \
+            --data "$(jq -n --arg i "$BLUESKY_HANDLE" --arg p "$BLUESKY_PASSWORD" \
+                      '{identifier:$i,password:$p}')")
+          if [ "$CODE" = "200" ]; then
+            echo "status=ok" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=invalid" >> "$GITHUB_OUTPUT"
+            echo "Bluesky auth returned HTTP $CODE"
+            exit 1
+          fi
+
+      # ── Claude Code OAuth ─────────────────────────────────────────────────
+      # A single trivial turn. This is the check that would have caught the
+      # 2026-07-20 revocation on day one.
+      - name: Check Claude Code OAuth
+        id: claude
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--max-turns 1 --dangerously-skip-permissions"
+          prompt: 'Reply with exactly: ok'
+
+      # ── Report ────────────────────────────────────────────────────────────
+      - name: Report
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TELEGRAM_RESULT: ${{ steps.telegram.outcome }}
+          BLUESKY_RESULT: ${{ steps.bluesky.outcome }}
+          CLAUDE_RESULT: ${{ steps.claude.outcome }}
+        run: |
+          FAILED=""
+          [ "$TELEGRAM_RESULT" != "success" ] && FAILED="${FAILED}Telegram "
+          [ "$BLUESKY_RESULT"  != "success" ] && FAILED="${FAILED}Bluesky "
+          [ "$CLAUDE_RESULT"   != "success" ] && FAILED="${FAILED}Claude-OAuth "
+
+          {
+            echo "## Credential Canary"
+            echo ""
+            echo "| Credential | Result |"
+            echo "|------------|--------|"
+            echo "| Telegram | $TELEGRAM_RESULT |"
+            echo "| Bluesky | $BLUESKY_RESULT |"
+            echo "| Claude Code OAuth | $CLAUDE_RESULT |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -z "$FAILED" ]; then
+            echo "All credentials healthy"
+            exit 0
+          fi
+
+          echo "::error::Credential check failed for: $FAILED"
+
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          TEXT="🔑 Watchboard credential canary FAILED%0A%0ABroken: ${FAILED}%0A${RUN_URL}"
+
+          # Telegram itself may be the thing that is broken, so this is
+          # best-effort and never masks the job failure below.
+          if [ -n "$TELEGRAM_BOT_TOKEN" ] && [ -n "$TELEGRAM_CHAT_ID" ]; then
+            curl -s --max-time 15 -X POST \
+              "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+              -d "chat_id=${TELEGRAM_CHAT_ID}" \
+              -d "text=${TEXT}" > /dev/null || true
+          fi
+
+          # A GitHub issue is the durable channel — it survives even when every
+          # messaging credential is dead. Reuse an open one instead of piling up.
+          TITLE="[canary] Credential check failing"
+          EXISTING=$(gh issue list --search "$TITLE in:title" --state open \
+                       --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "Still failing: ${FAILED}(${RUN_URL})" || true
+          else
+            {
+              echo "The daily credential canary is failing for: ${FAILED}"
+              echo ""
+              echo "Run: ${RUN_URL}"
+              echo ""
+              echo "| Credential | Result |"
+              echo "|------------|--------|"
+              echo "| Telegram | ${TELEGRAM_RESULT} |"
+              echo "| Bluesky | ${BLUESKY_RESULT} |"
+              echo "| Claude Code OAuth | ${CLAUDE_RESULT} |"
+              echo ""
+              echo "Rotate the affected secret, then re-run this workflow to confirm."
+            } > /tmp/canary-issue.md
+            gh issue create --title "$TITLE" --label "automated" \
+              --body-file /tmp/canary-issue.md || true
+          fi
+
+          exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,14 +83,15 @@ jobs:
   # ── Notify Telegram on build/deploy failure ──
   notify-failure:
     needs: [build, deploy]
-    if: failure()
+    # A timed-out job reports as cancelled, not failed — see update-data.yml.
+    if: failure() || cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Telegram failure alert
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
           BUILD_RESULT: ${{ needs.build.result }}
           DEPLOY_RESULT: ${{ needs.deploy.result }}
         run: |

--- a/.github/workflows/hourly-scan.yml
+++ b/.github/workflows/hourly-scan.yml
@@ -230,7 +230,10 @@ jobs:
 
       - name: Freshness check — DISABLED (RSS feeds now cover all trackers)
         id: freshness
-        if: false  # Disabled — with full RSS coverage, organic updates replace freshness pings
+        # Disabled — with full RSS coverage, organic updates replace freshness
+        # pings. Gated on a repo variable rather than a literal `false` so the
+        # workflow linter stays clean and it can be re-enabled without a commit.
+        if: vars.ENABLE_FRESHNESS_CHECK == 'true'
         run: |
           node -e "
             const fs = require('fs');
@@ -961,3 +964,35 @@ jobs:
           else
             echo "No hourly changes detected — skipping deploy trigger"
           fi
+
+  notify-failure:
+    needs: [scan, act, trigger-deploy]
+    # This workflow had no failure alert at all, despite being the most
+    # frequently failing one in the repo. `cancelled()` is included because a
+    # job that exceeds timeout-minutes reports as cancelled, not failed — which
+    # is exactly how the 20-minute scan timeouts went unnoticed.
+    if: failure() || cancelled()
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Telegram failure alert
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
+          SCAN_RESULT: ${{ needs.scan.result }}
+          ACT_RESULT: ${{ needs.act.result }}
+          DEPLOY_RESULT: ${{ needs.trigger-deploy.result }}
+        run: |
+          if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
+            echo "Telegram secrets missing; skipping alert"
+            exit 0
+          fi
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          TEXT=$(printf '⚠️ Hourly Breaking News Scan failed\n\nscan: %s\nact: %s\ntrigger-deploy: %s\n\n%s' \
+                  "$SCAN_RESULT" "$ACT_RESULT" "$DEPLOY_RESULT" "$RUN_URL")
+          PAYLOAD=$(jq -n --arg c "$TELEGRAM_CHAT_ID" --arg t "$TEXT" \
+                      '{chat_id:$c, text:$t}')
+          curl -s --max-time 15 -X POST \
+            "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -H 'Content-Type: application/json' \
+            -d "$PAYLOAD" > /dev/null || true

--- a/.github/workflows/light-scan.yml
+++ b/.github/workflows/light-scan.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run light scan
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID:   ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_CHAT_ID:   ${{ secrets.TELEGRAM_CHANNEL_ID }}
         run: npx tsx scripts/hourly-light-scan.ts
 
       - name: Commit pending-candidates + triage-log + state
@@ -50,7 +50,8 @@ jobs:
   # outage), we fall back to alerting — better noisy than silent.
   notify-failure:
     needs: [scan]
-    if: failure()
+    # A timed-out job reports as cancelled, not failed — see update-data.yml.
+    if: failure() || cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
@@ -58,7 +59,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
         run: |
           if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
             echo "TELEGRAM_BOT_TOKEN/CHAT_ID missing; skipping Telegram alert"

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,47 @@
+name: Lint Workflows
+
+# Static validation of the workflow files themselves.
+#
+# This exists because two real outages came from mistakes a linter catches
+# instantly:
+#   - `secrets` used in a step-level `if:` made daily-video.yml fail to parse.
+#     GitHub reported zero jobs, produced no logs, and silently stopped
+#     generating the scheduled runs — ~7.5 weeks with no daily video.
+#   - tracker-lifecycle.yml read `steps.scout.outputs.result`, an output the
+#     action does not expose, so the issue-creation step never ran.
+#
+# Neither surfaced as a normal test failure, and one left no logs at all.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Run actionlint
+        # Pinned to a release rather than latest so a new upstream check cannot
+        # turn an unrelated PR red without us choosing to take it.
+        run: |
+          VERSION=1.7.12
+          curl -sSLo actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_linux_amd64.tar.gz"
+          tar -xzf actionlint.tar.gz actionlint
+          ./actionlint -version
+
+          # shellcheck is available on the runner, so script bodies are linted
+          # too. -color for readable annotations in the job log.
+          ./actionlint -color

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -1254,7 +1254,11 @@ jobs:
   # ── Phase 4: Notify on failure ──
   notify-failure:
     needs: [resolve, update, finalize]
-    if: failure()
+    # `cancelled()` matters as much as `failure()`: a job that hits its
+    # timeout-minutes is reported as cancelled, not failed. That is exactly how
+    # this pipeline died silently for two weeks — finalize timed out every night
+    # and no alert ever fired.
+    if: failure() || cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -1263,7 +1267,7 @@ jobs:
       - name: Telegram failure alert
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
           RESOLVE_RESULT: ${{ needs.resolve.result }}
           UPDATE_RESULT: ${{ needs.update.result }}
           FINALIZE_RESULT: ${{ needs.finalize.result }}


### PR DESCRIPTION
**P0 of the pipeline resilience plan.** Every item exists because a real outage here went undetected — not generic hardening.

## 1. Workflow linting (new `lint-workflows.yml`)

Two outages came from mistakes `actionlint` catches instantly:

| Bug | Cost |
|---|---|
| `secrets` in a step-level `if:` | `daily-video.yml` failed to parse — **~7.5 weeks with no video**, zero jobs, no logs, cron silently stopped firing |
| `steps.scout.outputs.result` (non-existent output) | scout burned turns and created **no issues, ever** |

Neither surfaced as a test failure, and one produced no logs at all.

Pinned to 1.7.12 so a new upstream check can't redden an unrelated PR without us choosing to take it. Repo lints clean today — the only finding was the literal `if: false` on the disabled freshness check, now gated on `vars.ENABLE_FRESHNESS_CHECK` so it's re-enableable without a commit.

## 2. Alert routing actually works

**Two independent bugs meant the failure alerts have never fired.**

- **`if: failure()` doesn't match a timed-out job** — GitHub reports those as `cancelled`. Exactly how the nightly died silently every night for two weeks. Now `failure() || cancelled()`.
- **Wrong secret name.** `deploy`, `light-scan` and `update-data` all read `secrets.TELEGRAM_CHAT_ID`. The secret is `TELEGRAM_CHANNEL_ID`. The value was always empty, so the guard `exit 0`'d without sending. Even a correctly-triggered alert would have gone nowhere.

That second one is the answer to "why did two weeks of failures produce zero notifications" — it was never just the trigger condition.

`hourly-scan` had **no failure alert at all**, despite being the most frequently failing workflow in the repo. It gets one.

## 3. Credential canary (new `credential-canary.yml`)

`CLAUDE_CODE_OAUTH_TOKEN` was revoked 2026-07-20 and took seven workflows down for two weeks. The X credentials had been failing since ~April. **Both were found by accident.** A revoked secret is invisible until something that uses it happens to run and someone happens to read the log.

Daily at 06:00 UTC, ahead of the 14:00 nightly. Checks Telegram (`getMe`), Bluesky (`createSession`) and Claude OAuth (one trivial turn) **independently**, so one dead credential still reports on the others.

Alerts over Telegram *and* opens a deduplicated GitHub issue — the issue matters because it's the one channel that survives when the messaging credential is itself the broken thing.

## Testing

- `actionlint` 1.7.12 clean across all 17 workflows (with and without shellcheck).
- Both new files parse as YAML with the expected job/step structure.
- Canary pass/fail logic exercised across combinations:

| Telegram | Bluesky | Claude | Result |
|---|---|---|---|
| ok | ok | ok | healthy, exit 0 |
| ok | fail | ok | `alerta: Bluesky`, exit 1 |
| ok | ok | fail | `alerta: Claude-OAuth`, exit 1 |
| fail | fail | fail | all three listed, exit 1 |

Not exercised live: the canary's real API calls and the Telegram send path, which need repo secrets. First scheduled run will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)