### PR TITLE
ci(pipeline): Lint shell bodies at severity error

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -42,16 +42,23 @@ jobs:
           tar -xzf actionlint.tar.gz actionlint
           ./actionlint -version
 
-          # Script bodies are NOT linted here (-shellcheck= disables it).
-          # Enabling it surfaced 212 pre-existing findings across every
-          # workflow, almost all SC2086 "double quote to prevent globbing" on
-          # scripts that have run correctly for months. A check that starts red
-          # gets ignored or switched off, and mass-quoting long-lived shell for
-          # a style rule risks breaking working pipelines to fix nothing.
+          # Script bodies are linted, but only at severity `error`.
           #
-          # The purpose of this job is the class of bug that actually caused
-          # outages here — invalid contexts, non-existent outputs, malformed
-          # expressions — and actionlint catches those without shellcheck.
-          # Cleaning up the shell debt and re-enabling it is worth doing as its
-          # own change.
-          ./actionlint -color -shellcheck=
+          # Running shellcheck at its default severity reports 212 findings
+          # across every workflow, 158 of them SC2086 "double quote to prevent
+          # globbing" on scripts that have run correctly for months. A check
+          # that starts red gets ignored or switched off, and mass-quoting
+          # long-lived shell for a style rule risks breaking working pipelines
+          # to fix nothing.
+          #
+          # At `error` the repo is clean, so real shell defects fail the build
+          # while the style backlog stays out of the way. That backlog is not
+          # imaginary — 19 warnings remain (SC2044, SC2034, SC2046, SC2155) —
+          # and raising this to `warning` after clearing them is a worthwhile
+          # follow-up.
+          #
+          # `error` covers shell that cannot be parsed at all — quoting that
+          # terminates a string early, unbalanced constructs — which is the
+          # failure mode that killed the scout's issue-creation step at runtime
+          # with "syntax error near unexpected token".
+          SHELLCHECK_OPTS="-S error" ./actionlint -color


### PR DESCRIPTION
## Summary

#169 disabled shellcheck entirely because enabling it reported **212 pre-existing findings**, 158 of them `SC2086` on scripts that have run correctly for months. That was the right call to get the lint green — but it left real shell defects unchecked, which is how the scout shipped a step that died at runtime with `syntax error near unexpected token )`.

At severity `error` the repo is **clean today**, so unparseable shell fails the build while the style backlog stays out of the way.

## Measured across all 19 workflows

| Severity | Findings | Verdict |
|---|---|---|
| **error** | **0** | ← enabled |
| warning | 19 | real backlog, follow-up |
| info | 187 | mostly SC2086 noise |
| style | 204 | noise |

The four original errors are all resolved: two were a comment of mine shellcheck read as a directive, one was a genuine `-eq` on an unvalidated value (fixed in #169), and the fourth lived in the scout code rewritten in #176.

## The backlog is acknowledged, not dismissed

19 warnings remain — `SC2044` (find in a for loop), `SC2034` (unused), `SC2046` (word splitting), `SC2155`. Some are potentially real. Raising this to `warning` after clearing them is worthwhile; doing it *now* would mean editing 19 working scripts under no particular pressure, which is how you break a pipeline to satisfy a linter.

## A note on honesty

I initially wrote a comment claiming this level would have caught the scout bug specifically. I could not reproduce that locally, so I removed the claim rather than leave an unverifiable justification in the code. What I can state is what `error` covers: shell that cannot be parsed — which is the failure mode that killed that step.

Verified with shellcheck 0.11.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)