### PR TITLE
ci: Actually run the test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+# The repo had 225 vitest tests across 18 files and nothing ran them. They
+# passed locally and were never executed on a PR, which makes them decoration:
+# a test that never runs cannot fail, so it cannot tell you anything.
+#
+# This matters most for the pipeline logic under tests/ (light-scan dedup,
+# triage, data freshness), where the recurring failure mode has been a step
+# reporting success while its work silently went nowhere.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  vitest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test


### PR DESCRIPTION
## The gap

```
$ grep -l "vitest\|npm test" .github/workflows/*.yml
(nothing)

$ npm test
Test Files  18 passed (18)
     Tests  225 passed (225)
```

225 tests across 18 files, and no workflow ran any of them. They passed locally and were never executed on a PR.

## Why it matters

A test that never runs cannot fail, so it cannot tell you anything. That is the same shape as the failures that dominated this pipeline — something reports fine while its work silently goes nowhere. We hit that six times: metrics committing `[success]` with no data, a hardcoded section list, unstamped update-logs, a seed agent writing nothing, a one-field schema slip discarding a run, and light-scan state that had not committed since May.

It matters most for `tests/` — light-scan dedup, triage, data freshness. That is the logic where a silent regression stays invisible until someone notices the public Telegram channel repeating itself, which is how the last two were found.

## Change

Runs `npm test` on every PR and on pushes to `main`. Node 22, npm cache, 10-minute timeout, `contents: read` only. The suite takes under a second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)