### PR TITLE
fix(pipeline): Repair map-lines in the hourly scan and bound the last loops

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -26,6 +26,9 @@ concurrency:
 jobs:
   backfill:
     runs-on: ubuntu-latest
+    # Without this the job inherits GitHub's 6-hour default, so a stalled
+    # upstream host could burn hours of Actions time before anyone noticed.
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/hourly-scan.yml
+++ b/.github/workflows/hourly-scan.yml
@@ -768,9 +768,73 @@ jobs:
           npx tsx -e "
             import * as S from './src/lib/schemas.js';
             import { z } from 'zod';
-            import { existsSync, readFileSync } from 'fs';
+            import { existsSync, readFileSync, writeFileSync } from 'fs';
 
             const dir = 'trackers/$TRACKER/data';
+
+            // Normalise map-lines before validating. events/*.json already gets
+            // this treatment above, but map-lines did not — so a single
+            // out-of-enum value discarded the whole update. Real case: a source
+            // describing a 'drone or missile attack' produced
+            // weaponType 'drone/missile', which is not in the enum, and the
+            // saudi-arabia event was dropped entirely (2026-08-09).
+            const WEAPON_TYPES = ['ballistic','cruise','drone','drone_loitering','drone_ucav','drone_recon','drone_fpv','rocket','mixed','unknown'];
+            function normaliseWeaponType(v: unknown): string {
+              if (typeof v !== 'string') return 'unknown';
+              if (WEAPON_TYPES.includes(v)) return v;
+              const s = v.toLowerCase();
+              // Ambiguous source wording ('drone or missile') means mixed, not a guess.
+              const drone = s.includes('drone') || s.includes('uav');
+              const missile = s.includes('missile') || s.includes('ballistic') || s.includes('cruise');
+              if (drone && missile) return 'mixed';
+              if (s.includes('loiter') || s.includes('shahed') || s.includes('kamikaze')) return 'drone_loitering';
+              if (drone) return 'drone_loitering';
+              if (s.includes('ballistic')) return 'ballistic';
+              if (s.includes('cruise')) return 'cruise';
+              if (s.includes('rocket')) return 'rocket';
+              if (missile) return 'ballistic';
+              return 'unknown';
+            }
+            function normaliseTime(v: unknown): string | null {
+              if (typeof v !== 'string') return null;
+              if (/^([01][0-9]|2[0-3]):[0-5][0-9]\$/.test(v)) return v;
+              // Most common mistake: a full ISO timestamp instead of HH:MM.
+              const m = v.match(/T([01][0-9]|2[0-3]):([0-5][0-9])/) || v.match(/^([0-9]{1,2}):([0-5][0-9])/);
+              if (m) return String(m[1]).padStart(2,'0') + ':' + m[2];
+              return null;
+            }
+
+            const mlPath = dir + '/map-lines.json';
+            if (existsSync(mlPath)) {
+              try {
+                const lines = JSON.parse(readFileSync(mlPath, 'utf8'));
+                if (Array.isArray(lines)) {
+                  let changed = 0;
+                  for (const l of lines) {
+                    if (l && l.weaponType !== undefined) {
+                      const fixedW = normaliseWeaponType(l.weaponType);
+                      if (fixedW !== l.weaponType) {
+                        console.log('  map-lines: weaponType ' + JSON.stringify(l.weaponType) + ' -> ' + fixedW);
+                        l.weaponType = fixedW; changed++;
+                      }
+                    }
+                    if (l && l.time !== undefined) {
+                      const fixedT = normaliseTime(l.time);
+                      if (fixedT === null) {
+                        // Required for strike/retaliation, so dropping the entry
+                        // would lose the event. Keep it, flagged as midnight.
+                        console.log('  map-lines: unparseable time ' + JSON.stringify(l.time) + ' -> 00:00');
+                        l.time = '00:00'; changed++;
+                      } else if (fixedT !== l.time) {
+                        console.log('  map-lines: time ' + JSON.stringify(l.time) + ' -> ' + fixedT);
+                        l.time = fixedT; changed++;
+                      }
+                    }
+                  }
+                  if (changed > 0) writeFileSync(mlPath, JSON.stringify(lines, null, 2));
+                }
+              } catch { /* malformed JSON is caught by the validation below */ }
+            }
             const schemaMap: Record<string, z.ZodTypeAny> = {
               'kpis.json': z.array(S.KpiSchema),
               'timeline.json': z.array(S.TimelineEraSchema),

--- a/scripts/backfill-youtube.ts
+++ b/scripts/backfill-youtube.ts
@@ -96,7 +96,10 @@ async function searchYouTube(query: string): Promise<YTHit | null> {
   });
   const url = 'https://www.googleapis.com/youtube/v3/search?' + params.toString();
   let res: Response;
