### PR TITLE
fix(globe): Stop requesting Ion assets when no Ion token is configured

### DIFF
--- a/src/components/islands/CesiumGlobe/CesiumGlobe.tsx
+++ b/src/components/islands/CesiumGlobe/CesiumGlobe.tsx
@@ -6,7 +6,6 @@ import {
   JulianDate,
   Math as CesiumMath,
   Color,
-  Ion,
   Rectangle,
   SceneMode,
   createWorldTerrainAsync,
@@ -17,7 +16,7 @@ import type { CesiumComponentRef } from 'resium';
 import type { MapPoint, MapLine, KpiItem, Meta } from '../../../lib/schemas';
 import type { FlatEvent } from '../../../lib/timeline-utils';
 import { MAP_CATEGORIES } from '../../../lib/map-utils';
-import { configureCesium } from '../../../lib/cesium-config';
+import { configureCesium, hasIonToken } from '../../../lib/cesium-config';
 import { createCRTStage, createNVGStage, createThermalStage, createBloomStage, createSharpenStage, createPanopticStage, type VisualMode } from './cesium-shaders';
 import { useCesiumCamera } from './useCesiumCamera';
 import type { OrbitMode } from './useCesiumCamera';
@@ -403,8 +402,14 @@ function CesiumGlobeInner({ points, lines, kpis, meta, events = [], cameraPreset
     viewer.scene.backgroundColor = Color.fromCssColorString('#0a0b0e');
     viewer.scene.globe.baseColor = Color.fromCssColorString('#0d0f14');
 
-    // Terrain (free with Cesium Ion token)
-    if (Ion.defaultAccessToken) {
+    // Terrain (free with Cesium Ion token).
+    //
+    // The guard used to read Cesium's Ion.defaultAccessToken, which is ALWAYS
+    // truthy: Cesium ships a demo token and assigns it at import time. So this
+    // branch always ran, requested Ion asset 1 with a token that has no access,
+    // and got a 401 on every globe load. hasIonToken reflects whether we
+    // actually configured one.
+    if (hasIonToken) {
       createWorldTerrainAsync().then(terrain => {
         if (!viewer.isDestroyed()) {
           viewer.terrainProvider = terrain;
@@ -600,6 +605,12 @@ function CesiumGlobeInner({ points, lines, kpis, meta, events = [], cameraPreset
             if (v && v !== cesiumViewer) handleViewerReady(v);
           }}
           full
+          // With no Ion token, Cesium's default base layer is an Ion asset that
+          // 401s on every load and never renders. Skipping it changes nothing
+          // visually — the globe already falls back to scene.globe.baseColor —
+          // and drops two failed requests per globe load. If a token is set,
+          // this passes undefined and Cesium uses its default Ion imagery.
+          baseLayer={hasIonToken ? undefined : false}
           sceneMode={SceneMode.SCENE3D}
           animation={false}
           baseLayerPicker={false}

--- a/src/lib/cesium-config.ts
+++ b/src/lib/cesium-config.ts
@@ -2,6 +2,26 @@ import { Ion } from 'cesium';
 
 const ION_TOKEN = import.meta.env.PUBLIC_CESIUM_ION_TOKEN ?? '';
 
+/**
+ * Whether a Cesium Ion token is configured.
+ *
+ * Without one, Cesium's Viewer still requests its default Ion assets — asset 2
+ * for imagery, asset 1 for terrain — using the bundled demo token, and both
+ * come back 401 on every globe load:
+ *
+ *   401 https://api.cesium.com/v1/assets/1/endpoint?access_token=...
+ *   401 https://api.cesium.com/v1/assets/2/endpoint?access_token=...
+ *
+ * Nothing broke visibly, which is why it went unnoticed: the imagery simply
+ * never arrives and the globe shows scene.globe.baseColor (#0d0f14), which is
+ * the dark look this dashboard wants anyway. So the requests were pure waste —
+ * two failed round trips per load for imagery that was never going to render.
+ *
+ * Callers use this to skip the Ion base layer entirely when there is no token,
+ * rather than requesting it and letting it fail.
+ */
+export const hasIonToken = ION_TOKEN.length > 0;
+
 export function configureCesium() {
   if (ION_TOKEN) {
     Ion.defaultAccessToken = ION_TOKEN;


### PR DESCRIPTION
Closes the Cesium half of #220.

Every globe load fired two authenticated requests that could not succeed:

```
401  https://api.cesium.com/v1/assets/1/endpoint?access_token=...   (terrain)
401  https://api.cesium.com/v1/assets/2/endpoint?access_token=...   (imagery)
```

`PUBLIC_CESIUM_ION_TOKEN` is not set. **Requesting authenticated assets with no token is wrong regardless of whether one ever gets set**, so this is a fix, not a configuration preference — it does not decide anything about whether you want Ion.

## Two separate causes

**1. The Viewer had no `baseLayer`**, so Cesium requested its default Ion imagery (asset 2). Nothing rendered from it — the globe falls back to `scene.globe.baseColor` (`#0d0f14`), which is the dark look this dashboard wants anyway. The request was pure waste.

**2. The terrain guard never worked.** It read:

```js
if (Ion.defaultAccessToken) {
  createWorldTerrainAsync()...
}
```

`Ion.defaultAccessToken` is **always truthy** — Cesium ships a demo token and assigns it at import time. The guard looked like a check and never once prevented anything. Asset 1 was requested on every load and 401'd.

That is the same shape as the rest of this session: something that reads as correct, reports nothing wrong, and does no work.

## Change

Adds `hasIonToken` to `cesium-config.ts`, reflecting whether *we* configured a token, and uses it for both paths. **If you set a token later, both light up again** — `baseLayer` passes `undefined` and Cesium uses its Ion default.

## Verified in a browser

| | before | after |
| --- | --- | --- |
| requests to `api.cesium.com` | 2 (both 401) | **0** |
| canvas | 1280x720 | 1280x720 |
| page errors | none | none |

The globe looks identical, because the Ion imagery was never arriving in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
