### PR TITLE
fix(pipeline): Grant the canary id-token so its Claude check can authenticate

### DIFF
--- a/.github/workflows/credential-canary.yml
+++ b/.github/workflows/credential-canary.yml
@@ -19,6 +19,12 @@ on:
 permissions:
   contents: read
   issues: write
+  # claude-code-action exchanges an OIDC token, so without this the Claude
+  # check fails with "Unable to get ACTIONS_ID_TOKEN_REQUEST_URL" regardless of
+  # whether the credential is actually valid — a false alarm on the very thing
+  # this workflow exists to measure. Every other workflow using the action
+  # already declares it.
+  id-token: write
 
 jobs:
   canary:


### PR DESCRIPTION
## Summary

The credential canary reported **Claude OAuth as broken on a token that works fine**. The real error:

```
Failed to get OIDC token:
Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
```

`claude-code-action` exchanges an OIDC token, which requires `id-token: write`. The canary declared only `contents: read` and `issues: write`, so the check failed for a reason **unrelated to credential validity**.

That is the worst possible bug in a canary — a false alarm on the exact thing it exists to measure. A canary that cries wolf gets muted, and then it protects nothing.

Every other workflow using the action already declares it:

| Workflow | `id-token: write` |
|---|---|
| update-data | ✅ |
| hourly-scan | ✅ |
| tracker-lifecycle | ✅ |
| **credential-canary** | ❌ → fixed |

## Confirmed working

Telegram and Bluesky both verified clean against live APIs in the same run, so the rest of the canary is proven end to end. Only the Claude leg was misconfigured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)