-  try { res = await fetch(url); }
+  // Bounded on purpose. An unbounded fetch inside a per-event loop is the shape
+  // that took down the nightly and the hourly scan: one stalled host and the
+  // loop hangs until the job's wall-clock limit kills it, discarding the work.
+  try { res = await fetch(url, { signal: AbortSignal.timeout(15_000) }); }
   catch { return null; }
   if (!res.ok) {
     if (res.status === 403 || res.status === 429) {


### PR DESCRIPTION
**P1.4 and P2 of the resilience plan.**

## 1. Auto-repair `map-lines` in the hourly scan

The hourly scan already normalises `events/*.json` before validating — filling missing `source.name/tier/pole`, `type`, `detail`, `media`, remapping bad confidence enums. **`map-lines.json` got validation but no repair**, so one out-of-enum value discarded the entire update.

Not hypothetical. On 2026-08-09 a source describing a *"drone **or** missile attack"* produced:

```
✗ map-lines.json
   0.weaponType : Invalid enum value. received 'drone/missile'
   0.time       : Invalid time format, expected HH:MM
```

`Commit and push` was skipped and the `saudi-arabia` event was **lost**. Unlike the nightly, the hourly has no fix agent to retry.

`weaponType` and `time` are now normalised first. **Deterministic mapping, not an LLM call** — cheaper, repeatable, and these are format errors rather than judgement calls.

Choices worth flagging:
- Ambiguous wording maps to `mixed` rather than guessing a single weapon.
- Anything unrecognised becomes `unknown`, not something plausible-looking.
- An unparseable `time` falls back to `00:00` **and logs it**, because `time` is required for strike/retaliation lines and dropping the entry loses the event outright. Same trade-off already made by defaulting `detail` to `title`.

This also covers the `ukraine-war` ISO-timestamp bug referenced in the comment directly above it (2026-06-27 → 2026-07-04).

## 2. The last unbounded network loops

Audited every remaining fetch loop for the pattern behind the nightly and hourly outages:

| Script | Verdict |
|---|---|
| `backfill-media` | fine — funnels through a helper with `AbortSignal` |
| `backfill-wikimedia` | fine — same |
| `backfill-youtube` | **bare `fetch` in a per-event loop, no timeout** → bounded at 15s |

(My first grep suggested media and wikimedia were also unbounded; that was miscounting calls to their timeout-setting helpers. Verified before changing anything.)

`backfill.yml` also had **no `timeout-minutes`**, inheriting GitHub's 6-hour default. Capped at 60.

## Testing

- `actionlint` clean across all 18 workflows; 27 tests pass; no new `tsc` errors.
- Normalisation exercised over real and adversarial inputs:

| Input | → |
|---|---|
| `"drone/missile"` (the real failure) | `mixed` |
| `"drone or missile attack"` | `mixed` |
| `"Shahed-136"` | `drone_loitering` |
| `"ballistic missile"` | `ballistic` |
| `"airstrike"`, `42` | `unknown` |
| `"2026-08-09T15:11:28.000Z"` | `15:11` |
| `"9:05"` | `09:05` |
| `"25:99"`, `"morning"`, `null` | `00:00` (logged) |
| `"drone_ucav"`, `"15:11"` | unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)