### PR TITLE
fix(feeds): Make /rss a real page so readers can discover the feed

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,15 +7,10 @@ export default defineConfig({
   output: 'static',
   site: 'https://watchboard.dev',
   base: '/',
-  // /rss and /rss/ 404'd: src/pages/rss/ holds breaking.xml and light-scan.xml
-  // but has no index, so the directory itself was never a route. Nothing on the
-  // site linked there, but it is the URL people type by convention — a bad one
-  // to lose on a site whose product is feeds. Sent to the global feed rather
-  // than to /feeds/, since bare /rss conventionally means "the feed".
-  redirects: {
-    '/rss': '/rss.xml',
-    '/rss/': '/rss.xml',
-  },
+  // Note: /rss is a real page (src/pages/rss/index.astro), not a redirect.
+  // Astro's generated redirect stub is bare HTML with no <head> from
+  // BaseLayout, so an RSS reader pointed at /rss would get a page containing
+  // no feed autodiscovery and no way to find the actual feed.
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'es', 'fr', 'pt'],

--- a/src/pages/rss/index.astro
+++ b/src/pages/rss/index.astro
@@ -1,0 +1,71 @@
+---
+/**
+ * /rss — the URL people type by convention.
+ *
+ * Previously a 404: this directory held breaking.xml.ts and light-scan.xml.ts
+ * but no index, so the directory itself was never a route.
+ *
+ * Deliberately a real page rather than a redirect. Astro's redirect stub is
+ * bare HTML with no <head> from BaseLayout, so an RSS reader pointed at /rss
+ * would receive a page containing no feed autodiscovery — and readers do not
+ * follow meta-refresh. BaseLayout emits <link rel="alternate"
+ * type="application/rss+xml"> for every global feed, so a reader given this URL
+ * discovers rss.xml on its own, while a human gets something readable.
+ *
+ * Kept short on purpose: /feeds/ is the full index including all 96 per-tracker
+ * feeds. This lists only the global ones and points there.
+ */
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { discoverStaticFeeds, type FeedMeta } from '../../lib/feed-registry';
+
+const base = import.meta.env.BASE_URL;
+const basePath = base.endsWith('/') ? base : `${base}/`;
+const siteUrl = 'https://watchboard.dev';
+
+// Same discovery as /feeds/, paths relative to this file.
+const modules = import.meta.glob<{ feedMeta?: FeedMeta }>(
+  ['../rss.xml.ts', './*.xml.ts'],
+  { eager: true },
+);
+const globalFeeds = discoverStaticFeeds(modules, siteUrl, basePath);
+---
+
+<BaseLayout
+  title="RSS"
+  description="Watchboard RSS feeds — site-wide, breaking news and light-scan triage. Subscribe in any reader."
+>
+  <main id="main-content">
+    <div class="feeds-page">
+      <a class="feeds-back" href={basePath}>&larr; Home</a>
+      <h1>RSS</h1>
+      <p class="feeds-lede">
+        The main Watchboard feeds. For per-tracker feeds and machine-readable
+        indexes, see <a href={`${basePath}feeds/`}>all feeds</a>.
+      </p>
+
+      <ul class="feeds-list">
+        {globalFeeds.map((f) => (
+          <li class="feed-card">
+            <div class="feed-head">
+              <a class="feed-title" href={f.url.replace(siteUrl, '')}>{f.title}</a>
+              <code class="feed-url">{f.url}</code>
+            </div>
+            <p class="feed-desc">{f.description}</p>
+            <div class="feed-meta">
+              <span class="feed-cadence">{f.cadence}</span>
+              <span class="feed-tag">{f.category}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <div class="feeds-machine">
+        <span class="feeds-machine-label">Machine-readable index:</span>
+        <a href={`${basePath}feeds.json`}><code>feeds.json</code></a>
+        <span class="feed-sep">·</span>
+        <a href={`${basePath}feeds.opml`}><code>feeds.opml</code></a>
+        <span class="feeds-machine-hint">— OPML imports every feed at once.</span>
+      </div>
+    </div>
+  </main>
+</BaseLayout>


### PR DESCRIPTION
## Summary

**Replaces the redirect from #188, which was the wrong fix.** You were right to question it.

Astro's generated redirect stub is bare HTML with **no `<head>` from BaseLayout**:

```html
<!doctype html><title>Redirecting to: /rss.xml</title>
<meta http-equiv="refresh" content="0;url=/rss.xml">
```

**RSS readers do not follow meta-refresh.** So a reader pointed at `/rss` got a page with no feed autodiscovery and no way to reach the actual feed. The redirect only worked for humans in a browser — the smaller half of who types that URL into something.

## Why a real page is strictly better

`BaseLayout` already emits autodiscovery on every page of the site:

```html
<link rel="alternate" type="application/rss+xml" title="Watchboard RSS" href="/rss.xml">
<link rel="alternate" type="application/rss+xml" title="Watchboard Breaking News RSS" href="/rss/breaking.xml">
<link rel="alternate" type="application/rss+xml" title="Watchboard Light-Scan Triage RSS" href="/rss/light-scan.xml">
```

So one page serves both audiences:

| Who | Gets |
|---|---|
| RSS reader | autodiscovery → finds `rss.xml` on its own |
| Human | a readable list of feeds, not raw XML |

That's better than the redirect for readers, *and* better than it for humans, who previously landed on a wall of XML.

## Scope

Deliberately short. It lists the three global feeds using the same `discoverStaticFeeds` registry that `/feeds/` uses, and links there for the full index including all per-tracker feeds — no duplication of the 173-line feeds page.

## Verification

Built and confirmed in `dist/rss/index.html`:

- all three `rel="alternate"` autodiscovery links present
- three feed cards rendered: *All trackers — global digest*, *Breaking news*, *Light-scan triage firehose*
- `rss.xml`, `rss/breaking.xml`, `rss/light-scan.xml` all still emitted — the index sits alongside them, shadowing nothing

(Build still requires temporarily setting aside the OG routes because of the resvg `Abort trap: 6` that #145 addresses; restored afterwards, tree clean.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)