### PR TITLE
fix(nightly): Stamp update-log in the workflow instead of asking the agent

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -372,6 +372,33 @@ jobs:
             IMPORTANT: Do NOT commit or push. The workflow handles that.
           claude_args: "--max-turns 30 --dangerously-skip-permissions"  # Reduced from 50 to save Claude Code budget
 
+      - name: Stamp update-log
+        # STEP 4 of the prompt asks the agent to write update-log.json, and it
+        # usually does not: the 2026-08-09 catch-up recovered real events for 23
+        # trackers but only 2 update-logs came back. lastRun then still looks
+        # stale, so the scheduler keeps re-picking trackers that were in fact
+        # just updated, and the freshness numbers understate reality.
+        #
+        # Stamping it here rather than asking the model — the hourly scan has
+        # always done it this way. Only lastRun is written; per-section status
+        # stays the agent's to report, since only it knows what it touched.
+        if: success()
+        run: |
+          LOG="trackers/${{ matrix.slug }}/data/update-log.json"
+          [ -d "$(dirname "$LOG")" ] || exit 0
+          node -e "
+            const fs = require('fs');
+            const p = '$LOG';
+            let log = {};
+            try { log = JSON.parse(fs.readFileSync(p, 'utf8')); } catch {}
+            if (!log || typeof log !== 'object') log = {};
+            log.lastRun = new Date().toISOString();
+            log.tracker = '${{ matrix.slug }}';
+            if (!log.sections || typeof log.sections !== 'object') log.sections = {};
+            fs.writeFileSync(p, JSON.stringify(log, null, 2));
+            console.log('Stamped lastRun=' + log.lastRun);
+          "
+
       - name: Upload tracker changes
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

The catch-up run **worked**: real events recovered for 23 trackers (new July/August event files for `artemis-2`, `bad-bunny`, `bts` and others), pipeline green end to end, data committed.

But **only 2 of 23 `update-log.json` files came back.**

STEP 4 of the prompt asks the agent to write `update-log.json`. It usually doesn't, and nothing downstream notices. So `lastRun` still reads as months old for trackers that were *just* updated:

- the scheduler keeps re-picking trackers that don't need it, wasting budget
- the freshness numbers understate reality

That is the same class of dishonest telemetry as the hardcoded section list fixed in #167 — the data was fine, the record of it was wrong.

## Change

The workflow stamps `lastRun` itself after a successful update, which is **how the hourly scan has always done it**. Only `lastRun` is written; per-section status stays the agent's to report, since only it knows which sections it actually touched.

Reads defensively — existing sections preserved, unreadable or non-object files rebuilt rather than throwing.

## The pattern

This is the same mistake in a third place: **relying on an LLM for something deterministic**.

| PR | Moved off the model |
|---|---|
| #171 | map-lines repair (`drone/missile` → `mixed`) |
| #185 | confidence enum normalisation |
| **this** | update-log stamping |

Each one was found the same way — something downstream quietly didn't happen.

## Testing

- Stamping preserves existing `sections` and updates only `lastRun`.
- A corrupt/non-JSON log is rebuilt rather than throwing.
- `actionlint` clean at severity `error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)