### PR TITLE
fix(ci): Three failing workflows — turn budget, tally conflict, deploy bursts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,27 @@ name: Build and Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+    # Data commits do not trigger a deploy on their own.
+    #
+    # Every push to main queued another deploy, and a burst of them — a few
+    # merges in a row, or a run of bot commits — leaves runs stacked in the
+    # concurrency group cancelling each other. Twice now the group has ended up
+    # wedged: runs sit `pending` with zero jobs indefinitely and nothing
+    # publishes (see #193). Renaming the group cleared it the first time, which
+    # is why it was thought to be the cause; it wedged again under the new name,
+    # so the trigger volume is the real driver.
+    #
+    # Data still reaches the site through three other paths: the hourly scan's
+    # explicit trigger-deploy job, the nightly's workflow_run, and the daily
+    # schedule below. This only stops each individual data commit from opening
+    # its own deploy.
+    paths-ignore:
+      - 'trackers/**'
+      - 'public/_metrics/**'
+      - 'public/_hourly/**'
+      - 'public/_social/**'
+      - 'public/_tracker-votes/**'
+      - 'video/state/**'
   workflow_dispatch:
   workflow_run:
     workflows: ["Nightly Data Update"]

--- a/.github/workflows/hourly-scan.yml
+++ b/.github/workflows/hourly-scan.yml
@@ -614,7 +614,14 @@ jobs:
         with:
           allowed_bots: "github-actions[bot]"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 35 --dangerously-skip-permissions --model claude-sonnet-4-6"
+          # 35 was not enough: runs finished the work and were then failed for
+          # overrunning, losing the tracker entirely.
+          #   2026-08-14  "successful result after 37 turns, exceeding 35"
+          #   2026-08-16  "successful result after 45 turns, exceeding 35" (x2)
+          # Aligned with init-tracker/seed-tracker, which build a tracker from
+          # scratch the same way. The observed runs take ~5 min, so 80 turns
+          # still sits well inside this job's 15-minute timeout.
+          claude_args: "--max-turns 80 --dangerously-skip-permissions --model claude-sonnet-4-6"
           prompt: |
             You are creating a new Watchboard tracker based on a breaking news event.
 

--- a/.github/workflows/tally-tracker-votes.yml
+++ b/.github/workflows/tally-tracker-votes.yml
@@ -170,8 +170,28 @@ jobs:
                 pushed=true
                 break
               fi
+              # Backoff alone does not help here. When another run has also
+              # written tally.json the rebase fails with "could not apply" —
+              # a content conflict, not contention — so every retry hits the
+              # same wall and the run dies after five identical failures.
+              #
+              # tally.json is regenerated from scratch each run (a full recount
+              # of every vote issue), so the newest version is always the
+              # correct one. Rebase our commit onto the updated main by keeping
+              # our file rather than trying to merge two generated snapshots.
               git rebase --abort 2>/dev/null || true
-              echo "Push attempt $i failed, retrying with jitter..."
+              cp public/_tracker-votes/tally.json /tmp/tally-ours.json
+              git reset --hard origin/main
+              mkdir -p public/_tracker-votes
+              cp /tmp/tally-ours.json public/_tracker-votes/tally.json
+              if git diff --quiet public/_tracker-votes/tally.json; then
+                echo "Tally already current on main after reset — nothing to push"
+                pushed=true
+                break
+              fi
+              git add public/_tracker-votes/tally.json
+              git commit -m "chore(votes): tally tracker-vote issues $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+              echo "Push attempt $i failed, rebuilt commit on latest main; retrying with jitter..."
               sleep $(( (RANDOM % 8) + 3 ))
             done
             if [ "$pushed" != "true" ]; then


### PR DESCRIPTION
## 1. New tracker creation loses its work — `hourly-scan`

Jobs **finish successfully** and are then failed for overrunning:

```
2026-08-14  successful result after 37 turns, exceeding the configured maximum of 35
2026-08-16  successful result after 45 turns, exceeding the configured maximum of 35  (x2)
```

The tracker is never committed, so work that completed is thrown away. Recurring: 2 jobs on 08-16, 1 on 08-14.

Raised to **80**, matching `init-tracker` and `seed-tracker`, which build a tracker the same way. Observed runs take ~5 min, so this stays well inside the job's 15-minute timeout.

Same failure shape as the scout dying at 5 turns.

## 2. Vote tally cannot push — `tally-tracker-votes`

It already retries five times with jitter and still fails, because **this isn't contention**:

```
error: could not apply 9c77718... chore(votes): tally tracker-vote issues
```

A concurrent run also wrote `tally.json`, so the rebase hits a **content conflict** — every retry meets the same wall, five times, then the run dies.

`tally.json` is regenerated from scratch each run (a full recount of every vote issue), so the newest version is authoritative. On conflict the commit is now rebuilt on top of updated `main` with our file, rather than trying to merge two generated snapshots.

## 3. Deploy wedges after bursts — `deploy`

**The concurrency group has now jammed twice.** Runs sit `pending` with zero jobs and nothing publishes.

Renaming the group cleared it the first time (#192), which is why it looked like the cause. **It jammed again under the new name**, so trigger volume is the real driver — every push to `main` queued a deploy, and a burst leaves runs stacked cancelling each other.

Worth being plain about: three of the four cancelled runs in this burst were **my own merges**.

Data commits no longer trigger a deploy on their own — **22 of the last 25 commits** fall into that category, measured against real history rather than guessed. Data still reaches the site three other ways:

| Route | Covers |
|---|---|
| hourly scan's `trigger-deploy` | hourly data |
| nightly's `workflow_run` | nightly data |
| daily `schedule` | anything the other two miss |

## Verification

`actionlint` clean at `warning`; all three files parse; the `paths-ignore` list validated against the last 25 commits.

Updates #193 — the group name was not the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)