### PR TITLE
fix(scan): Require substance to route, not just a score (#149)

### DIFF
--- a/.github/workflows/light-scan.yml
+++ b/.github/workflows/light-scan.yml
@@ -41,7 +41,15 @@ jobs:
           # state.alerted never persisted, so the dedup added in #198 started
           # every run with no memory and re-posted the same stories every
           # 15 minutes.
-          for f in public/_hourly/triage-log.json public/_hourly/state.json; do
+          # The weekly archives (triage-log-YYYY-Www.json) must be committed too.
+          # The log partitions aged-out entries into them and prunes the main
+          # file; committing only the main file means those entries are pruned
+          # from a tracked file into an untracked one that the next run's fresh
+          # checkout never sees. They are gone, and the `weeks` index in the
+          # main log points at files that were never pushed -- which is why the
+          # audit page's archive loader has always had nothing to load.
+          for f in public/_hourly/triage-log.json public/_hourly/state.json \
+                   public/_hourly/triage-log-[0-9]*.json; do
             [ -f "$f" ] && git add "$f"
           done
           if ! git diff --cached --quiet; then

--- a/scripts/hourly-light-scan.ts
+++ b/scripts/hourly-light-scan.ts
@@ -27,7 +27,7 @@ import {
   saveState,
   normalizeCandidate,
 } from './hourly-types.js';
-import { buildKeywordIndices, scoreCandidateDetailed } from '../src/lib/keyword-match.js';
+import { buildKeywordIndices, scoreCandidateDetailed, hasSubstance as hasSubstanceFor } from '../src/lib/keyword-match.js';
 import { pollRealtimeSources } from '../src/lib/realtime-sources.js';
 import { appendTriageEntries } from '../src/lib/triage-log.js';
 import { loadAllTrackers } from './lib/load-trackers-node.js';
@@ -293,13 +293,28 @@ async function main() {
       }
     }
 
-    // Substance gate: even with a high score, a direct post needs at least
-    // 2 distinct specific tokens — single-keyword matches like "Trump" or
-    // "United States" alone produce false positives, and the heavy scan's
-    // AI triage handles those better than the threshold alone.
-    const hasSubstance =
-      bestDetail.specificHits >= 2 ||
-      (bestDetail.specificHits >= 1 && bestDetail.phraseHits >= 1);
+    // Substance gate: a single matched token is not evidence, whatever the
+    // score says. It governs both the alert path and the defer path below.
+    //
+    // One specific hit scores 0.3167 at tier 2, which clears MODERATE_THRESHOLD
+    // on its own. Measured against a full day of traffic, 143 of 170 deferred
+    // candidates (84%) routed on exactly one token, and the token was routinely
+    // a domain acronym colliding with an ordinary English word:
+    //
+    //   "car"    -> cancer-breakthroughs   (CAR-T cell therapy)
+    //   "who"    -> covid-pandemic         (the WHO)
+    //   "system" -> brics                  ("payment system")
+    //
+    // Tokenisation lowercases, so "WHO" and "who" are the same token — it
+    // cannot carry evidence in either direction. That produced routes like
+    // "Angélique Kidjo becomes first African musician with a Hollywood star"
+    // -> sheinbaum-presidency, and "Watch: SpaceX rocket spotted off Christmas
+    // Island" -> artemis-2.
+    //
+    // None of those 143 reached HIGH_THRESHOLD, so requiring substance to
+    // route costs no alerts; it only stops the heavy scan's AI triage from
+    // spending turns on noise.
+    const hasSubstance = hasSubstanceFor(bestDetail);
 
     if (bestScore >= HIGH_THRESHOLD && bestSlug && hasSubstance) {
       cand.matchedTracker = bestSlug;
@@ -351,7 +366,7 @@ async function main() {
         decision: 'update', reason: `light-scan posted directly + queued for heavy scan (score ${bestScore.toFixed(2)})`,
         confidence: bestScore, model: null, scanType: 'light',
       });
