### PR TITLE
fix(lifecycle): Create scout issues without a shell, and survive missing labels

### DIFF
--- a/.github/workflows/tracker-lifecycle.yml
+++ b/.github/workflows/tracker-lifecycle.yml
@@ -127,14 +127,25 @@ jobs:
               if (!candidates.length) { console.log('Scout returned no candidates'); process.exit(0); }
               console.log('Scout returned ' + candidates.length + ' candidate(s)');
 
-              const { execSync } = require('child_process');
+              // execFileSync, not execSync: arguments go straight to gh instead
+              // of through a shell, so no quoting or escaping is involved. The
+              // shell-string version below used to carry an unescaped double
+              // quote inside a regex, which terminated the surrounding bash
+              // string and killed the step with a syntax error. It never
+              // surfaced because the step was gated on a non-existent output
+              // and so had never once run.
+              const { execFileSync } = require('child_process');
+              const fs = require('fs');
               for (const c of candidates) {
                 if (c.confidence < 0.6) continue;
 
+                const title = '[Scout] Proposed tracker: ' + c.slug;
+
                 // Check for existing open issue
                 try {
-                  const existing = execSync(
-                    'gh issue list --search \"[Scout] Proposed tracker: ' + c.slug + '\" --state open --json number --jq length',
+                  const existing = execFileSync(
+                    'gh',
+                    ['issue','list','--search',title,'--state','open','--json','number','--jq','length'],
                     { encoding: 'utf8' }
                   ).trim();
                   if (parseInt(existing) > 0) {
@@ -171,13 +182,21 @@ jobs:
                 ].join('\n');
 
                 try {
-                  execSync(
-                    'gh issue create' +
-                    ' --title \"[Scout] Proposed tracker: ' + c.slug + '\"' +
-                    ' --label \"' + labels.join(',') + '\"' +
-                    ' --body \"' + body.replace(/"/g, '\\\\"').replace(/\n/g, '\\n') + '\"',
-                    { stdio: 'inherit' }
-                  );
+                  // --body-file rather than inlining the body: it can contain
+                  // quotes, newlines and backticks from the model's prose.
+                  const bodyFile = '/tmp/scout-issue-' + c.slug + '.md';
+                  fs.writeFileSync(bodyFile, body);
+                  const base = ['issue','create','--title',title,'--body-file',bodyFile];
+                  try {
+                    execFileSync('gh', [...base,'--label',labels.join(',')], { stdio: 'inherit' });
+                  } catch {
+                    // gh refuses the whole call if any label is missing, and
+                    // these (scout, auto-triage, domain:*) are not defined in
+                    // the repo. Losing a candidate over a missing label would
+                    // be worse than losing the label.
+                    console.warn('Label(s) rejected — creating issue without labels');
+                    execFileSync('gh', base, { stdio: 'inherit' });
+                  }
                   console.log('Created issue for: ' + c.slug);
                 } catch(e) {
                   console.error('Failed to create issue for ' + c.slug + ':', e.message);


### PR DESCRIPTION
## Summary

With the scout finally *reaching* its issue-creation step (after #165/#166), that step turned out to be broken too — it had **never run before**, so nothing had exercised it.

```
/home/runner/work/_temp/....sh: line 64: syntax error near unexpected token ')'
```

The `gh` commands were assembled as shell strings inside a `node -e "..."` body, and one carried an **unescaped double quote inside a regex**:

```js
' --body \"' + body.replace(/"/g, '\\\\"') ...
                          ↑ closes the bash string
```

That killed the step before node ever started. The bug predates this work — the broken `outputs.result` gate meant the step was always skipped, so it sat there undetected. Fixing the gate is what exposed it.

## Changes

- **`execFileSync` with an argument array** for both `gh` calls: nothing passes through a shell, so no quoting or escaping is involved.
- **`--body-file`** instead of inlining the body. Model prose routinely contains quotes, newlines and backticks.
- **Label fallback.** The step requests `scout`, `auto-triage`, `domain:*` — none of which exist in this repo — and `gh` rejects the *entire* call if any label is missing. Same trap that stopped the canary opening issues. It now retries without labels rather than losing the candidate.

## The scout itself worked

Worth recording, since the run shows as failed. Structured output returned five well-formed candidates, each conforming to the schema:

| Slug | Domain | Confidence |
|---|---|---|
| yemen-houthi-red-sea | conflict | 0.85 |
| bolivia-crisis | governance | 0.82 |
| thailand-cambodia-border | conflict | 0.78 |
| georgia-political-crisis | governance | 0.74 |
| philippines-energy-crisis | economy | 0.67 |

Only delivery was broken.

## Testing

Ran the step **exactly as it appears in the YAML** against a stubbed `gh` that rejects `--label` the way the real repo does, with a payload containing quotes, newlines and backticks:

```
Scout returned 2 candidate(s)
could not add label: 'scout' not found
Label(s) rejected — creating issue without labels
FAKE gh issue create: title=[Scout] Proposed tracker: yemen-houthi-red-sea
Created issue for: yemen-houthi-red-sea
exit=0
```

Sub-threshold candidate skipped, label rejection handled, issue created, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)