### PR TITLE
fix(scout): Create missing labels instead of silently dropping all of them

### DIFF
--- a/.github/workflows/tracker-lifecycle.yml
+++ b/.github/workflows/tracker-lifecycle.yml
@@ -187,13 +187,26 @@ jobs:
                   const bodyFile = '/tmp/scout-issue-' + c.slug + '.md';
                   fs.writeFileSync(bodyFile, body);
                   const base = ['issue','create','--title',title,'--body-file',bodyFile];
+                  // gh refuses the whole call if any single label is missing,
+                  // so create them first. Without this the fallback below
+                  // silently swallowed ALL labels whenever ONE was undefined,
+                  // which is what left #177-#180 completely unlabelled while
+                  // #205-#208 a week later came out fine — the labels happened
+                  // to exist by then. A new domain would have repeated it.
+                  for (const name of labels) {
+                    try {
+                      execFileSync('gh', ['label','create',name,'--force'],
+                                   { stdio: 'ignore' });
+                    } catch {
+                      // Non-fatal: if label creation is not permitted, the
+                      // fallback below still gets the issue filed.
+                    }
+                  }
                   try {
                     execFileSync('gh', [...base,'--label',labels.join(',')], { stdio: 'inherit' });
                   } catch {
-                    // gh refuses the whole call if any label is missing, and
-                    // these (scout, auto-triage, domain:*) are not defined in
-                    // the repo. Losing a candidate over a missing label would
-                    // be worse than losing the label.
+                    // Last resort. Losing a candidate over a label would be
+                    // worse than losing the label.
                     console.warn('Label(s) rejected — creating issue without labels');
                     execFileSync('gh', base, { stdio: 'inherit' });
                   }


### PR DESCRIPTION
You spotted that half the Scout issues have no labels. Here is why.

`gh` refuses an entire `issue create` call if **any single** `--label` is undefined. The workflow caught that failure and retried with **no labels at all**:

```js
try {
  execFileSync('gh', [...base, '--label', labels.join(',')]);
} catch {
  console.warn('Label(s) rejected — creating issue without labels');
  execFileSync('gh', base);   // <-- all three labels lost
}
```

So one missing label cost all three, and the warning went to a workflow log nobody reads.

That is exactly the split you saw:

| issues | date | labels |
| --- | --- | --- |
| #177-#180 | 2026-08-09 | **none** — the labels did not exist yet |
| #205-#208 | 2026-08-16 | correct — the labels existed by then |

Nothing about those issues differed. The repo state did.

## Change

Creates each label with `gh label create --force` before filing. A new domain value (say `domain:health`) would otherwise have repeated this silently.

The bare fallback stays as a last resort — losing a candidate over a label is still worse than losing the label.

Also backfilled the four affected issues by hand, so #177-#180 now carry `scout`, `auto-triage` and their `domain:*` tag.