### PR TITLE
ops(canary): Watch PostHog and Cesium Ion — both are broken right now

### DIFF
--- a/.github/workflows/credential-canary.yml
+++ b/.github/workflows/credential-canary.yml
@@ -96,7 +96,59 @@ jobs:
           claude_args: "--max-turns 3 --dangerously-skip-permissions"
           prompt: 'Reply with exactly: ok'
 
-      # ── Report ────────────────────────────────────────────────────────────
+      # ── PostHog ───────────────────────────────────────────────────────────
+      # Added after finding analytics had never worked: the key rendered into
+      # every page was 49 chars instead of 47, with a trailing "." that made
+      # PostHog return 400 on every load. Nothing failed loudly — the build was
+      # green, the script tag rendered, and the request 400'd in the browser
+      # where no workflow was looking.
+      - name: Check PostHog
+        id: posthog
+        continue-on-error: true
+        env:
+          POSTHOG_KEY: ${{ secrets.PUBLIC_POSTHOG_KEY }}
+        run: |
+          if [ -z "$POSTHOG_KEY" ]; then
+            echo "PUBLIC_POSTHOG_KEY not set"; exit 1
+          fi
+          # Shape check first: catches stray whitespace or punctuation from a
+          # copy-paste, which is the failure that actually happened.
+          case "$POSTHOG_KEY" in
+            phc_*) ;;
+            *) echo "::error::key does not start with phc_"; exit 1 ;;
+          esac
+          if [ "${#POSTHOG_KEY}" -ne 47 ]; then
+            echo "::error::key is ${#POSTHOG_KEY} chars, expected 47 — check for a trailing character"
+            exit 1
+          fi
+          CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 \
+            "https://us-assets.i.posthog.com/array/${POSTHOG_KEY}/config.js")
+          echo "PostHog config.js -> $CODE"
+          [ "$CODE" = "200" ]
+
+      # ── Cesium Ion ────────────────────────────────────────────────────────
+      # The globe requests Ion assets 1 and 2 (imagery + terrain). A rejected
+      # token 401s in the browser and the globe silently falls back, so this is
+      # invisible from the server side.
+      - name: Check Cesium Ion
+        id: cesium
+        continue-on-error: true
+        env:
+          ION_TOKEN: ${{ secrets.PUBLIC_CESIUM_ION_TOKEN }}
+        run: |
+          if [ -z "$ION_TOKEN" ]; then
+            echo "PUBLIC_CESIUM_ION_TOKEN not set"; exit 1
+          fi
+          FAILED=0
+          for ASSET in 1 2; do
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 \
+              "https://api.cesium.com/v1/assets/${ASSET}/endpoint?access_token=${ION_TOKEN}")
+            echo "Ion asset ${ASSET} -> $CODE"
+            [ "$CODE" = "200" ] || FAILED=1
+          done
+          [ "$FAILED" -eq 0 ]
+
+      # ── Report ───────────────────────────────────────────────────────────
       - name: Report
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
@@ -109,11 +161,15 @@ jobs:
           TELEGRAM_RESULT: ${{ steps.telegram.outcome }}
           BLUESKY_RESULT: ${{ steps.bluesky.outcome }}
           CLAUDE_RESULT: ${{ steps.claude.outcome }}
+          POSTHOG_RESULT: ${{ steps.posthog.outcome }}
+          CESIUM_RESULT: ${{ steps.cesium.outcome }}
         run: |
           FAILED=""
           [ "$TELEGRAM_RESULT" != "success" ] && FAILED="${FAILED}Telegram "
           [ "$BLUESKY_RESULT"  != "success" ] && FAILED="${FAILED}Bluesky "
           [ "$CLAUDE_RESULT"   != "success" ] && FAILED="${FAILED}Claude-OAuth "
+          [ "$POSTHOG_RESULT"  != "success" ] && FAILED="${FAILED}PostHog "
+          [ "$CESIUM_RESULT"   != "success" ] && FAILED="${FAILED}Cesium-Ion "
 
           {
             echo "## Credential Canary"
@@ -123,6 +179,8 @@ jobs:
             echo "| Telegram | $TELEGRAM_RESULT |"
             echo "| Bluesky | $BLUESKY_RESULT |"
             echo "| Claude Code OAuth | $CLAUDE_RESULT |"
+            echo "| PostHog | $POSTHOG_RESULT |"
+            echo "| Cesium Ion | $CESIUM_RESULT |"
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [ -z "$FAILED" ]; then


### PR DESCRIPTION
Found while verifying #218 in a real browser. **Two credentials fail on every page load, and nothing was watching either.**

```
400  https://us-assets.i.posthog.com/array/phc_...Hwuw./config.js
401  https://api.cesium.com/v1/assets/1/endpoint?access_token=...
401  https://api.cesium.com/v1/assets/2/endpoint?access_token=...
```

## PostHog: the key has a trailing period

This is what is rendered into every page:

```js
posthogKey = "phc_CtJ5gPA3KykaauRYyqjkjq3ELJrBeJWxeKFoZkFNHwuw.";
```

**49 characters. PostHog keys are 47.** The `PUBLIC_POSTHOG_KEY` secret has a trailing `.` — almost certainly a copy-paste that grabbed the end of a sentence.

**Analytics has never worked.** #147 moved the key out of the workflow and into a secret correctly; the secret's *value* is what is wrong. Worth noting because I closed #147 earlier today as resolved — the move was right, the value was not, and nothing in between would have told us.

## Cesium Ion: token rejected

Assets 1 and 2 (imagery and terrain) both 401. The globe still paints because it falls back, which is why this was invisible.

## Why this kept surviving

Same shape as everything else in this pipeline: the build is green, the script tag renders, and the request 400s **in a browser, where no workflow was looking**. Server-side checks structurally cannot see it.

## Change

Both added to the daily canary. PostHog gets a **shape check before the network call** — starts with `phc_`, exactly 47 chars — because that is the failure that actually happened, and a length check catches it without depending on PostHog being reachable. Verified against the real broken value:

```
longitud actual: 49 (esperada 47)  -> el canary la habría marcado como rota
```

## What this does not do

Neither can be fixed from here — both are secrets only you can set. Two things to do when convenient:

1. Re-paste `PUBLIC_POSTHOG_KEY` without the trailing period.
2. Check whether `PUBLIC_CESIUM_ION_TOKEN` is expired or lacks access to assets 1/2 in the Cesium Ion console.

Until then the canary will report both as failing daily — which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
