### PR TITLE
fix(canary): An unset Ion token is a decision, not a fault

### DIFF
--- a/.github/workflows/credential-canary.yml
+++ b/.github/workflows/credential-canary.yml
@@ -145,9 +145,17 @@ jobs:
         env:
           ION_TOKEN: ${{ secrets.PUBLIC_CESIUM_ION_TOKEN }}
         run: |
+          # Not set is a valid, deliberate state, not a failure. The globe no
+          # longer requests Ion assets without a token (#222) — it uses the
+          # dark baseColor, which is the intended look. Failing here would be
+          # a daily alarm about a decision rather than a fault, and an alarm
+          # nobody can act on is the kind people learn to ignore.
           if [ -z "$ION_TOKEN" ]; then
-            echo "PUBLIC_CESIUM_ION_TOKEN not set"; exit 1
+            echo "PUBLIC_CESIUM_ION_TOKEN not set — Ion unused by design, skipping"
+            exit 0
           fi
+          # If a token IS set, the globe will request Ion assets, so a broken
+          # token is a real fault and this must fail.
           FAILED=0
           for ASSET in 1 2; do
             CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 \


### PR DESCRIPTION
Follow-up to #222.

The globe no longer requests Ion assets when no token is configured, so **not set** is now a valid deliberate state rather than something broken. The canary was failing on it every day.

An alarm nobody can act on is the kind people learn to ignore — which is precisely what this canary exists to prevent. It was built because a revoked token went unnoticed for two weeks; training its owner to skip the notification would undo that.

Still fails if a token **is** set but does not work. In that case the globe really does request Ion assets, and a broken token is a genuine fault.