### PR TITLE
security(csp): Enforce the policy — Report-Only was a no-op (#138)

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,9 +1,19 @@
+# NOTE: this file is Netlify/Cloudflare Pages syntax. GitHub Pages does not
+# read it, and serves none of these headers -- verified with `curl -I` against
+# watchboard.dev, which returns no CSP header at all. The live policy comes
+# from the <meta> tag in src/layouts/BaseLayout.astro.
+#
+# Kept in sync anyway so that putting a CDN in front of Pages is a config
+# change rather than a security regression. Two things only work here and not
+# in a meta tag: frame-ancestors (clickjacking) and Content-Security-Policy-
+# Report-Only, which the spec does not permit in a meta element at all.
+
 /*
   X-Content-Type-Options: nosniff
   X-Frame-Options: SAMEORIGIN
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), microphone=(), camera=()
-  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline' https://*.posthog.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://*.posthog.com https://app.posthog.com https://us.i.posthog.com https://api.open-meteo.com https://earthquake.usgs.gov https://opensky-network.org https://*.wikipedia.org https://*.wikimedia.org https://api.memegen.link https://assets.ion.cesium.com https://tiles.ion.cesium.com https://cesium.com https://static.cloudflareinsights.com; frame-src https://www.youtube.com https://youtube.com; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'self' blob:
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://*.posthog.com https://static.cloudflareinsights.com 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://*.posthog.com https://app.posthog.com https://us.i.posthog.com https://api.open-meteo.com https://archive-api.open-meteo.com https://earthquake.usgs.gov https://opensky-network.org https://celestrak.org https://*.celestrak.org https://api.github.com https://*.basemaps.cartocdn.com https://tile.openstreetmap.org https://t.me wss://stream.aisstream.io https://*.wikipedia.org https://*.wikimedia.org https://api.memegen.link https://*.cesium.com https://cesium.com https://static.cloudflareinsights.com https://cloudflareinsights.com https://assets.ion.cesium.com https://tiles.ion.cesium.com; frame-src https://www.youtube.com https://youtube.com; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'self' blob:
 
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -57,39 +57,42 @@ const pushTrackers = loadAllTrackers()
   <meta name="theme-color" content="#0d1117">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta name="referrer" content="strict-origin-when-cross-origin">
-  {/* Report-Only — reverted from enforcement, which broke the globe.
+  {/* Enforced. Previously Report-Only, which turned out to mean "no policy".
 
-      The connect-src list below is correct and was worth fixing: it had
-      drifted behind what the islands call (celestrak, archive-api.open-meteo,
-      stream.aisstream, basemaps.cartocdn, api.github, tile.openstreetmap, t.me)
-      and *.cesium.com was missing entirely.
+      Report-Only is not permitted in a <meta> element — the spec allows it
+      only as an HTTP header, and Chrome says so out loud:
 
-      But connect-src was never the blocker. Loading the live pages in a real
-      browser — which is what static analysis could not substitute for — showed
-      script-src is what actually breaks Cesium:
+        "The report-only Content Security Policy ... was delivered via a
+         <meta> element, which is disallowed. The policy has been ignored."
 
-        EvalError: Evaluating a string as JavaScript violates CSP
-          → CesiumGlobe.js fails to hydrate; the globe does not render
-        WebAssembly.instantiate() violates CSP
-          → Cesium's WASM module is blocked
+      And GitHub Pages serves no CSP header at all (public/_headers is Netlify
+      /Cloudflare syntax and is inert here — confirmed with curl). So the site
+      had no effective CSP whatsoever: not enforcement, not report-only. The
+      soak period this was waiting on was never collecting anything.
 
-      Cesium needs 'unsafe-eval' and 'wasm-unsafe-eval'. Granting both to get
-      the globe back would leave script-src as 'self' 'unsafe-inline'
-      'unsafe-eval' — at which point enforcement buys almost nothing against
-      XSS, which is the threat a CSP exists for.
+      Cesium needs 'unsafe-eval' and 'wasm-unsafe-eval' — that is what broke
+      the globe when this was first flipped, and both are granted here.
+      Verified with Playwright against the live pages, not by static analysis:
+      home and /globe/ load with zero CSP refusals and the Cesium canvas
+      renders.
 
-      Two other findings from the same run, worth keeping:
-        - connect-src misses cloudflareinsights.com (the beacon posts to
-          /cdn-cgi/rum on the apex, not the static. subdomain that is listed)
-        - frame-ancestors is IGNORED in a <meta> CSP; it only works as an HTTP
-          header. It was never providing the clickjacking protection claimed
-          for it, and GitHub Pages cannot set headers.
+      What this does and does not buy, so nobody reads more into it:
+        blocks  external <script src> from non-allowlisted hosts
+        blocks  fetch/XHR/WebSocket exfiltration (connect-src allowlist)
+        blocks  form-action, base-uri, object-src vectors
+        does not stop injected inline scripts — 'unsafe-inline' is still here
+        does not stop image-based exfiltration — img-src must allow https:
+                because event media comes from arbitrary publishers' og:image
 
-      So enforcement here is worth less than it appears and costs a working
-      globe. Doing it properly means moving the policy to an HTTP header
-      (a CDN in front of Pages) and isolating Cesium, not flipping this
-      attribute. Left Report-Only deliberately, not by oversight. */}
-  <meta http-equiv="Content-Security-Policy-Report-Only" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://*.posthog.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://*.posthog.com https://app.posthog.com https://us.i.posthog.com https://api.open-meteo.com https://archive-api.open-meteo.com https://earthquake.usgs.gov https://opensky-network.org https://celestrak.org https://*.celestrak.org https://api.github.com https://*.basemaps.cartocdn.com https://tile.openstreetmap.org https://t.me wss://stream.aisstream.io https://*.wikipedia.org https://*.wikimedia.org https://api.memegen.link https://*.cesium.com https://cesium.com https://static.cloudflareinsights.com https://cloudflareinsights.com; frame-src https://www.youtube.com https://youtube.com; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'self' blob:">
+      The change that would actually harden this is removing 'unsafe-inline'
+      via nonces. That is separate, larger work.
+
+      frame-ancestors is deliberately NOT in this string: it is ignored in a
+      meta element and browsers log a warning about it on every page load. It
+      lives in public/_headers instead, ready for a CDN in front of Pages.
+      X-Frame-Options (set there too) is the clickjacking control that
+      actually applies today. */}
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://*.posthog.com https://static.cloudflareinsights.com 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://*.posthog.com https://app.posthog.com https://us.i.posthog.com https://api.open-meteo.com https://archive-api.open-meteo.com https://earthquake.usgs.gov https://opensky-network.org https://celestrak.org https://*.celestrak.org https://api.github.com https://*.basemaps.cartocdn.com https://tile.openstreetmap.org https://t.me wss://stream.aisstream.io https://*.wikipedia.org https://*.wikimedia.org https://api.memegen.link https://*.cesium.com https://cesium.com https://static.cloudflareinsights.com https://cloudflareinsights.com; frame-src https://www.youtube.com https://youtube.com; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; worker-src 'self' blob:">
   <meta http-equiv="Permissions-Policy" content="geolocation=(), microphone=(), camera=()">
   <link rel="preload" href={`${basePath}fonts/jetbrains-mono-latin.woff2`} as="font" type="font/woff2" crossorigin>
   <link rel="preload" href={`${basePath}fonts/dm-sans-latin.woff2`} as="font" type="font/woff2" crossorigin>