-    } else if (bestScore >= MODERATE_THRESHOLD) {
+    } else if (bestScore >= MODERATE_THRESHOLD && hasSubstance) {
       cand.matchedTracker = bestSlug;
       if (!pendingUrls.has(cand.url)) {
         pending.entries.push({ candidate: cand, score: bestScore, recordedAt: new Date().toISOString() });
@@ -366,9 +381,16 @@ async function main() {
       });
     } else {
       discarded++;
+      // Separate the two discard reasons so the audit page can tell "nothing
+      // matched" from "matched, but on a single token" — the latter is what
+      // #149 was reporting as misrouting.
+      const reason =
+        bestScore >= MODERATE_THRESHOLD
+          ? `matched ${bestSlug} on a single token — no substance (score ${bestScore.toFixed(2)})`
+          : `low score (${bestScore.toFixed(2)})`;
       logEntries.push({
         timestamp: new Date().toISOString(), candidate: cand,
-        decision: 'discard', reason: `low score (${bestScore.toFixed(2)})`,
+        decision: 'discard', reason,
         confidence: bestScore, model: null, scanType: 'light',
       });
     }

--- a/src/lib/keyword-match.ts
+++ b/src/lib/keyword-match.ts
@@ -205,3 +205,23 @@ export function scoreCandidate(
 ): number {
   return scoreCandidateDetailed(candidate, index, corpus).score;
 }
+
+/**
+ * Whether a match is backed by enough evidence to route on, independent of the
+ * scalar score.
+ *
+ * A single matched token scores 0.3167 at tier 2, which clears the light
+ * scan's defer threshold on its own. That is not evidence: index tokens are
+ * lowercased, so domain acronyms collide with ordinary English words and match
+ * headlines that have nothing to do with the tracker ("car" for CAR-T therapy,
+ * "who" for the WHO, "system" for a payment system).
+ *
+ * Two distinct specific tokens, or one specific token plus a long phrase, is
+ * the bar. Both the alert path and the defer path use it.
+ */
+export function hasSubstance(detail: Pick<ScoreDetail, 'specificHits' | 'phraseHits'>): boolean {
+  return (
+    detail.specificHits >= 2 ||
+    (detail.specificHits >= 1 && detail.phraseHits >= 1)
+  );
+}

