### PR TITLE
ops(x): Add a read-only way to ask whether X posting works again

### DIFF
--- a/.github/workflows/x-api-check.yml
+++ b/.github/workflows/x-api-check.yml
@@ -1,0 +1,59 @@
+name: X API Check
+
+# The X account was suspended in April 2026 and posting moved to Bluesky.
+# This answers "can we post again?" without finding out the expensive way.
+#
+#   verify     one read-only GET /2/users/me. No writes, minimal quota.
+#   post-test  posts a single tweet, after verifying auth first.
+#
+# Manual dispatch only, never scheduled: the whole point is to touch the API
+# as little as possible while an enforcement action may still be in effect.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'verify (read-only) or post-test (publishes one tweet)'
+        required: true
+        default: 'verify'
+        type: choice
+        options: [verify, post-test]
+      text:
+        description: 'Tweet text — only used when mode is post-test'
+        required: false
+        default: ''
+
+concurrency:
+  group: x-api-check
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+
+      - name: Guard post-test input
+        if: inputs.mode == 'post-test'
+        run: |
+          if [ -z "${{ inputs.text }}" ]; then
+            echo "::error::post-test requires text"; exit 1
+          fi
+
+      - name: Run check
+        env:
+          X_API_KEY: ${{ secrets.X_API_KEY }}
+          X_API_SECRET: ${{ secrets.X_API_SECRET }}
+          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+          X_TEST_TEXT: ${{ inputs.text }}
+        run: npx tsx scripts/x-check.ts "${{ inputs.mode }}"

--- a/scripts/x-check.ts
+++ b/scripts/x-check.ts
@@ -1,0 +1,95 @@
+/**
+ * X (Twitter) API check.
+ *
+ * The account was suspended in April 2026 and posting moved to Bluesky. This
+ * exists to answer "can we post again?" without finding out the expensive way.
+ *
+ *   verify     one read-only GET /2/users/me. No writes, minimal quota.
+ *   post-test  posts a single tweet, then reports its URL.
+ *
+ * Deliberately two modes: a suspended or rate-limited app should be discovered
+ * with a read, not with a write that could re-trigger enforcement.
+ */
+import { TwitterApi } from 'twitter-api-v2';
+
+const MODE = process.argv[2] ?? 'verify';
+
+function client(): TwitterApi {
+  const appKey = process.env.X_API_KEY;
+  const appSecret = process.env.X_API_SECRET;
+  const accessToken = process.env.X_ACCESS_TOKEN;
+  const accessSecret = process.env.X_ACCESS_TOKEN_SECRET;
+  const missing = [
+    ['X_API_KEY', appKey], ['X_API_SECRET', appSecret],
+    ['X_ACCESS_TOKEN', accessToken], ['X_ACCESS_TOKEN_SECRET', accessSecret],
+  ].filter(([, v]) => !v).map(([k]) => k);
+  if (missing.length) {
+    console.error(`Missing credentials: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+  return new TwitterApi({
+    appKey: appKey!, appSecret: appSecret!,
+    accessToken: accessToken!, accessSecret: accessSecret!,
+  });
+}
+
+function describe(err: any): string {
+  const code = err?.code ?? err?.data?.status;
+  const detail = err?.data?.detail ?? err?.data?.title ?? err?.message;
+  // 401/403 on a previously-suspended account almost always means the
+  // suspension or the app's write permission, not a typo in the keys.
+  const hint =
+    code === 401 ? ' (credentials rejected — rotated, revoked, or app suspended)'
+    : code === 403 ? ' (forbidden — app lacks write access, or account restricted)'
+    : code === 429 ? ' (rate limited — do NOT retry in a loop)'
+    : '';
+  return `HTTP ${code ?? '?'}: ${detail ?? 'unknown'}${hint}`;
+}
+
+async function main() {
+  const api = client();
+
+  if (MODE === 'verify') {
+    try {
+      const me = await api.v2.me();
+      console.log(`OK  authenticated as @${me.data.username} (${me.data.name}), id ${me.data.id}`);
+      console.log('read_ok=true');
+    } catch (err) {
+      console.error(`FAIL  read check: ${describe(err)}`);
+      console.log('read_ok=false');
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (MODE === 'post-test') {
+    const text = process.env.X_TEST_TEXT;
+    if (!text) { console.error('X_TEST_TEXT is required for post-test'); process.exit(1); }
+    // Verify first: never spend a write to discover the account is suspended.
+    let username = 'unknown';
+    try {
+      const me = await api.v2.me();
+      username = me.data.username;
+      console.log(`Authenticated as @${username}`);
+    } catch (err) {
+      console.error(`FAIL  cannot authenticate, not attempting a post: ${describe(err)}`);
+      process.exit(1);
+    }
+    try {
+      const res = await api.v2.tweet(text);
+      const url = `https://x.com/${username}/status/${res.data.id}`;
+      console.log(`OK  posted: ${url}`);
+      console.log(`post_ok=true url=${url}`);
+    } catch (err) {
+      console.error(`FAIL  post: ${describe(err)}`);
+      console.log('post_ok=false');
+      process.exit(1);
+    }
+    return;
+  }
+
+  console.error(`Unknown mode: ${MODE} (expected verify | post-test)`);
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
You asked whether we can post to X again, and to be careful not to get banned a second time.

The account was suspended in April 2026 and posting moved to Bluesky. The app looks normal now — but **finding out by posting** is exactly the move that risks re-triggering enforcement.

So this has two modes, manual dispatch only, never scheduled:

| mode | what it does |
| --- | --- |
| `verify` | one read-only `GET /2/users/me`. No writes, minimal quota. |
| `post-test` | posts a single tweet — **and verifies auth first**, so a write is never spent discovering the account is still suspended. |

## Error messages that answer the actual question

`401` vs `403` vs `429` is the whole answer here, so each gets a hint rather than a raw stack trace:

- **401** — credentials rejected: rotated, revoked, or app suspended
- **403** — forbidden: app lacks write access, or account restricted
- **429** — rate limited, and explicitly says *do not retry in a loop*

That last one matters given the history. An automatic retry against a rate-limited suspended account is how a temporary problem becomes a permanent one.

I have not run `post-test` yet — running `verify` first.