### PR TITLE
fix(feeds): Redirect /rss to the global feed instead of 404ing

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,15 @@ export default defineConfig({
   output: 'static',
   site: 'https://watchboard.dev',
   base: '/',
+  // /rss and /rss/ 404'd: src/pages/rss/ holds breaking.xml and light-scan.xml
+  // but has no index, so the directory itself was never a route. Nothing on the
+  // site linked there, but it is the URL people type by convention — a bad one
+  // to lose on a site whose product is feeds. Sent to the global feed rather
+  // than to /feeds/, since bare /rss conventionally means "the feed".
+  redirects: {
+    '/rss': '/rss.xml',
+    '/rss/': '/rss.xml',
+  },
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'es', 'fr', 'pt'],


### PR DESCRIPTION
## Summary

`https://watchboard.dev/rss/` returns **404**.

`src/pages/rss/` holds `breaking.xml.ts` and `light-scan.xml.ts` but has **no index**, so the directory itself was never a route:

| Route | Before |
|---|---|
| `/rss/` | **404** |
| `/rss.xml` | 200 |
| `/rss/breaking.xml` | 200 |
| `/feeds/` | 200 |

Nothing on the site links to `/rss/` — the only `/rss/` strings in the source are third-party feed URLs in `tracker-feeds.ts` — so no internal link was broken. But it's the URL people type by convention, and a 404 there is a poor thing to serve from a site whose product *is* feeds.

## Choice of target

Points at **`/rss.xml`**, not `/feeds/`: a bare `/rss` conventionally means "the feed", and is as likely to be pasted into a reader as opened in a browser. `/feeds/` remains the human-readable index of everything (and `/feeds.json` / `/feeds.opml` for machines).

## Verification

Built and confirmed `dist/rss/index.html` is emitted:

```html
<title>Redirecting to: /rss.xml</title>
<meta http-equiv="refresh" content="0;url=/rss.xml">
<link rel="canonical" href="https://watchboard.dev/rss.xml">
```

`rss.xml`, `rss/breaking.xml` and `rss/light-scan.xml` are all still produced — the redirect adds `index.html` alongside them rather than shadowing anything.

## Unrelated finding

A clean local `npm run build` **cannot currently complete on macOS** — it aborts during OG image generation with `Abort trap: 6`, the pre-existing resvg segfault that #145 addresses. I verified this change with the OG routes temporarily moved aside and then restored. Worth flagging since it means local build verification is degraded until #145 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)