### PR TITLE
fix(nightly): Stop tweet drafting from failing a successful night

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -1132,6 +1132,13 @@ jobs:
       - name: Generate social queue via Claude
         id: social
         if: steps.social_prompt.outputs.has_prompt == 'true'
+        # Non-blocking. This runs after Commit and push data, so by the time it
+        # executes the night's work is already safely on main. Letting it fail
+        # the job marked two successful nights (2026-08-17, 2026-08-18) as
+        # failures, which alerted and opened issues for runs that had committed
+        # their data correctly. Drafting tweets is not worth a false alarm about
+        # the data pipeline.
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

The nightly failed on **2026-08-17** and **2026-08-18**. Both runs had already done their job:

```
✓ Validate Zod schemas
✓ Build gate
✓ Commit and push data     ← the night's work, safely on main
✓ Collect metrics
✗ Generate social queue via Claude
```

That step runs **after** the data commit, so its failure costs nothing. But without `continue-on-error` it failed the whole job — alerting, and opening issues (#210, #184), for two nights that had committed their data correctly.

## Why this matters beyond the noise

This is the **inverse** of the pattern that dominated this pipeline. Six times we found *success reported over work that silently vanished*. This is *failure reported over work that actually happened*.

Both mislead, and this direction is expensive in its own way: false alarms about the data pipeline train you to ignore the alerts that matter — right after we spent this session making those alerts work for the first time.

## Change

Marked non-blocking, alongside `Validate media URLs` and `Audit source URLs`, which already are.

Drafting tweets is not worth a false alarm about data integrity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)