### PR TITLE
fix(deploy): Rename the pages concurrency group to unblock publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,8 +23,17 @@ permissions:
   pages: write
   id-token: write
 
+# Renamed from "pages" on 2026-08-10. Every deploy queued behind that group
+# stopped materialising: runs sat `pending` with zero jobs for 15+ minutes and
+# were then superseded, so nothing published for ~14 hours while every other
+# workflow in the repo started and finished normally. Ruled out in turn: repo
+# concurrency collisions (no other workflow used the group), runner contention
+# (no overlapping runs), the environment's branch policy (main is allowed),
+# GitHub-wide incidents (all components operational), an orphaned github-pages
+# deployment stuck without a status since 17:44 (resolved, no effect), and a
+# stale queue (drained, no effect). What remained was the group itself.
 concurrency:
-  group: "pages"
+  group: pages-deploy
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary

**Nothing has published since 2026-08-09T17:44Z.** Deploy runs sit `pending` with **zero jobs** for 15+ minutes, get superseded by the next one, and are cancelled. The site is serving a build from ~14 hours ago while `main` has moved well past it — `/rss/` still 404s despite #188/#189 being merged.

## Investigated and ruled out

| Hypothesis | Result |
|---|---|
| Repo concurrency collision | No other workflow uses the `pages` group |
| Runner contention | **Zero** workflows overlapping the stuck runs |
| Environment branch policy | `github-pages` allows `main` |
| GitHub incident | All components operational |
| Orphaned deployment | One deployment sat with **0 statuses** since 17:44 — real, resolved by marking it `inactive`, but publishing stayed stuck |
| Stale queue | Drained it and dispatched a clean run; **that run also sat pending with zero jobs** |

## What narrows it

Every other workflow in the repo **started and finished normally** at the same timestamps:

```
07:19:30  Telegram Channel Notifications   success
07:19:26  Build and Deploy to GitHub Pages pending   ← only this one
07:18:18  Hourly Light Scan                success
07:10:25  Hourly Breaking News Scan        success
07:03:45  Lint Workflows                   success
```

So it isn't GitHub-wide, and it isn't the account. The deploy workflow alone stalls, and the only thing exclusive to it is this concurrency group. A run GitHub still considers active in `pages` — not visible through the API — produces exactly this shape, since `cancel-in-progress: false` makes queued runs wait indefinitely.

## The change

Renames the group to `pages-deploy`, sidestepping the stuck one. `cancel-in-progress` stays `false`, which is correct for Pages — a half-finished deploy shouldn't be interrupted.

**This is a workaround, not a root cause.** If runs stall again under the new name, the group isn't the problem and this is worth raising with GitHub Support. I'll confirm which it is once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)