### PR TITLE
feat(pipeline): Add data freshness alarm and unblock the deploy path

### DIFF
--- a/.github/workflows/data-freshness.yml
+++ b/.github/workflows/data-freshness.yml
@@ -1,0 +1,103 @@
+name: Data Freshness Alarm
+
+# The pipeline's last line of defence.
+#
+# Every other alarm watches a specific failure — a job that errored, a
+# credential that stopped authenticating, a workflow that would not parse. Each
+# only fires for a failure mode somebody anticipated.
+#
+# This one watches the outcome. If tracker data stops moving forward it
+# reports, whatever the cause, including causes not yet seen. All three outages
+# found in this repo would have tripped it, and none of them raised an alert at
+# the time:
+#
+#   - revoked OAuth token      — agents never ran
+#   - finalize timeout         — data produced but never committed
+#   - hourly GDELT stall       — triage starved, state never committed
+#
+# Runs after the nightly has had time to finish (14:00 UTC + ~4h).
+
+on:
+  schedule:
+    - cron: '0 18 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  freshness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Check data freshness
+        id: check
+        continue-on-error: true
+        run: npx tsx scripts/check-data-freshness.ts
+
+      - name: Alert
+        if: steps.check.outcome != 'success'
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SUMMARY: ${{ steps.check.outputs.summary }}
+          FRESHEST_DAYS: ${{ steps.check.outputs.freshest_days }}
+          STALE_COUNT: ${{ steps.check.outputs.stale_count }}
+          ACTIVE_COUNT: ${{ steps.check.outputs.active_count }}
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          {
+            echo "## Data Freshness — STALE"
+            echo ""
+            echo "${SUMMARY}"
+            echo ""
+            echo "- Freshest tracker: ${FRESHEST_DAYS}d ago"
+            echo "- Stale: ${STALE_COUNT}/${ACTIVE_COUNT}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -n "$TELEGRAM_BOT_TOKEN" ] && [ -n "$TELEGRAM_CHAT_ID" ]; then
+            TEXT=$(printf '📉 Watchboard data is stale\n\n%s\n\nFreshest: %sd ago\nStale: %s/%s\n\n%s' \
+                    "$SUMMARY" "$FRESHEST_DAYS" "$STALE_COUNT" "$ACTIVE_COUNT" "$RUN_URL")
+            PAYLOAD=$(jq -n --arg c "$TELEGRAM_CHAT_ID" --arg t "$TEXT" '{chat_id:$c, text:$t}')
+            curl -s --max-time 15 -X POST \
+              "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+              -H 'Content-Type: application/json' -d "$PAYLOAD" > /dev/null || true
+          fi
+
+          # Durable channel, deduplicated so a sustained outage does not pile up
+          # a new issue every day.
+          TITLE="[freshness] Tracker data has gone stale"
+          EXISTING=$(gh issue list --search "$TITLE in:title" --state open \
+                       --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "Still stale: ${SUMMARY} (${RUN_URL})" || true
+          else
+            {
+              echo "${SUMMARY}"
+              echo ""
+              echo "- Freshest tracker: ${FRESHEST_DAYS}d ago"
+              echo "- Stale: ${STALE_COUNT}/${ACTIVE_COUNT}"
+              echo ""
+              echo "Run: ${RUN_URL}"
+              echo ""
+              echo "This alarm watches the outcome, not a specific job, so the cause"
+              echo "could be anywhere in the pipeline. Check the nightly and hourly"
+              echo "runs, then the credential canary."
+            } > /tmp/freshness-issue.md
+            gh issue create --title "$TITLE" --label "automated" \
+              --body-file /tmp/freshness-issue.md || true
+          fi
+
+          exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,15 @@ on:
     workflows: ["Nightly Data Update"]
     types: [completed]
     branches: [main]
+  # Safety net. The site went 16 days without publishing (last success
+  # 2026-07-18) because every path to a deploy was blocked at once: the
+  # workflow_run path required the nightly to conclude 'success' and it was
+  # timing out to 'cancelled', while the push path never fires for bot commits
+  # — GitHub does not trigger workflows for pushes made with GITHUB_TOKEN.
+  # A daily schedule guarantees the published site cannot drift far behind the
+  # committed data no matter which trigger is broken.
+  schedule:
+    - cron: '30 19 * * *'  # after the nightly (14:00) and freshness check (18:00)
 
 permissions:
   contents: read
@@ -20,13 +29,20 @@ concurrency:
 
 jobs:
   build:
-    # When triggered by workflow_run (nightly update), only deploy if it succeeded.
-    # Push events (including hourly-scan commits) and workflow_dispatch always pass
-    # this condition because event_name is 'push' or 'workflow_dispatch', not
-    # 'workflow_run', so the first clause is true and the || short-circuits.
+    # When triggered by workflow_run (nightly update), deploy unless it failed
+    # outright. Other events (push, workflow_dispatch, schedule) always pass,
+    # because the first clause is true and the || short-circuits.
+    #
+    # 'cancelled' is accepted deliberately: that is what a job timeout reports,
+    # and a timed-out nightly still commits whatever it validated before the
+    # wall. Requiring 'success' meant a partially-successful night published
+    # nothing at all — data sat committed but unpublished for over two weeks.
+    # Anything committed has already passed the JSON + Zod + build gates, so
+    # publishing it is safe.
     if: >-
       github.event_name != 'workflow_run' ||
-      github.event.workflow_run.conclusion == 'success'
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event.workflow_run.conclusion == 'cancelled'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/scripts/check-data-freshness.ts
+++ b/scripts/check-data-freshness.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env tsx
+/**
+ * Data freshness check — the pipeline's last line of defence.
+ *
+ * Every other alarm watches a specific failure: a job that errored, a
+ * credential that stopped authenticating, a workflow that would not parse.
+ * Each one only fires for a failure mode somebody thought of in advance.
+ *
+ * This one watches the outcome instead. If tracker data stops moving forward
+ * it reports, regardless of the cause — including causes we have not seen yet.
+ * Every outage found in this repo would have tripped it:
+ *
+ *   - the revoked OAuth token (agents never ran)
+ *   - the finalize timeout (data was produced but never committed)
+ *   - the hourly GDELT stall (triage starved, state never committed)
+ *
+ * None of those raised an alert at the time. All of them stopped the data.
+ *
+ * Exit codes: 0 healthy, 1 stale (alert), 2 usage/read error.
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * If not one single active tracker has been updated in this many days, the
+ * pipeline is considered down. The nightly runs daily and the hourly scan
+ * every six hours, so a healthy system refreshes something continuously; three
+ * days is slack for a quiet news cycle plus a skipped run.
+ */
+const GLOBAL_STALE_DAYS = Number(process.env.FRESHNESS_GLOBAL_STALE_DAYS ?? 3);
+
+/**
+ * Share of active trackers allowed to sit past their own staleness horizon
+ * before we report. Individual trackers legitimately go quiet — historical
+ * arcs especially — so this is about the fleet, not any single one.
+ */
+const STALE_TRACKER_RATIO = Number(process.env.FRESHNESS_STALE_RATIO ?? 0.9);
+const TRACKER_STALE_DAYS = Number(process.env.FRESHNESS_TRACKER_STALE_DAYS ?? 30);
+
+export interface TrackerFreshness {
+  slug: string;
+  lastRun: string | null;
+  daysSince: number | null;
+}
+
+export interface FreshnessReport {
+  healthy: boolean;
+  reasons: string[];
+  activeCount: number;
+  staleCount: number;
+  freshest: TrackerFreshness | null;
+  stalest: TrackerFreshness | null;
+  trackers: TrackerFreshness[];
+}
+
+export function collectFreshness(now: Date, root: string = ROOT): TrackerFreshness[] {
+  const trackersDir = join(root, 'trackers');
+  const out: TrackerFreshness[] = [];
+
+  for (const slug of readdirSync(trackersDir)) {
+    const configPath = join(trackersDir, slug, 'tracker.json');
+    if (!existsSync(configPath)) continue;
+
+    let config: { status?: string };
+    try {
+      config = JSON.parse(readFileSync(configPath, 'utf8'));
+    } catch {
+      continue;
+    }
+    if (config.status !== 'active') continue;
+
+    let lastRun: string | null = null;
+    try {
+      const log = JSON.parse(
+        readFileSync(join(trackersDir, slug, 'data', 'update-log.json'), 'utf8'),
+      );
+      lastRun = typeof log.lastRun === 'string' && log.lastRun ? log.lastRun : null;
+    } catch {
+      lastRun = null;
+    }
+
+    let daysSince: number | null = null;
+    if (lastRun) {
+      const parsed = new Date(lastRun);
+      if (!Number.isNaN(parsed.getTime())) {
+        daysSince = Math.floor((now.getTime() - parsed.getTime()) / 86_400_000);
+      }
+    }
+
+    out.push({ slug, lastRun, daysSince });
+  }
+
+  return out;
+}
+
+export function evaluate(trackers: TrackerFreshness[]): FreshnessReport {
+  const reasons: string[] = [];
+
+  // Unknown lastRun counts as stale — a tracker we cannot date is not evidence
+  // of health.
+  const withDays = trackers.filter((t) => t.daysSince !== null) as Array<
+    TrackerFreshness & { daysSince: number }
+  >;
+
+  const sorted = [...withDays].sort((a, b) => a.daysSince - b.daysSince);
+  const freshest = sorted[0] ?? null;
+  const stalest = sorted[sorted.length - 1] ?? null;
+
+  const staleCount =
+    trackers.length - withDays.filter((t) => t.daysSince < TRACKER_STALE_DAYS).length;
+
+  if (trackers.length === 0) {
+    reasons.push('No active trackers found — cannot assess freshness');
+  } else {
+    // Primary signal: is anything moving at all?
+    if (!freshest) {
+      reasons.push('No active tracker has a usable lastRun timestamp');
+    } else if (freshest.daysSince > GLOBAL_STALE_DAYS) {
+      reasons.push(
+        `Nothing updated in ${freshest.daysSince}d — the freshest active tracker is ` +
+          `${freshest.slug} (limit ${GLOBAL_STALE_DAYS}d). The pipeline is not writing data.`,
+      );
+    }
+
+    // Secondary signal: a slow bleed where most of the fleet drifts past its
+    // horizon while a couple of trackers keep the primary check satisfied.
+    const ratio = staleCount / trackers.length;
+    if (ratio >= STALE_TRACKER_RATIO) {
+      reasons.push(
+        `${staleCount}/${trackers.length} active trackers (${Math.round(ratio * 100)}%) ` +
+          `have not been updated in ${TRACKER_STALE_DAYS}d.`,
+      );
+    }
+  }
+
+  return {
+    healthy: reasons.length === 0,
+    reasons,
+    activeCount: trackers.length,
+    staleCount,
+    freshest,
+    stalest,
+    trackers,
+  };
+}
+
+function main(): void {
+  let trackers: TrackerFreshness[];
+  try {
+    trackers = collectFreshness(new Date());
+  } catch (err) {
+    console.error('[freshness] Could not read trackers:', (err as Error).message);
+    process.exit(2);
+  }
+
+  const report = evaluate(trackers);
+
+  console.log(`[freshness] Active trackers: ${report.activeCount}`);
+  if (report.freshest) {
+    console.log(
+      `[freshness] Freshest: ${report.freshest.slug} (${report.freshest.daysSince}d ago)`,
+    );
+  }
+  if (report.stalest) {
+    console.log(
+      `[freshness] Stalest: ${report.stalest.slug} (${report.stalest.daysSince}d ago)`,
+    );
+  }
+  console.log(
+    `[freshness] Past ${TRACKER_STALE_DAYS}d: ${report.staleCount}/${report.activeCount}`,
+  );
+
+  if (process.env.GITHUB_OUTPUT) {
+    const { appendFileSync } = require('node:fs');
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `healthy=${report.healthy}\n` +
+        `summary=${report.reasons.join(' | ') || 'All good'}\n` +
+        `freshest_days=${report.freshest?.daysSince ?? -1}\n` +
+        `stale_count=${report.staleCount}\n` +
+        `active_count=${report.activeCount}\n`,
+    );
+  }
+
+  if (report.healthy) {
+    console.log('[freshness] OK — data is moving');
+    process.exit(0);
+  }
+
+  for (const r of report.reasons) console.error(`[freshness] STALE: ${r}`);
+  process.exit(1);
+}
+
+// Only run when executed directly, so the exported helpers stay importable.
+if (process.argv[1] && process.argv[1].includes('check-data-freshness')) {
+  main();
+}

--- a/tests/check-data-freshness.test.ts
+++ b/tests/check-data-freshness.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { evaluate, type TrackerFreshness } from '../scripts/check-data-freshness.js';
+
+const t = (slug: string, daysSince: number | null): TrackerFreshness => ({
+  slug,
+  lastRun: daysSince === null ? null : new Date(Date.now() - daysSince * 86_400_000).toISOString(),
+  daysSince,
+});
+
+describe('check-data-freshness', () => {
+  it('is healthy when the fleet is moving', () => {
+    const r = evaluate([t('a', 0), t('b', 1), t('c', 5)]);
+    expect(r.healthy).toBe(true);
+    expect(r.reasons).toEqual([]);
+    expect(r.freshest?.slug).toBe('a');
+    expect(r.stalest?.slug).toBe('c');
+  });
+
+  it('reports when nothing has been updated recently', () => {
+    // This is the shape of the outage that ran undetected for two weeks:
+    // agents never ran, so no tracker advanced at all.
+    const r = evaluate([t('a', 14), t('b', 20), t('c', 30)]);
+    expect(r.healthy).toBe(false);
+    expect(r.reasons.join(' ')).toMatch(/Nothing updated in 14d/);
+  });
+
+  it('tolerates individual quiet trackers while the fleet moves', () => {
+    // Historical arcs legitimately go silent — one stale tracker is not an alert.
+    const fleet = Array.from({ length: 20 }, (_, i) => t(`live-${i}`, 1));
+    const r = evaluate([...fleet, t('tlatelolco-1968', 400)]);
+    expect(r.healthy).toBe(true);
+  });
+
+  it('catches a slow bleed where most of the fleet drifts past its horizon', () => {
+    // A couple of trackers keep the primary check satisfied while everything
+    // else silently rots — the state this repo was actually in.
+    const stale = Array.from({ length: 19 }, (_, i) => t(`stale-${i}`, 60));
+    const r = evaluate([...stale, t('fresh', 0)]);
+    expect(r.healthy).toBe(false);
+    expect(r.reasons.join(' ')).toMatch(/have not been updated in 30d/);
+  });
+
+  it('treats an unknown lastRun as stale rather than healthy', () => {
+    const r = evaluate([t('a', null), t('b', null)]);
+    expect(r.healthy).toBe(false);
+    expect(r.staleCount).toBe(2);
+  });
+
+  it('reports rather than passing when there are no trackers', () => {
+    const r = evaluate([]);
+    expect(r.healthy).toBe(false);
+    expect(r.reasons.join(' ')).toMatch(/No active trackers/);
+  });
+});


### PR DESCRIPTION
**P1 of the resilience plan.**

## 1. Data freshness alarm

Every existing alarm watches a *specific* failure — a job that errored, a credential that stopped authenticating, a workflow that would not parse. Each only fires for a failure mode somebody anticipated.

This watches the **outcome**. If tracker data stops moving forward it reports, whatever the cause. All three outages found in this repo would have tripped it — and **none of them raised an alert at the time**:

| Outage | What broke | Data stopped? |
|---|---|---|
| Revoked OAuth token | agents never ran | yes |
| Finalize timeout | data produced, never committed | yes |
| Hourly GDELT stall | triage starved, state never committed | yes |

That is the argument for it: patching known bugs never protects against the next unknown one, but "the data stopped" catches them all.

### Two signals

- **Primary** — did anything move? If not one active tracker has been updated in 3 days, the pipeline is not writing.
- **Secondary** — the slow bleed, where a couple of trackers keep the primary check satisfied while the rest of the fleet quietly rots. This is the state the repo was actually in.

Individual trackers are allowed to go quiet — historical arcs legitimately do — so the secondary signal is about the fleet, not any single tracker. An unknown `lastRun` counts as **stale**: a tracker we cannot date is not evidence of health.

### Calibration, stated plainly

The repo currently sits at **83/96 (86.5%)** past the 30-day horizon, just under the 90% default — so the secondary signal will not fire today. That backlog is real, but it is *residue* from the outage rather than an active failure, and the primary signal correctly reports healthy now that the hourly scan is writing again. **Worth lowering the ratio once the backfill lands**; both thresholds are env-overridable.

## 2. Deploy is no longer hostage to the nightly

The site went **16 days without publishing** (last success 2026-07-18) because every path to a deploy was blocked simultaneously:

- the `workflow_run` path required the nightly to conclude `success`, and it was timing out to `cancelled`
- the `push` path never fires for bot commits — GitHub does not trigger workflows for pushes made with `GITHUB_TOKEN`

Two changes:

- **A daily schedule**, so the published site cannot drift far behind the committed data whichever trigger is broken.
- **`cancelled` is now accepted** from `workflow_run`. A timed-out nightly still commits whatever it validated before the wall, and anything committed has already passed the JSON + Zod + build gates, so publishing it is safe.

## Testing

- `actionlint` clean across all 18 workflows.
- **27 tests pass**, 6 new: healthy fleet, total stall, tolerated quiet tracker, slow-bleed, unknown timestamps, empty repo.
- Script run against real repo data:

```
Active trackers: 96
Freshest: somalia-conflict (0d ago)
Stalest: species-recovery (88d ago)
Past 30d: 83/96
OK — data is moving
```

Not exercised live: the Telegram/issue alert paths, which need repo secrets and a genuinely stale fleet. The pass/fail logic itself is covered by the unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)