### PR TITLE
fix(freshness): Judge each tracker against its own cadence

### DIFF
--- a/scripts/check-data-freshness.ts
+++ b/scripts/check-data-freshness.ts
@@ -34,17 +34,33 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const GLOBAL_STALE_DAYS = Number(process.env.FRESHNESS_GLOBAL_STALE_DAYS ?? 3);
 
 /**
- * Share of active trackers allowed to sit past their own staleness horizon
- * before we report. Individual trackers legitimately go quiet — historical
- * arcs especially — so this is about the fleet, not any single one.
+ * How many times its own configured cadence a tracker may exceed before it
+ * counts as stale.
+ *
+ * The first version of this compared every tracker against a flat 30 days,
+ * which measured almost nothing: configured cadences here run from 7 to 365
+ * days, and 67 of 96 trackers are on 90 days or more, so most of the fleet sat
+ * "past 30 days" permanently and by design. Judging each tracker against its
+ * own cadence is what separates a genuinely stalled tracker from one that is
+ * simply slow on purpose — uap-disclosure at 66 days on a 7-day cadence (9.4x)
+ * is a real problem; a 180-day arc at 88 days is not.
  */
-const STALE_TRACKER_RATIO = Number(process.env.FRESHNESS_STALE_RATIO ?? 0.9);
-const TRACKER_STALE_DAYS = Number(process.env.FRESHNESS_TRACKER_STALE_DAYS ?? 30);
+const STALE_CADENCE_FACTOR = Number(process.env.FRESHNESS_CADENCE_FACTOR ?? 2);
+
+/**
+ * Share of active trackers allowed to be stale before we report. This is about
+ * the fleet, not any single tracker — individual ones legitimately go quiet.
+ */
+const STALE_TRACKER_RATIO = Number(process.env.FRESHNESS_STALE_RATIO ?? 0.35);
 
 export interface TrackerFreshness {
   slug: string;
   lastRun: string | null;
   daysSince: number | null;
+  /** Longest configured update interval, in days. */
+  cadenceDays: number;
+  /** daysSince / cadenceDays — how far past its own schedule it has drifted. */
+  overdueRatio: number | null;
 }
 
 export interface FreshnessReport {
@@ -65,13 +81,24 @@ export function collectFreshness(now: Date, root: string = ROOT): TrackerFreshne
     const configPath = join(trackersDir, slug, 'tracker.json');
     if (!existsSync(configPath)) continue;
 
-    let config: { status?: string };
+    let config: {
+      status?: string;
+      ai?: { updatePolicy?: { escalation?: number[] }; updateIntervalDays?: number };
+    };
     try {
       config = JSON.parse(readFileSync(configPath, 'utf8'));
     } catch {
       continue;
     }
     if (config.status !== 'active') continue;
+
+    // The slowest step of the escalation ladder is the real deadline: a quiet
+    // tracker is allowed to drift out to it before anything is wrong.
+    const escalation = config.ai?.updatePolicy?.escalation;
+    const cadenceDays =
+      escalation && escalation.length
+        ? Math.max(...escalation)
+        : (config.ai?.updateIntervalDays ?? 1);
 
     let lastRun: string | null = null;
     try {
@@ -91,7 +118,13 @@ export function collectFreshness(now: Date, root: string = ROOT): TrackerFreshne
       }
     }
 
-    out.push({ slug, lastRun, daysSince });
+    out.push({
+      slug,
+      lastRun,
+      daysSince,
+      cadenceDays,
+      overdueRatio: daysSince === null ? null : daysSince / Math.max(cadenceDays, 1),
+    });
   }
 
   return out;