### PR DESCRIPTION
Closes #138.

## The finding that reframes this issue

**The site has had no effective CSP at all** — not enforcement, not report-only.

`Content-Security-Policy-Report-Only` is **not permitted in a `<meta>` element**. The spec allows it only as an HTTP header, and Chrome says so out loud:

> The report-only Content Security Policy ... was delivered via a `<meta>` element, which is disallowed. The policy has been ignored.

And GitHub Pages serves **no CSP header** — `public/_headers` is Netlify/Cloudflare syntax and is inert here:

```
$ curl -sI https://watchboard.dev/iran-conflict/globe/ | grep -i content-security
(nothing)
```

So the ~week-long soak this issue was waiting on was never collecting anything, and the revert in #199 did not leave the site in a safe middle ground — it left it with nothing.

## Verification, the part #196 got wrong

#196 flipped enforcement on static analysis alone and broke the globe. This time the policy was tested in a real browser first — Playwright against the **live production pages**, with the candidate policy swapped in via response interception:

| page | CSP refusals | Cesium canvas |
| --- | --- | --- |
| `/` | **0** | rendered |
| `/iran-conflict/globe/` | **0** | rendered |

`'unsafe-eval'` and `'wasm-unsafe-eval'` are granted, which is what Cesium needs and what broke it last time.

## What enforcement buys, stated plainly

| | |
| --- | --- |
| ✅ blocks | external `<script src>` from non-allowlisted hosts |
| ✅ blocks | fetch/XHR/WebSocket exfiltration (`connect-src` allowlist) |
| ✅ blocks | `form-action`, `base-uri`, `object-src` vectors |
| ❌ does not | stop injected inline scripts — `'unsafe-inline'` remains |
| ❌ does not | stop image-based exfiltration — `img-src` must allow `https:` because event media comes from arbitrary publishers' og:image hosts |

Going from *no policy* to *this policy* is a real improvement, but it is not the XSS hardening the issue's title implies. **Removing `'unsafe-inline'` via nonces is the change that would actually matter**, and it is separate, larger work. I would rather name that than let this flip imply the site is now XSS-proof.

## Also in this PR

- **`public/_headers` had drifted 10 origins behind the meta tag** (celestrak, archive-api.open-meteo, cartocdn, tile.openstreetmap, api.github, t.me, aisstream, cloudflareinsights, `*.cesium.com`). Enforcing while they disagreed would have enforced the stale, stricter policy wherever the header won. Now synced, with a comment recording that it is inert on Pages and kept ready for a CDN.
- **`frame-ancestors` dropped from the meta.** It is ignored there and browsers log a warning about it on every page load. It stays in `_headers`; `X-Frame-Options` is the clickjacking control that actually applies today.

## Acceptance criteria

- [x] Patch the allowlist for legitimate origins (done across this session; `_headers` synced here)
- [x] Flip `http-equiv` to `Content-Security-Policy`
- [x] Mirror in `public/_headers`
- [x] Remove the `TODO(security):` comment
- [ ] ~Soak a week of report-only traffic~ — **not possible**: report-only via meta is ignored, so no data was ever collected. Replaced with direct runtime verification above.
- [ ] `report-uri`/`report-to` — still not added; there is no collection endpoint. Worth a follow-up if you want production violation data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
