### PR TITLE
docs: Add the LICENSE the README has been promising (#156)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Artemio Padilla
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,69 @@
+# Third-Party Notices
+
+Watchboard is an independent project. It is not derived from, and does not
+incorporate code from, any other OSINT dashboard. The 3D globe is built on
+CesiumJS and the 2D map on Leaflet — both widely used libraries — and any
+resemblance to other dashboards using the same libraries follows from that
+shared foundation rather than from shared code.
+
+The project itself is MIT licensed (see `LICENSE`). This file records the
+third-party components it depends on and their terms.
+
+## Runtime dependencies
+
+License fields read from the installed packages, not from memory.
+
+| Package | License |
+| --- | --- |
+| `astro`, `@astrojs/react`, `@astrojs/rss`, `@astrojs/sitemap` | MIT |
+| `react`, `react-dom`, `@types/react`, `@types/react-dom` | MIT |
+| `cesium` | Apache-2.0 |
+| `resium` | MIT |
+| `globe.gl` | MIT |
+| `leaflet` | BSD-2-Clause |
+| `react-leaflet` | **Hippocratic-2.1** |
+| `satellite.js` | MIT |
+| `zod` | MIT |
+| `sharp` | Apache-2.0 |
+| `satori` | MPL-2.0 |
+| `@resvg/resvg-js` | MPL-2.0 |
+
+Two notes for anyone reusing this project:
+
+- **`react-leaflet` is Hippocratic-2.1**, an ethical-source licence that is not
+  OSI-approved and places conditions on use. It is more restrictive than the
+  MIT terms covering Watchboard's own code, and those conditions travel with
+  the dependency.
+- **`satori` and `@resvg/resvg-js` are MPL-2.0**, a file-level copyleft. They
+  are used only at build time to render social stat cards; no MPL code is
+  redistributed in the published site.
+
+## Fonts
+
+Bundled under `public/fonts/` and served from `/fonts/`:
+
+- JetBrains Mono
+- DM Sans
+- Cormorant Garamond
+
+All three are published under the SIL Open Font License 1.1. **The OFL requires
+that the licence text accompany the font files, and it is not currently
+bundled.** Copies of `OFL.txt` should be added alongside them. Flagged rather
+than silently fixed, because the correct text must come from each font's own
+upstream release rather than be reconstructed.
+
+## Map and imagery services
+
+- **Basemap tiles** — OpenStreetMap data under ODbL, served via CARTO. Attributed
+  in the map UI (`src/components/islands/LeafletMap.tsx`).
+- **Cesium World Terrain / Ion assets** — used under Cesium Ion's terms; Cesium's
+  own attribution widget is retained.
+- **Event media** — thumbnails and article links are fetched from the publishers'
+  own `og:image` metadata and attributed to the source outlet at every display
+  surface. No media is rehosted.
+
+## Data
+
+Tracker data is compiled from public reporting, with a source tier and citation
+recorded per data point. Tier 1-2 sources (governments, UN bodies, Reuters, AP,
+BBC) are linked rather than reproduced.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "watchboard",
   "type": "module",
   "version": "1.0.0",
+  "license": "MIT",
   "scripts": {
     "copy-cesium": "node -e \"const{cpSync,existsSync}=require('fs');const s='node_modules/cesium/Build/Cesium/';['Workers','ThirdParty','Assets','Widgets'].forEach(d=>{if(!existsSync('public/cesium/'+d))cpSync(s+d,'public/cesium/'+d,{recursive:true})})\"",
     "dev": "npm run copy-cesium && astro dev",


### PR DESCRIPTION
Addresses #156 (provenance/licensing check).

## What the audit found

`README.md` line 11 carries a **"License: MIT"** badge linking to `LICENSE`, and line 401 says *"MIT — use freely"*.

There is no `LICENSE` file. The badge 404s, and `package.json` declared no `license` field.

A public repo with no license file defaults to **all rights reserved**. The README states the intent clearly enough to be arguable — but nobody should have to argue about it. This adds the MIT text and the `package.json` field to match what has been advertised all along.

## Provenance

`THIRD-PARTY-NOTICES.md` answers the issue's question directly: Watchboard is independent, not derived from any other OSINT dashboard. The globe is CesiumJS and the map is Leaflet; resemblance to other dashboards on those same libraries follows from the shared foundation, not shared code.

Licences were read from the **installed packages**, not from memory. Two findings worth knowing:

- **`react-leaflet` is Hippocratic-2.1** — an ethical-source licence, not OSI-approved, that places conditions on use. It is more restrictive than the MIT terms covering this project's own code, and those conditions travel with the dependency. Anyone reusing Watchboard should know this before assuming the whole stack is permissive.
- **`satori` and `@resvg/resvg-js` are MPL-2.0** (file-level copyleft), used only at build time for social stat cards. No MPL code reaches the published site.

## One thing flagged, not fixed

The bundled fonts (JetBrains Mono, DM Sans, Cormorant Garamond) are SIL OFL 1.1, and **the OFL requires its licence text to accompany the font files** — it is not bundled. I did not write the `OFL.txt` files myself: the correct text has to come from each font's own upstream release rather than be reconstructed from memory, where a subtly wrong copyright line would be worse than a missing file.

## Note on the copyright line

`Copyright (c) 2026 Artemio Padilla`, taken from the repo's git identity. Worth a glance in case you want a different holder or year range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)