### PR TITLE
security(csp): Enforce the Content Security Policy

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -57,16 +57,14 @@ const pushTrackers = loadAllTrackers()
   <meta name="theme-color" content="#0d1117">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  {/* Still Report-Only, and deliberately so.
+  {/* Enforced. Previously Report-Only for months behind a TODO saying "flip
+      after 1 week of clean violation reports" — reports that were never
+      collected, since the policy has no report-uri or report-to. It neither
+      blocked nor reported: decorative in both directions.
 
-      The original TODO said "flip to enforcement after 1 week of clean
-      violation reports". Those reports were never going anywhere: the policy
-      has no report-uri or report-to, so for months it neither blocked nor
-      reported — decorative in both directions.
-
-      Auditing the client code against the policy showed enforcement today
-      would have broken real features, since connect-src had drifted behind
-      what the islands actually call:
+      connect-src had drifted well behind what the islands actually call, so
+      enforcing it earlier would have broken working features. Recovered by
+      auditing the client code and then the compiled bundles:
 
         celestrak.org              useSatellites.ts   (globe satellites)
         archive-api.open-meteo.com useMapOverlays.ts  (historical weather)
@@ -75,14 +73,19 @@ const pushTrackers = loadAllTrackers()
         api.github.com             SocialCommandCenter.tsx (PAT auth)
         tile.openstreetmap.org     TrackerDirectory.tsx
         t.me                       useMapOverlays.ts
+        *.cesium.com               Cesium Ion — api.cesium.com appears in the
+                                   bundle and the old explicit hosts did not
+                                   cover it, which would have broken the globe
 
-      Those are now allowed. Enforcement is a separate change once this has
-      been live long enough to confirm nothing else is missing — note that
-      'unsafe-inline' in script-src (required by the PostHog snippet and
-      Astro's define:vars) limits the XSS protection enforcement would buy;
-      the durable wins are object-src, base-uri, frame-ancestors, form-action
-      and constraining connect-src. */}
-  <meta http-equiv="Content-Security-Policy-Report-Only" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://*.posthog.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://*.posthog.com https://app.posthog.com https://us.i.posthog.com https://api.open-meteo.com https://archive-api.open-meteo.com https://earthquake.usgs.gov https://opensky-network.org https://celestrak.org https://*.celestrak.org https://api.github.com https://*.basemaps.cartocdn.com https://tile.openstreetmap.org https://t.me wss://stream.aisstream.io https://*.wikipedia.org https://*.wikimedia.org https://api.memegen.link https://assets.ion.cesium.com https://tiles.ion.cesium.com https://cesium.com https://static.cloudflareinsights.com; frame-src https://www.youtube.com https://youtube.com; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'self' blob:">
+      Scope, honestly: 'unsafe-inline' in script-src is required by the PostHog
+      snippet and Astro's define:vars, so this buys less XSS protection than it
+      looks. The durable wins are object-src 'none', base-uri, frame-ancestors,
+      form-action, and constraining where the page may connect.
+
+      If something does break, reverting is one word: put -Report-Only back on
+      the http-equiv below. Worth checking the globe and /social/ with a
+      console open, since those exercise the most third-party endpoints. */}
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://*.posthog.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://*.posthog.com https://app.posthog.com https://us.i.posthog.com https://api.open-meteo.com https://archive-api.open-meteo.com https://earthquake.usgs.gov https://opensky-network.org https://celestrak.org https://*.celestrak.org https://api.github.com https://*.basemaps.cartocdn.com https://tile.openstreetmap.org https://t.me wss://stream.aisstream.io https://*.wikipedia.org https://*.wikimedia.org https://api.memegen.link https://*.cesium.com https://cesium.com https://static.cloudflareinsights.com; frame-src https://www.youtube.com https://youtube.com; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'self' blob:">
   <meta http-equiv="Permissions-Policy" content="geolocation=(), microphone=(), camera=()">
   <link rel="preload" href={`${basePath}fonts/jetbrains-mono-latin.woff2`} as="font" type="font/woff2" crossorigin>
   <link rel="preload" href={`${basePath}fonts/dm-sans-latin.woff2`} as="font" type="font/woff2" crossorigin>


### PR DESCRIPTION
## Summary

The policy has been `Report-Only` since May behind:

```
TODO(2026-05): flip to enforcement after 1 week of clean violation reports
```

**Those reports were never collected** — there is no `report-uri` and no `report-to`. For three months it neither blocked nor reported. Waiting longer would never have produced the evidence the TODO was waiting for.

## Validated against the code instead, in two passes

**Pass 1 — the islands** (#190): six hosts missing from `connect-src`, added.

**Pass 2 — the compiled bundles** in `dist/_astro`: one more found. `api.cesium.com` appears in Cesium's shipped code, and the explicit `assets.ion.cesium.com` / `tiles.ion.cesium.com` entries **did not cover it** — enforcement would have broken the globe. Now a `*.cesium.com` wildcard.

That second pass is the one that mattered: source-level review had already "passed", and the bundle still hid a break.

## Cross-check

Every `https`/`wss` host our client code references, checked against the policy — **nothing unallowed**. The apparent misses aren't real:

| Host | Why it's fine |
|---|---|
| RSS feeds (`feeds.reuters.com`, …) | `tracker-feeds.ts` runs at build time, server-side |
| `aisstream.io`, `carto.com` | only inside attribution `<a href>` — `connect-src` doesn't govern links |

The actual calls are `wss://stream.aisstream.io` and `basemaps.cartocdn.com`, both permitted.

## Scope, stated plainly

`'unsafe-inline'` in `script-src` is required by the PostHog snippet and Astro's `define:vars`, so **this buys less XSS protection than flipping a CSP to enforcement suggests**. The durable wins are `object-src 'none'`, `base-uri`, `frame-ancestors`, `form-action`, and constraining where the page may connect — which matters here specifically because the site renders text and URLs an LLM extracted from external feeds.

## Not verified

**Runtime behaviour.** The Chrome extension isn't connected in this session, so no console was read. Static analysis over source *and* bundles is strong, but it is not proof.

Reverting is one word — put `-Report-Only` back on the `http-equiv`. The globe and `/social/` are the pages worth opening first; they exercise the most third-party endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)