### PR TITLE
fix(security): Close CSP drift before enforcement, read PostHog key from secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,13 @@ jobs:
 
       - name: Build Astro site
         env:
-          PUBLIC_POSTHOG_KEY: phc_CtJ5gPA3KykaauRYyqjkjq3ELJrBeJWxeKFoZkFNHwuw
+          # A PUBLIC_POSTHOG_KEY secret has existed since April but nothing read
+          # it — the key was inlined here instead. phc_ keys are public by
+          # design (they ship in the HTML), so this was never an exposure, just
+          # two sources of truth where rotating meant editing code. Falls back
+          # to the literal so a fork or a missing secret still builds with
+          # analytics rather than silently losing them.
+          PUBLIC_POSTHOG_KEY: ${{ secrets.PUBLIC_POSTHOG_KEY || 'phc_CtJ5gPA3KykaauRYyqjkjq3ELJrBeJWxeKFoZkFNHwuw' }}
           PUBLIC_POSTHOG_HOST: https://us.i.posthog.com
         run: npm run build
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -57,8 +57,32 @@ const pushTrackers = loadAllTrackers()
   <meta name="theme-color" content="#0d1117">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  {/* TODO(2026-05): flip CSP-Report-Only to enforcement after 1 week of clean violation reports */}
-  <meta http-equiv="Content-Security-Policy-Report-Only" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://*.posthog.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://*.posthog.com https://app.posthog.com https://us.i.posthog.com https://api.open-meteo.com https://earthquake.usgs.gov https://opensky-network.org https://*.wikipedia.org https://*.wikimedia.org https://api.memegen.link https://assets.ion.cesium.com https://tiles.ion.cesium.com https://cesium.com https://static.cloudflareinsights.com; frame-src https://www.youtube.com https://youtube.com; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'self' blob:">
+  {/* Still Report-Only, and deliberately so.
+
+      The original TODO said "flip to enforcement after 1 week of clean
+      violation reports". Those reports were never going anywhere: the policy
+      has no report-uri or report-to, so for months it neither blocked nor
+      reported — decorative in both directions.
+
+      Auditing the client code against the policy showed enforcement today
+      would have broken real features, since connect-src had drifted behind
+      what the islands actually call:
+
+        celestrak.org              useSatellites.ts   (globe satellites)
+        archive-api.open-meteo.com useMapOverlays.ts  (historical weather)
+        stream.aisstream.io        useShips.ts        (AIS ship traffic)
+        basemaps.cartocdn.com      LeafletMap.tsx     (basemap tiles)
+        api.github.com             SocialCommandCenter.tsx (PAT auth)
+        tile.openstreetmap.org     TrackerDirectory.tsx
+        t.me                       useMapOverlays.ts
+
+      Those are now allowed. Enforcement is a separate change once this has
+      been live long enough to confirm nothing else is missing — note that
+      'unsafe-inline' in script-src (required by the PostHog snippet and
+      Astro's define:vars) limits the XSS protection enforcement would buy;
+      the durable wins are object-src, base-uri, frame-ancestors, form-action
+      and constraining connect-src. */}
+  <meta http-equiv="Content-Security-Policy-Report-Only" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://*.posthog.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://*.posthog.com https://app.posthog.com https://us.i.posthog.com https://api.open-meteo.com https://archive-api.open-meteo.com https://earthquake.usgs.gov https://opensky-network.org https://celestrak.org https://*.celestrak.org https://api.github.com https://*.basemaps.cartocdn.com https://tile.openstreetmap.org https://t.me wss://stream.aisstream.io https://*.wikipedia.org https://*.wikimedia.org https://api.memegen.link https://assets.ion.cesium.com https://tiles.ion.cesium.com https://cesium.com https://static.cloudflareinsights.com; frame-src https://www.youtube.com https://youtube.com; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'self' blob:">
   <meta http-equiv="Permissions-Policy" content="geolocation=(), microphone=(), camera=()">
   <link rel="preload" href={`${basePath}fonts/jetbrains-mono-latin.woff2`} as="font" type="font/woff2" crossorigin>
   <link rel="preload" href={`${basePath}fonts/dm-sans-latin.woff2`} as="font" type="font/woff2" crossorigin>


### PR DESCRIPTION
## The CSP was decorative, and enforcing it today would have broken things

It has sat in `Report-Only` since May behind:

```
TODO(2026-05): flip CSP-Report-Only to enforcement after 1 week of clean violation reports
```

**Those reports were never going anywhere.** The policy has no `report-uri` and no `report-to`, so for three months it neither blocked nor reported. Decorative in both directions — and the wait was for data nobody was collecting.

So I audited the client code against the policy instead. **Six of nine external hosts used by browser code were missing from `connect-src`:**

| Host | Used by | Feature |
|---|---|---|
| `celestrak.org` | `useSatellites.ts` | globe satellites |
| `archive-api.open-meteo.com` | `useMapOverlays.ts` | historical weather |
| `stream.aisstream.io` | `useShips.ts` | AIS ship traffic |
| `basemaps.cartocdn.com` | `LeafletMap.tsx` | basemap tiles |
| `api.github.com` | `SocialCommandCenter.tsx` | PAT auth on `/social/` |
| `tile.openstreetmap.org` | `TrackerDirectory.tsx` | directory thumbnails |
| `t.me` | `useMapOverlays.ts` | — |

Flipping to enforcement would have silently broken all of them. That is presumably what the "week of clean reports" was meant to catch, and it never could.

## What this does, and does not do

Adds the missing hosts and replaces the TODO with what was actually found.

**Enforcement stays a separate change.** Flipping it in the same commit that widens the policy would mean trusting a static audit as if it were runtime evidence. This needs to be live long enough to confirm nothing else is missing first.

Also worth recording: `'unsafe-inline'` in `script-src` is required by the PostHog snippet and Astro's `define:vars`, so enforcement buys **less XSS protection than it appears to**. The durable wins are `object-src`, `base-uri`, `frame-ancestors`, `form-action` and a constrained `connect-src` — real, but not "we're protected from XSS now".

## PostHog key

`deploy.yml` inlined the key while a `PUBLIC_POSTHOG_KEY` secret has existed **unused** since April.

Not an exposure — `phc_` keys are public by design and ship in the page HTML. It was two sources of truth, where rotating meant editing code. Now reads the secret with the literal as fallback, so a fork or a missing secret still builds with analytics rather than silently losing them.

## Testing

CSP still parses as 12 well-formed directives, with all seven hosts present in `connect-src`. `actionlint` clean at severity `error`.

Verification was static: the Chrome extension isn't connected in this session, so I couldn't read live console violations. That is exactly why enforcement isn't in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)