### PR TITLE
feat(pipeline): Allow a catch-up run to recover trackers stuck behind the cap

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -6,9 +6,13 @@ on:
   workflow_dispatch:
     inputs:
       tracker_slug:
-        description: 'Tracker slug to update, or "all" to check all eligible trackers'
+        description: 'Tracker slug, comma-separated list of slugs, or "all" for every eligible tracker'
         required: false
         default: 'all'
+      review_window_days:
+        description: 'Max review-window days for gap detection (default 30). Raise for a catch-up run.'
+        required: false
+        default: ''
 
 permissions:
   contents: write
@@ -51,10 +55,18 @@ jobs:
           MANUAL_SLUG="${{ github.event.inputs.tracker_slug || 'all' }}"
 
           if [ "$MANUAL_SLUG" != "all" ]; then
-            echo "slugs=$MANUAL_SLUG" >> $GITHUB_OUTPUT
-            echo "slugs_json=[\"$MANUAL_SLUG\"]" >> $GITHUB_OUTPUT
+            # Accepts one slug or a comma-separated list, so a catch-up run can
+            # target the specific trackers that fell behind without processing
+            # all 96.
+            SLUGS=$(echo "$MANUAL_SLUG" | tr ',' ' ' | xargs)
+            SLUGS_JSON=$(echo "$SLUGS" | node -e "
+              const s = require('fs').readFileSync(0,'utf8').trim();
+              console.log(JSON.stringify(s.split(/\s+/).filter(Boolean)));
+            ")
+            echo "slugs=$SLUGS" >> $GITHUB_OUTPUT
+            echo "slugs_json=$SLUGS_JSON" >> $GITHUB_OUTPUT
             echo "has_trackers=true" >> $GITHUB_OUTPUT
-            echo "Manual trigger: $MANUAL_SLUG"
+            echo "Manual trigger: $SLUGS"
             exit 0
           fi
 
@@ -190,6 +202,9 @@ jobs:
           path: /tmp/
 
       - name: Generate review manifest
+        env:
+          # Empty on scheduled runs, so the script keeps its 30-day default.
+          REVIEW_WINDOW_MAX_DAYS: ${{ github.event.inputs.review_window_days }}
         run: ELIGIBLE_SLUGS="${{ matrix.slug }}" npx tsx scripts/generate-review-manifest.ts
 
       - name: Build sibling context for prompt

--- a/scripts/generate-review-manifest.ts
+++ b/scripts/generate-review-manifest.ts
@@ -35,8 +35,22 @@ for (const slug of slugs) {
     }
   }
 
-  // Window: min(max(daysSinceLastRun, 7), 30)
-  const windowSize = Math.min(Math.max(daysSinceLastRun, 7), 30);
+  // Window: min(max(daysSinceLastRun, 7), MAX_WINDOW_DAYS)
+  //
+  // The cap is what stops a stale tracker from ever catching up: once the
+  // nightly runs, lastRun resets to today and the window shrinks back to 7, so
+  // anything older than the cap is skipped permanently rather than gradually
+  // recovered. After the 2026-07/08 outage some trackers were 60+ days behind
+  // and would have kept a hole forever. Override it for a one-off catch-up run
+  // and leave the default alone for normal nights, since a wide window inflates
+  // the manifest and the agent has a fixed turn budget.
+  // Parsed defensively: on scheduled runs GitHub passes workflow inputs through
+  // as an empty string, and `'' ?? 30` is '' — so a naive Number() would yield
+  // 0 and silently disable gap detection on every normal night.
+  const rawMax = process.env.REVIEW_WINDOW_MAX_DAYS;
+  const parsedMax = rawMax ? Number(rawMax) : NaN;
+  const MAX_WINDOW_DAYS = Number.isFinite(parsedMax) && parsedMax > 0 ? parsedMax : 30;
+  const windowSize = Math.min(Math.max(daysSinceLastRun, 7), MAX_WINDOW_DAYS);
 
   const windowStart = new Date(today);
   windowStart.setDate(windowStart.getDate() - windowSize);


### PR DESCRIPTION
## The problem

The review window is `min(max(daysSinceLastRun, 7), 30)`. **That cap is what makes a stale tracker permanently stale**: the nightly recovers at most 30 days, then `lastRun` resets to today and the window shrinks back to 7 — so anything older is skipped forever rather than gradually caught up.

After the July/August outage, **83 active trackers** sit past 30 days. Split by their *own configured cadence*:

| Group | Count | Behind | Verdict |
|---|---|---|---|
| Fast cadence (escalation floor ≤ 2d) | **23** | 63–65 days | needs recovery |
| 30-day historical arcs | 58 | ~3 cycles | far less urgent |

The 23 are the ones that matter, and the cap alone will never bring them back.

## Why not `backfill.yml`

It runs on `ANTHROPIC_API_KEY`, which is **not configured** in this repo and bills per token. The nightly already has the machinery — gap detection, sibling dedup, validation, the build gate — and runs on the Max OAuth token at no per-token cost.

## Changes

- **`REVIEW_WINDOW_MAX_DAYS`** overrides the cap. Default unchanged at 30, since a wide window inflates the manifest against a fixed turn budget.
- **`tracker_slug` accepts a comma-separated list**, so a catch-up can target just the trackers that fell behind instead of processing all 96.

### Defensive parsing — this one nearly shipped a serious bug

On scheduled runs GitHub passes an unset workflow input as an **empty string**, and `'' ?? 30` evaluates to `''`. A naive `Number()` would give **0**, silently disabling gap detection on every normal night — the opposite of the intent.

```
env=undefined   -> cap 30  | window: 30d
env="" (cron)   -> cap 30  | window: 30d   ← the trap
env="90"        -> cap 90  | window: 63d
env="0"         -> cap 30  | window: 30d
env="abc"       -> cap 30  | window: 30d
env="-5"        -> cap 30  | window: 30d
```

Only a valid positive override changes behaviour.

## Usage

```
gh workflow run update-data.yml \
  -f tracker_slug="slug-a,slug-b,..." \
  -f review_window_days=90
```

## Testing

Cap resolution exercised across the input space (table above); `actionlint` clean; no new `tsc` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)