### PR TITLE
fix(deploy): Rename the concurrency group again to unblock the stuck queue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,8 +53,15 @@ permissions:
 # GitHub-wide incidents (all components operational), an orphaned github-pages
 # deployment stuck without a status since 17:44 (resolved, no effect), and a
 # stale queue (drained, no effect). What remained was the group itself.
+# Renamed a second time (2026-08-16). Renaming is the only thing that has ever
+# cleared a wedged group — runs sitting `pending` with zero jobs indefinitely —
+# but it treats the symptom: the group jammed again under the previous name, so
+# the name was never the cause. The paths-ignore above is the actual fix, since
+# it removes the trigger bursts that precede every jam. This rename is only to
+# unblock the queue that is stuck right now. If it wedges a third time, the
+# burst theory is wrong too and #193 should go to GitHub Support.
 concurrency:
-  group: pages-deploy
+  group: pages-deploy-2
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary

The group is **wedged again** — runs sit `pending` with zero jobs, nothing publishes. Same shape as 2026-08-10, now under the name that was supposed to have fixed it.

That's the useful finding: renaming cleared it the first time, which made the name *look* like the cause. **It wasn't.**

## What's actually the fix

#202's `paths-ignore` — it removes the trigger bursts that precede every jam. 22 of the last 25 commits no longer open a deploy.

But that only prevents the *next* jam. The queue stuck right now still needs clearing, and renaming is the only thing that has ever done it.

## Honest framing

This is a symptom fix. If the group wedges a **third** time, the burst theory is wrong too, and #193 should go to GitHub Support with all three occurrences documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)