### PR TITLE
fix(pipeline): Fix three defects the new alarms found in themselves

### DIFF
--- a/.github/workflows/credential-canary.yml
+++ b/.github/workflows/credential-canary.yml
@@ -84,7 +84,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 1 --dangerously-skip-permissions"
+          # 1 turn is not enough: the action treats hitting the cap as an
+          # error, so a healthy token still reported failure. Same trap that
+          # broke the scout at 5 turns.
+          claude_args: "--max-turns 3 --dangerously-skip-permissions"
           prompt: 'Reply with exactly: ok'
 
       # ── Report ────────────────────────────────────────────────────────────
@@ -152,7 +155,7 @@ jobs:
               echo ""
               echo "Rotate the affected secret, then re-run this workflow to confirm."
             } > /tmp/canary-issue.md
-            gh issue create --title "$TITLE" --label "automated" \
+            gh issue create --title "$TITLE" --label "automation" \
               --body-file /tmp/canary-issue.md || true
           fi
 

--- a/.github/workflows/data-freshness.yml
+++ b/.github/workflows/data-freshness.yml
@@ -96,7 +96,7 @@ jobs:
               echo "could be anywhere in the pipeline. Check the nightly and hourly"
               echo "runs, then the credential canary."
             } > /tmp/freshness-issue.md
-            gh issue create --title "$TITLE" --label "automated" \
+            gh issue create --title "$TITLE" --label "automation" \
               --body-file /tmp/freshness-issue.md || true
           fi
 

--- a/scripts/check-data-freshness.ts
+++ b/scripts/check-data-freshness.ts
@@ -19,7 +19,7 @@
  * Exit codes: 0 healthy, 1 stale (alert), 2 usage/read error.
  */
 
-import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, existsSync, appendFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -175,7 +175,6 @@ function main(): void {
   );
 
   if (process.env.GITHUB_OUTPUT) {
-    const { appendFileSync } = require('node:fs');
     appendFileSync(
       process.env.GITHUB_OUTPUT,
       `healthy=${report.healthy}\n` +


### PR DESCRIPTION
## Summary

Dispatching the two alarms added in #168 and #170 made **both fail**. All three causes were bugs in the alarms themselves, not in what they watch.

### 1. `check-data-freshness` crashed on the CI-only path

The `GITHUB_OUTPUT` branch used `require('node:fs')` inside an **ESM module**, where `require` is not defined.

Locally `GITHUB_OUTPUT` is unset, so that branch never ran and the script passed. In CI it threw, the step failed, and the alert fired **against a healthy fleet**. Now a static import — and reproduced locally by setting `GITHUB_OUTPUT`, which is how it should have been tested to begin with.

### 2. The canary reported a healthy Claude token as broken

`--max-turns 1` is not enough for the action to complete even a trivial reply — hitting the cap is reported as an error.

This is **the same trap that had the scout dying at 5 turns**, reintroduced while building the check designed to catch that class of problem. Raised to 3.

### 3. Both alarms opened issues with a non-existent label

The repo's label is `automation`; both used `automated`, so `gh issue create` failed with `could not add label`. The `|| true` kept it non-fatal — meaning **the durable notification channel would have silently produced nothing**, which is exactly the failure mode these alarms exist to prevent.

## The canary was otherwise correct

Worth stating plainly, since it looked like a failure:

```
TELEGRAM_RESULT: success
BLUESKY_RESULT:  success
CLAUDE_RESULT:   failure     ← the only failing check
```

It verified Telegram and Bluesky end to end against live APIs and flagged the one check that was failing. The signal worked; the check was miscalibrated.

## Testing

- Script with `GITHUB_OUTPUT` set: `exit=0`, emitting `healthy=true`, `freshest_days=0`, `stale_count=83`, `active_count=96`.
- `actionlint` clean; 6 freshness tests pass.
- Both workflows re-dispatched after merge to confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)