### PR TITLE
fix(alerts): Stop sending infrastructure errors to the public Telegram channel

### DIFF
--- a/.github/workflows/credential-canary.yml
+++ b/.github/workflows/credential-canary.yml
@@ -100,7 +100,11 @@ jobs:
       - name: Report
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
+          # Infra alerts go to TELEGRAM_ALERT_CHAT_ID (private ops chat), NEVER to
+          # TELEGRAM_CHANNEL_ID — that is the public content channel with
+          # outside subscribers. If the alert secret is unset the guard below
+          # exits quietly rather than falling back to the public channel.
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_ALERT_CHAT_ID }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TELEGRAM_RESULT: ${{ steps.telegram.outcome }}
           BLUESKY_RESULT: ${{ steps.bluesky.outcome }}

--- a/.github/workflows/data-freshness.yml
+++ b/.github/workflows/data-freshness.yml
@@ -49,7 +49,11 @@ jobs:
         if: steps.check.outcome != 'success'
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
+          # Infra alerts go to TELEGRAM_ALERT_CHAT_ID (private ops chat), NEVER to
+          # TELEGRAM_CHANNEL_ID — that is the public content channel with
+          # outside subscribers. If the alert secret is unset the guard below
+          # exits quietly rather than falling back to the public channel.
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_ALERT_CHAT_ID }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SUMMARY: ${{ steps.check.outputs.summary }}
           FRESHEST_DAYS: ${{ steps.check.outputs.freshest_days }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,7 +107,11 @@ jobs:
       - name: Telegram failure alert
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
+          # Infra alerts go to TELEGRAM_ALERT_CHAT_ID (private ops chat), NEVER to
+          # TELEGRAM_CHANNEL_ID — that is the public content channel with
+          # outside subscribers. If the alert secret is unset the guard below
+          # exits quietly rather than falling back to the public channel.
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_ALERT_CHAT_ID }}
           BUILD_RESULT: ${{ needs.build.result }}
           DEPLOY_RESULT: ${{ needs.deploy.result }}
         run: |

--- a/.github/workflows/hourly-scan.yml
+++ b/.github/workflows/hourly-scan.yml
@@ -1042,7 +1042,11 @@ jobs:
       - name: Telegram failure alert
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
+          # Infra alerts go to TELEGRAM_ALERT_CHAT_ID (private ops chat), NEVER to
+          # TELEGRAM_CHANNEL_ID — that is the public content channel with
+          # outside subscribers. If the alert secret is unset the guard below
+          # exits quietly rather than falling back to the public channel.
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_ALERT_CHAT_ID }}
           SCAN_RESULT: ${{ needs.scan.result }}
           ACT_RESULT: ${{ needs.act.result }}
           DEPLOY_RESULT: ${{ needs.trigger-deploy.result }}

--- a/.github/workflows/light-scan.yml
+++ b/.github/workflows/light-scan.yml
@@ -59,7 +59,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
+          # Infra alerts go to TELEGRAM_ALERT_CHAT_ID (private ops chat), NEVER to
+          # TELEGRAM_CHANNEL_ID — that is the public content channel with
+          # outside subscribers. If the alert secret is unset the guard below
+          # exits quietly rather than falling back to the public channel.
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_ALERT_CHAT_ID }}
         run: |
           if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
             echo "TELEGRAM_BOT_TOKEN/CHAT_ID missing; skipping Telegram alert"

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -1272,7 +1272,11 @@ jobs:
       - name: Telegram failure alert
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHANNEL_ID }}
+          # Infra alerts go to TELEGRAM_ALERT_CHAT_ID (private ops chat), NEVER to
+          # TELEGRAM_CHANNEL_ID — that is the public content channel with
+          # outside subscribers. If the alert secret is unset the guard below
+          # exits quietly rather than falling back to the public channel.
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_ALERT_CHAT_ID }}
           RESOLVE_RESULT: ${{ needs.resolve.result }}
           UPDATE_RESULT: ${{ needs.update.result }}
           FINALIZE_RESULT: ${{ needs.finalize.result }}


### PR DESCRIPTION
## Summary

Infra failure alerts were posting to `TELEGRAM_CHANNEL_ID` — the **public content channel with outside subscribers**, not an ops channel. A `🔑 Watchboard credential canary FAILED` message with a link to the Actions run went out there today.

**This is my regression, introduced in #168.**

Those alerts pointed at `secrets.TELEGRAM_CHAT_ID`, a secret that does not exist, so the guard exited quietly and nothing was ever sent. I diagnosed that as a bug and repointed them at the real secret — but the only real secret *was* the public channel. "Fixing" the routing is precisely what started publishing internal errors to subscribers. The broken name had been acting as accidental protection, and I removed it.

## Change

All six infra-alert send paths now use `TELEGRAM_ALERT_CHAT_ID`:

| Workflow | Path |
|---|---|
| update-data | notify-failure |
| deploy | notify-failure |
| light-scan | notify-failure |
| hourly-scan | notify-failure |
| credential-canary | Report |
| data-freshness | Alert |

**Until that secret is set, the existing guard exits quietly** — the default is silence, never a fallback to the public channel. GitHub issues remain the durable channel and are unaffected, so alerting still works with no secret configured.

Content paths deliberately keep the public channel: `daily-video` (the daily brief), `telegram-notify`, `light-scan`'s breaking-news alert, and the canary's Telegram *credential check*. Every send site now carries a comment naming which destination it must use, so the two don't get merged again.

## Action needed

Set `TELEGRAM_ALERT_CHAT_ID` to a private chat or group to receive alerts:

```
gh secret set TELEGRAM_ALERT_CHAT_ID
```

Until then, alerts land only in GitHub issues. You may also want to delete the already-posted messages from the public channel.

## Verification

- No infra-alert path references `TELEGRAM_CHANNEL_ID`.
- The four content paths are unchanged.
- `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)