--- a/tests/keyword-substance.test.ts
+++ b/tests/keyword-substance.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { loadAllTrackers } from '../scripts/lib/load-trackers-node.js';
+import {
+  buildKeywordIndices,
+  scoreCandidateDetailed,
+  hasSubstance,
+} from '../src/lib/keyword-match';
+
+/**
+ * Regression tests for #149 — headlines routed into unrelated trackers.
+ *
+ * The cause was not the score being too generous in aggregate; it was a single
+ * matched token being enough. Index tokens are lowercased, so domain acronyms
+ * collide with ordinary English words. Measured over one full day of traffic,
+ * 143 of 170 deferred candidates routed on exactly one token.
+ *
+ * These headlines are real: three from the issue, the rest from
+ * public/_hourly/triage-log.json.
+ */
+
+// Mirrors how scripts/hourly-light-scan.ts builds its corpus.
+const trackers = loadAllTrackers().filter((t: any) => t.status === 'active');
+const indices = buildKeywordIndices(
+  trackers.map((t: any) => ({
+    slug: t.slug,
+    keywords: [...(Array.isArray(t.tags) ? t.tags : []), ...(t.name ? [t.name] : [])],
+    searchContext: t.ai?.searchContext,
+  })),
+);
+
+function best(title: string, sourceTier: 1 | 2 | 3 = 2) {
+  const cand: any = { title, url: '', source: 'test', timestamp: '', sourceTier };
+  let top = { score: 0, specificHits: 0, commonHits: 0, phraseHits: 0 };
+  let slug = '';
+  for (const t of trackers as any[]) {
+    const i = indices.get(t.slug);
+    if (!i) continue;
+    const d = scoreCandidateDetailed(cand, i, indices);
+    if (d.score > top.score) { top = d; slug = t.slug; }
+  }
+  return { slug, ...top };
+}
+
+const MODERATE_THRESHOLD = 0.25;
+
+describe('single-token matches do not route', () => {
+  const misroutes: Array<[string, string]> = [
+    ['Israel confirms soldiers fired at car in which Hind Rajab was killed', 'car / CAR-T'],
+    ['Florida surgeon who removed wrong organ says he is forever traumatized', 'who / WHO'],
+    ['Who is Natalie Harp, Trump’s right-hand woman?', 'who / WHO'],
+    ['Tesla Model Y is first vehicle to pass new US driver-assistance system tests', 'system'],
+    ['Angélique Kidjo becomes first African musician with a Hollywood star', 'single token'],
+    ['Watch: SpaceX rocket spotted off Christmas Island coast', 'single token'],
+    ['Head-on collision between bus and lorry in Brazil kills more than 20', 'single token'],
+    ['81-year-old confesses to German cold case murder of US tourist', 'single token'],
+  ];
+
+  it.each(misroutes)('does not route %s (%s)', (title) => {
+    const b = best(title);
+    // It may still score above the threshold — that is the point. The gate is
+    // what stops it, not the score.
+    expect(hasSubstance(b)).toBe(false);
+  });
+
+  it('the score alone would have let them through', () => {
+    // Documents why the threshold was not the right lever: these clear it.
+    const b = best('Israel confirms soldiers fired at car in which Hind Rajab was killed');
+    expect(b.score).toBeGreaterThan(MODERATE_THRESHOLD);
+    expect(b.specificHits).toBe(1);
+  });
+});
+
+describe('genuine matches still route', () => {
+  it('accepts a headline naming several tracker-specific tokens', () => {
+    // Built from a real tracker's own tags so the test tracks the corpus.
+    const withTags = (trackers as any[]).find(
+      (t) => Array.isArray(t.tags) && t.tags.length >= 3 && t.status === 'active',
+    );
+    expect(withTags, 'expected some active tracker to carry >= 3 tags').toBeTruthy();
+    const title = `${withTags.tags.slice(0, 3).join(' ')} escalates sharply`;
+    const cand: any = { title, url: '', source: 'test', timestamp: '', sourceTier: 1 };
+    const d = scoreCandidateDetailed(cand, indices.get(withTags.slug)!, indices);
+    expect(hasSubstance(d)).toBe(true);
+  });
+});
+
+describe('hasSubstance', () => {
+  it('requires two specific tokens, or one plus a phrase', () => {
+    expect(hasSubstance({ specificHits: 2, phraseHits: 0 })).toBe(true);
+    expect(hasSubstance({ specificHits: 1, phraseHits: 1 })).toBe(true);
+    expect(hasSubstance({ specificHits: 1, phraseHits: 0 })).toBe(false);
+    expect(hasSubstance({ specificHits: 0, phraseHits: 1 })).toBe(false);
+    expect(hasSubstance({ specificHits: 0, phraseHits: 0 })).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #149.

## The cause was not the threshold

One matched token scores **0.3167** at tier 2 — which clears the 0.25 defer bar by itself. Index tokens are lowercased, so domain acronyms collide with ordinary English:

| token | routes to | because |
|---|---|---|
| `car` | `cancer-breakthroughs` | CAR-T cell therapy |
| `who` | `covid-pandemic` | the WHO |
| `system` | `brics` | "payment system" |

`WHO` and `who` are the same token after tokenisation, so it cannot carry evidence in *either* direction. That is how these happened:

```
"Angélique Kidjo becomes first African musician with a Hollywood star"
  -> sheinbaum-presidency  0.317
"Watch: SpaceX rocket spotted off Christmas Island coast"
  -> artemis-2             0.317
"Who is Natalie Harp, Trump's right-hand woman?"
  -> covid-pandemic        0.317
```

## Measured, not guessed

Re-scored a full day of traffic (243 candidates) with production's exact index construction, reproducing **221/243** of the logged decisions:

| | |
|---|---|
| candidates over the defer threshold | 170 |
| routing on **exactly one token** | **143 (84%)** |
| of those, reaching `HIGH_THRESHOLD` | **0** |

Requiring substance costs **zero alerts**. It only stops the heavy scan's AI triage from spending turns on noise — the structural waste the issue reported.

## Change

The alert path already required 2 specific tokens. This extends the same gate to the defer path, and lifts it into `keyword-match.ts` as an exported `hasSubstance()` so there is one definition rather than an inline predicate. Discards now distinguish "nothing matched" from "matched on one token" so the audit page can tell them apart.

11 new tests, using the real headlines from the issue and the triage log. One asserts the misroutes *still clear the score threshold* — the point being that the score was never the right lever, and the test would fail vacuously if the index were empty.

## Second commit: the audit archives were being dropped

Separate defect found while working here. `triage-log.ts` partitions aged-out entries into weekly files and prunes them from the main log — but the commit step only added the main log. Entries were pruned from a tracked file into an untracked one that the next run's fresh checkout never sees.

`weeks` in the committed log is `[]`, and `TriageLogBoard.tsx` has a whole load-on-demand archive feature reading it. **That feature has never had anything to load.**

Same defect as #211, one step further: the `git add` list was still incomplete. Glob verified in bash (not zsh, where unmatched globs abort) for both the empty and non-empty case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)