### PR TITLE
fix(seed): Fail when a seed writes nothing, and stop agents delegating away

### DIFF
--- a/.github/workflows/init-tracker.yml
+++ b/.github/workflows/init-tracker.yml
@@ -492,6 +492,15 @@ jobs:
             Read back every file, count items vs backfillTargets, print summary table.
 
             IMPORTANT: Do NOT commit or push. The workflow handles that.
+
+            DO THE RESEARCH YOURSELF — do not delegate it to sub-agents or
+            background tasks. This job is a single turn: when you stop, the run
+            ends. Nothing resumes and no notification arrives later.
+
+            Two runs on 2026-08-16 ended with the tracker empty for exactly this
+            reason, both stopping to "wait for the background research agents".
+            They reported success after ~12 turns having written no files. Search
+            and write the files yourself, in this turn.
           claude_args: "--max-turns 80 --dangerously-skip-permissions"
 
       - name: Check for changes
@@ -500,8 +509,16 @@ jobs:
           SLUG="${{ github.event.inputs.slug }}"
           git add "trackers/${SLUG}/"
           if git diff --cached --quiet "trackers/${SLUG}/"; then
+            # Fail rather than skip — see seed-tracker.yml for the same guard.
+            # The init job has already committed a live, active tracker.json by
+            # this point, so a silent no-op here publishes an empty tracker.
+            # That is how super-el-nino-2026 went live active, 8 sections, zero
+            # data: the seed agent delegated to background agents, stopped to
+            # wait for them, wrote nothing, and the run still reported success.
             echo "changed=false" >> $GITHUB_OUTPUT
-            echo "No changes from seed"
+            echo "::error::Seed produced no changes — ${SLUG} is live but empty."
+            echo "Re-run seed-tracker.yml for this slug, or archive the tracker."
+            exit 1
           else
             echo "changed=true" >> $GITHUB_OUTPUT
             echo "Seed produced changes"

--- a/.github/workflows/seed-tracker.yml
+++ b/.github/workflows/seed-tracker.yml
@@ -191,6 +191,22 @@ jobs:
                { "lastRun": "<current ISO timestamp>", "tracker": "${{ steps.validate.outputs.slug }}", "sections": { "<section>": { "status": "seeded", "itemCount": <n> }, ... } }
 
             IMPORTANT: Do NOT commit or push. The workflow handles that.
+
+            DO THE RESEARCH YOURSELF — do not delegate it to sub-agents or
+            background tasks. This job is a single turn: when you stop, the run
+            ends. There is no later notification and nothing resumes.
+
+            Two consecutive runs on 2026-08-16 ended with the tracker still
+            empty because of exactly this. Their final messages were:
+
+              "Three research agents are running in the background. I'll wait
+               for them to complete before assembling the tracker data."
+              "I'll just wait for the automatic completion notifications from
+               the background research agents instead."
+
+            Both reported success after ~12 turns having written nothing, and
+            the commit step was skipped because there were no changes. Search
+            and write the files yourself, in this turn.
           claude_args: "--max-turns 80 --dangerously-skip-permissions"
 
       - name: Check for changes
@@ -203,8 +219,16 @@ jobs:
           echo "=== Staged changes ==="
           git diff --cached --name-only "trackers/${SLUG}/"
           if git diff --cached --quiet "trackers/${SLUG}/"; then
+            # Fail rather than skip. A seed that writes nothing is a failure,
+            # not a no-op: the whole purpose of this job is to populate a
+            # tracker. Reporting success and silently skipping the commit is
+            # how super-el-nino-2026 reached production active, with 8 sections
+            # and zero data, twice in a row.
             echo "changed=false" >> $GITHUB_OUTPUT
-            echo "No changes detected"
+            echo "::error::Seed produced no changes — the tracker is still empty."
+            echo "Check the agent's final message: if it delegated to background"
+            echo "agents and stopped waiting for them, it never wrote anything."
+            exit 1
           else
             echo "changed=true" >> $GITHUB_OUTPUT
             echo "Changes detected, will commit"

--- a/trackers/super-el-nino-2026/data/update-log.json
+++ b/trackers/super-el-nino-2026/data/update-log.json
@@ -1,5 +1,5 @@
 {
-  "lastRun": "2026-08-16T00:00:00Z",
+  "lastRun": "",
   "tracker": "super-el-nino-2026",
   "sections": {}
 }


### PR DESCRIPTION
## What happened

`super-el-nino-2026` went live **active, 8 sections, zero data**. Two seed runs in a row reported `success` having written no files — and both said exactly why:

```
"Three research agents are running in the background. I'll wait for them to
 complete before assembling the tracker data."

"I'll just wait for the automatic completion notifications from the background
 research agents instead."
```

The agent delegates the research to sub-agents and **stops to wait for them**. This job is a single turn: when it stops, the run ends. Nothing resumes, no notification arrives. It finished at ~12 of 80 turns having produced nothing.

## Two changes

**1. Both seed prompts say to do the research in-turn**, quoting those two messages so the instruction is concrete rather than abstract advice.

**2. Both "check for changes" steps fail instead of skipping.** A seed that writes nothing is a failure, not a no-op — populating the tracker is the entire job.

This matters most in `init-tracker`: by that point the init job has **already committed a live, active `tracker.json`**, so a silent skip publishes an empty tracker. Which is precisely what happened here, twice, with the run reporting success both times.

## Also: the empty tracker's `lastRun`

`init` stamped `lastRun: 2026-08-16T00:00:00Z` on a tracker it never populated. With the escalation ladder starting at 1 day, that would have made the nightly **skip it for up to three days**.

Blanked, so the next nightly picks it up and fills it.

Same class of dishonest bookkeeping as the hardcoded section list (#167) and the unstamped update-logs (#186): the record claimed work had happened when it hadn't. That pattern has now appeared four times in this pipeline, always as a `success` that produced nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)