### PR TITLE
fix(hourly): Fill missing map-point sub instead of discarding the tracker

### DIFF
--- a/.github/workflows/hourly-scan.yml
+++ b/.github/workflows/hourly-scan.yml
@@ -843,6 +843,31 @@ jobs:
                 }
               } catch { /* malformed JSON is caught by the validation below */ }
             }
+
+            // map-points: sub is a required subtitle the agent regularly omits.
+            // On 2026-08-17 a single missing sub failed the whole job with
+            // '0.sub : Required', so the indonesia-earthquake-2026 tracker was
+            // never committed — the same shape as the weaponType enum above.
+            // Falling back to the label loses no information: it is the string
+            // that would have been shown anyway.
+            const mpPath = dir + '/map-points.json';
+            if (existsSync(mpPath)) {
+              try {
+                const points = JSON.parse(readFileSync(mpPath, 'utf8'));
+                if (Array.isArray(points)) {
+                  let changed = 0;
+                  for (const p of points) {
+                    if (!p || typeof p !== 'object') continue;
+                    if (typeof p.sub !== 'string') {
+                      p.sub = typeof p.label === 'string' ? p.label : '';
+                      console.log('  map-points: filled missing sub for ' + (p.id ?? '(no id)'));
+                      changed++;
+                    }
+                  }
+                  if (changed > 0) writeFileSync(mpPath, JSON.stringify(points, null, 2));
+                }
+              } catch { /* malformed JSON is caught by the validation below */ }
+            }
             const schemaMap: Record<string, z.ZodTypeAny> = {
               'kpis.json': z.array(S.KpiSchema),
               'timeline.json': z.array(S.TimelineEraSchema),


### PR DESCRIPTION
## Summary

The 00:40 hourly run failed on **one field**:

```
✗ map-points.json
     0.sub : Required
```

`sub` is a required subtitle that the agent regularly omits. That single missing string failed the whole job, `Commit and push` was skipped, and the `indonesia-earthquake-2026` tracker it had just built was thrown away.

Worth noting what came *before* the failure in that same run:

```
✓ Create new tracker      ← the turn-budget fix in #202 worked
✓ Trigger seed job
✗ Validate modified JSON  ← then one field discarded all of it
```

## Fix

Filled from the point's `label`, which loses no information — `label` is the string that would have been displayed anyway. Points that already carry a `sub` are untouched; a point missing both gets an empty string rather than blocking the commit.

| Input | Result |
|---|---|
| `{label: "Jakarta epicentre"}`, no `sub` | `sub: "Jakarta epicentre"` |
| `{sub: "2,400 displaced"}` | untouched |
| neither field | `sub: ""` |

## The pattern, fifth time

Same treatment as the `weaponType` enum (#171) and `confidence` normalisation (#185): deterministic repair for a fixed format mistake, ahead of validation, instead of letting a one-field slip discard a whole run's work.

Each instance has been found the same way — a job reporting failure or success while the actual data quietly went missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)