### PR TITLE
fix(canary): Drop the PostHog length check — 47 was a guess, and wrong

### DIFF
--- a/.github/workflows/credential-canary.yml
+++ b/.github/workflows/credential-canary.yml
@@ -112,15 +112,24 @@ jobs:
             echo "PUBLIC_POSTHOG_KEY not set"; exit 1
           fi
           # Shape check first: catches stray whitespace or punctuation from a
-          # copy-paste, which is the failure that actually happened.
+          # copy-paste, which is the failure that actually happened (a trailing
+          # "." made the key 49 chars and PostHog returned 400).
+          #
+          # Deliberately NOT a length check. The first version of this asserted
+          # 47 characters, which was a guess — real keys are 48 — so it would
+          # have rejected the correct key and reported a false failure. The
+          # character class is what actually distinguishes a clean key from a
+          # copy-paste with punctuation attached, and it does not go stale if
+          # PostHog changes key lengths.
           case "$POSTHOG_KEY" in
             phc_*) ;;
             *) echo "::error::key does not start with phc_"; exit 1 ;;
           esac
-          if [ "${#POSTHOG_KEY}" -ne 47 ]; then
-            echo "::error::key is ${#POSTHOG_KEY} chars, expected 47 — check for a trailing character"
-            exit 1
-          fi
+          case "$POSTHOG_KEY" in
+            *[!A-Za-z0-9_]*)
+              echo "::error::key contains a character outside [A-Za-z0-9_] — likely trailing punctuation or whitespace from a paste"
+              exit 1 ;;
+          esac
           CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 \
             "https://us-assets.i.posthog.com/array/${POSTHOG_KEY}/config.js")
           echo "PostHog config.js -> $CODE"


### PR DESCRIPTION
Fixes a bug I introduced in #219.

The PostHog check asserted the key was exactly **47 characters**. That number was a guess. Real PostHog project keys are **48**.

So once the correct key is set, the canary would have rejected it and reported a healthy credential as broken — a false alarm on the very thing the canary exists to measure, which is the failure mode it was built to prevent.

## The length was never the signal

The actual bug was a trailing `.` from a paste. What distinguishes a clean key from one with punctuation attached is the **character class**, not the count:

```
phc_...Hwuw     accepted   (48 chars)
phc_...Hwuw.    rejected   invalid character
"phc_abc "      rejected   invalid character
```

Verified end to end against PostHog:

```
config.js with the clean key       -> 200
config.js with the trailing dot    -> 400
```

Checks `[A-Za-z0-9_]` instead. It catches the real failure mode, and it does not go stale if PostHog changes key lengths. The HTTP 200 remains the actual test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
