### PR TITLE
fix(light-scan): Commit state again — the duplicate alerts trace back to this

### DIFF
--- a/.github/workflows/light-scan.yml
+++ b/.github/workflows/light-scan.yml
@@ -33,7 +33,17 @@ jobs:
         run: |
           git config user.name  "watchboard-bot"
           git config user.email "bot@watchboard.dev"
-          git add public/_hourly/pending-candidates.json public/_hourly/triage-log.json public/_hourly/state.json || true
+          # Add each file separately. `git add a b c` fails as a whole when any
+          # path is missing, and the `|| true` hid it: pending-candidates.json
+          # is written to scripts/state/ (and gitignored), not public/_hourly/,
+          # so the add aborted and state.json was never staged either. Nothing
+          # from this workflow has been committed since 2026-05-21 as a result —
+          # state.alerted never persisted, so the dedup added in #198 started
+          # every run with no memory and re-posted the same stories every
+          # 15 minutes.
+          for f in public/_hourly/triage-log.json public/_hourly/state.json; do
+            [ -f "$f" ] && git add "$f"
+          done
           if ! git diff --cached --quiet; then
             git commit -m "chore(light-scan): update pending + audit + state $(date -u +%Y-%m-%dT%H:%M:%SZ)"
             for i in 1 2 3; do


### PR DESCRIPTION
## The real cause of the duplicate alerts

The channel still repeats the same story every 15 minutes despite the topic dedup in #198. **The dedup was never the problem — its memory was never being saved.**

```
fatal: pathspec 'public/_hourly/pending-candidates.json' did not match any files
```

`git add` takes **all paths or none**. `pending-candidates.json` is written to `scripts/state/` — and is gitignored — not `public/_hourly/`. So the add aborted and took `triage-log.json` and `state.json` with it. The `|| true` swallowed the error and the step reported success.

**Nothing from this workflow has been committed since 2026-05-21.**

## Why that produced the duplicates

Every run started from three-month-old state:

- `state.alerted` never persisted → the dedup had **no memory** of what it had already posted
- `sentToday` counted **zero** every time → the daily cap of 6 never applied

Both limits I added in #198 were dead on arrival. They work; they were just handed an empty slate 96 times a day.

It also explains something that looked unrelated: the triage log stopping in May, which I had assumed was pruning.

## Fix

Each file added separately, so one missing path cannot silently discard the rest.

## Verified by reproduction

```
git add missing.json a.json b.json   →  0 files staged
for f in a.json b.json; do git add   →  2 files staged
```

## Note

This is the sixth instance of the same shape in this pipeline: a step reporting success while the work silently went nowhere. The others were metrics committing `[success]` with no data, the hardcoded section list (#167), unstamped update-logs (#186), the seed agent that wrote nothing (#204), and a one-field schema slip discarding a whole run (#209).

🤖 Generated with [Claude Code](https://claude.com/claude-code)