@@ -110,8 +143,13 @@ export function evaluate(trackers: TrackerFreshness[]): FreshnessReport {
   const freshest = sorted[0] ?? null;
   const stalest = sorted[sorted.length - 1] ?? null;
 
-  const staleCount =
-    trackers.length - withDays.filter((t) => t.daysSince < TRACKER_STALE_DAYS).length;
+  // Stale relative to its own cadence, not a flat day count. An unknown
+  // lastRun counts as stale — a tracker we cannot date is not evidence of
+  // health.
+  const staleTrackers = trackers.filter(
+    (t) => t.overdueRatio === null || t.overdueRatio > STALE_CADENCE_FACTOR,
+  );
+  const staleCount = staleTrackers.length;
 
   if (trackers.length === 0) {
     reasons.push('No active trackers found — cannot assess freshness');
@@ -132,7 +170,7 @@ export function evaluate(trackers: TrackerFreshness[]): FreshnessReport {
     if (ratio >= STALE_TRACKER_RATIO) {
       reasons.push(
         `${staleCount}/${trackers.length} active trackers (${Math.round(ratio * 100)}%) ` +
-          `have not been updated in ${TRACKER_STALE_DAYS}d.`,
+          `are more than ${STALE_CADENCE_FACTOR}x past their own configured cadence.`,
       );
     }
   }
@@ -171,7 +209,7 @@ function main(): void {
     );
   }
   console.log(
-    `[freshness] Past ${TRACKER_STALE_DAYS}d: ${report.staleCount}/${report.activeCount}`,
+    `[freshness] Past ${STALE_CADENCE_FACTOR}x own cadence: ${report.staleCount}/${report.activeCount}`,
   );
 
   if (process.env.GITHUB_OUTPUT) {

--- a/tests/check-data-freshness.test.ts
+++ b/tests/check-data-freshness.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { evaluate, type TrackerFreshness } from '../scripts/check-data-freshness.js';
 
-const t = (slug: string, daysSince: number | null): TrackerFreshness => ({
+const t = (slug: string, daysSince: number | null, cadenceDays = 1): TrackerFreshness => ({
   slug,
   lastRun: daysSince === null ? null : new Date(Date.now() - daysSince * 86_400_000).toISOString(),
   daysSince,
+  cadenceDays,
+  overdueRatio: daysSince === null ? null : daysSince / cadenceDays,
 });
 
 describe('check-data-freshness', () => {
@@ -27,23 +29,38 @@ describe('check-data-freshness', () => {
   it('tolerates individual quiet trackers while the fleet moves', () => {
     // Historical arcs legitimately go silent — one stale tracker is not an alert.
     const fleet = Array.from({ length: 20 }, (_, i) => t(`live-${i}`, 1));
-    const r = evaluate([...fleet, t('tlatelolco-1968', 400)]);
+    const r = evaluate([...fleet, t('tlatelolco-1968', 400, 365)]);
     expect(r.healthy).toBe(true);
   });
 
   it('catches a slow bleed where most of the fleet drifts past its horizon', () => {
     // A couple of trackers keep the primary check satisfied while everything
     // else silently rots — the state this repo was actually in.
-    const stale = Array.from({ length: 19 }, (_, i) => t(`stale-${i}`, 60));
+    const stale = Array.from({ length: 19 }, (_, i) => t(`stale-${i}`, 60, 7));
     const r = evaluate([...stale, t('fresh', 0)]);
     expect(r.healthy).toBe(false);
-    expect(r.reasons.join(' ')).toMatch(/have not been updated in 30d/);
+    expect(r.reasons.join(' ')).toMatch(/past their own configured cadence/);
   });
 
   it('treats an unknown lastRun as stale rather than healthy', () => {
     const r = evaluate([t('a', null), t('b', null)]);
     expect(r.healthy).toBe(false);
     expect(r.staleCount).toBe(2);
+  });
+
+  it('judges each tracker against its own cadence, not a flat day count', () => {
+    // The exact pair the flat 30-day threshold could not tell apart: a 7-day
+    // tracker 66 days behind is badly stalled (9.4x); a 180-day arc 88 days
+    // behind is early. Measured against a flat 30 days both look identical.
+    const stalled = t('uap-disclosure', 66, 7);
+    const healthy = t('september-11', 88, 180);
+    expect(stalled.overdueRatio).toBeGreaterThan(2);
+    expect(healthy.overdueRatio).toBeLessThan(1);
+
+    // A fleet of slow arcs sitting inside their cadence must not alarm, even
+    // though every one of them is far past 30 days.
+    const arcs = Array.from({ length: 20 }, (_, i) => t(`arc-${i}`, 88, 180));
+    expect(evaluate([t('live', 0, 1), ...arcs]).healthy).toBe(true);
   });
 
   it('reports rather than passing when there are no trackers', () => {


### PR DESCRIPTION
## Summary

The secondary freshness signal compared every tracker against a **flat 30 days**. That measured almost nothing useful.

Configured cadences in this repo:

| Max cadence | Trackers |
|---|---|
| 7d | 1 |
| 30d | 18 |
| 60d | 9 |
| 90d | 34 |
| 180d | 33 |
| 365d | 1 |

**67 of 96 are on 90 days or more**, so most of the fleet sat "past 30 days" permanently and by design. The check reported **79/96 stale while the pipeline was working correctly** — a number too noisy to act on, which is the same as having no signal.

## Change

Staleness is now **relative**: a tracker is stale when it exceeds its own longest configured interval by more than 2×.

That separates the two cases the flat threshold could not distinguish:

| Tracker | Behind | Cadence | Ratio | Verdict |
|---|---|---|---|---|
| `uap-disclosure` | 66d | 7d | **9.4×** | genuinely stalled |
| `september-11` | 88d | 180d | 0.5× | early, fine |

Under the old rule both counted identically as "past 30 days".

Against real data the fleet now reads **12/96** instead of 79/96, and those 12 really are behind. The fleet ratio drops from 0.9 to 0.35 to match, since the denominator is no longer inflated by trackers that are slow on purpose.

The **primary signal is untouched** — "has anything moved at all in 3 days" was already the robust check, and correctly reports healthy.

## Follow-up this surfaces

Most of the 12 will clear on their own tonight: they are the catch-up trackers whose `update-log` went unstamped until #186. **`uap-disclosure` is not one of them** — 66 days on a 7-day cadence — and wants a look.

That is the point of fixing the metric: it now names something worth acting on instead of reporting 82% and meaning nothing.

## Testing

7 tests pass, including a new one asserting the 7-day/180-day pair is separated correctly and that a fleet of slow arcs inside their cadence does not alarm. No new `tsc` errors. Run against real data: 12/96, healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)