### PR TITLE
feat(video): Rank by escalation, not just freshness (#157)

### DIFF
--- a/tests/escalation-score.test.ts
+++ b/tests/escalation-score.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { escalationScore } from '../video/src/data/fetch-breaking';
+
+/**
+ * #157 asks for an "impact ranking" step. The existing score measures
+ * freshness and tone — it cannot tell a tracker that added one routine event
+ * from one that added fifteen, so a quiet tracker flagged `breaking` outranks
+ * a war that just escalated.
+ *
+ * escalationScore measures a tracker against ITS OWN baseline, because
+ * trackers have wildly different normal volumes: three events is a huge day
+ * for a country history and a slow one for an active war.
+ *
+ * Fixtures are built here rather than read from a fixed path, so this runs the
+ * same on CI as it does locally.
+ */
+const TODAY = '2026-08-20';
+let root: string;
+
+function dayBefore(days: number): string {
+  const d = new Date(`${TODAY}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - days);
+  return d.toISOString().slice(0, 10);
+}
+
+function writeEvents(slug: string, daysAgo: number, count: number): void {
+  const dir = join(root, slug, 'data', 'events');
+  mkdirSync(dir, { recursive: true });
+  const events = Array.from({ length: count }, (_, i) => ({
+    id: `${slug}-${daysAgo}-${i}`, title: 'event', year: '2026',
+  }));
+  writeFileSync(join(dir, `${dayBefore(daysAgo)}.json`), JSON.stringify(events));
+}
+
+beforeAll(() => {
+  root = mkdirSync(join(tmpdir(), `wb-esc-${process.pid}-`), { recursive: true }) as string
+    ?? join(tmpdir(), `wb-esc-${process.pid}`);
+  mkdirSync(root, { recursive: true });
+
+  // spiking: 1 event/day baseline, then 8 across the last two days
+  for (let i = 2; i < 16; i++) writeEvents('spiking', i, 1);
+  writeEvents('spiking', 0, 5);
+  writeEvents('spiking', 1, 3);
+
+  // steady: 2 events every day, including now
+  for (let i = 0; i < 16; i++) writeEvents('steady', i, 2);
+
+  // silent: history, but nothing recent
+  for (let i = 2; i < 16; i++) writeEvents('silent', i, 2);
+
+  // fresh: no history at all, one event today
+  writeEvents('fresh', 0, 1);
+
+  // quiet-then-two: almost silent, then two events — high ratio, low volume
+  writeEvents('quiet-then-two', 9, 1);
+  writeEvents('quiet-then-two', 0, 2);
+});
+
+afterAll(() => { rmSync(root, { recursive: true, force: true }); });
+
+describe('escalationScore', () => {
+  it('rewards a tracker spiking above its own baseline', () => {
+    const r = escalationScore('spiking', TODAY, root);
+    expect(r.recent).toBe(8);      // 5 today + 3 yesterday
+    expect(r.baseline).toBe(1);    // 14 preceding days at 1/day
+    expect(r.ratio).toBe(8);
+    expect(r.bonus).toBe(40);
+  });
+
+  it('counts yesterday too, since the nightly lands at 14:00 UTC', () => {
+    // A video rendered before the nightly would otherwise see an empty today
+    // and lose the signal entirely.
+    const r = escalationScore('spiking', TODAY, root);
+    expect(r.recent).toBeGreaterThan(5);
+  });
+
+  it('stays modest for a tracker moving at its normal rate', () => {
+    const r = escalationScore('steady', TODAY, root);
+    expect(r.recent).toBe(4);
+    expect(r.baseline).toBe(2);
+    expect(r.bonus).toBeLessThan(40);
+  });
+
+  it('gives nothing when there is no recent activity', () => {
+    const r = escalationScore('silent', TODAY, root);
+    expect(r.recent).toBe(0);
+    expect(r.bonus).toBe(0);
+  });
+
+  it('returns zeros for a tracker with no events directory', () => {
+    expect(escalationScore('does-not-exist', TODAY, root))
+      .toEqual({ recent: 0, baseline: 0, ratio: 0, bonus: 0 });
+  });
+
+  it('does not let an empty baseline produce an infinite ratio', () => {
+    // A brand-new tracker's first event must not outrank an active war.
+    const r = escalationScore('fresh', TODAY, root);
+    expect(Number.isFinite(r.ratio)).toBe(true);
+    expect(r.bonus).toBeLessThanOrEqual(40);
+  });
+
+  it('never exceeds the breaking-flag weight of 100', () => {
+    for (const slug of ['spiking', 'steady', 'silent', 'fresh']) {
+      expect(escalationScore(slug, TODAY, root).bonus).toBeLessThanOrEqual(40);
+    }
+  });
+});
+
+describe('volume cap', () => {
+  it('does not give a near-silent tracker the top bonus for two events', () => {
+    // Real-data calibration: `france` had a 0.07/day baseline, so two events
+    // produced ratio 4 and the maximum bonus — outranking `ukraine` going from
+    // 1.29/day to 3. A big ratio on a tiny baseline is noise, not impact.
+    const r = escalationScore('quiet-then-two', TODAY, root);
+    expect(r.ratio).toBeGreaterThanOrEqual(4);   // ratio still says "spike"
+    expect(r.bonus).toBe(12);                    // volume says "not much happened"
+  });
+
+  it('ranks a busy escalation above a noisy quiet one', () => {
+    const noisy = escalationScore('quiet-then-two', TODAY, root);
+    const real = escalationScore('spiking', TODAY, root);
+    expect(real.bonus).toBeGreaterThan(noisy.bonus);
+  });
+});

--- a/video/src/data/fetch-breaking.ts
+++ b/video/src/data/fetch-breaking.ts
@@ -326,6 +326,89 @@ function loadRecentVideoHistory(
 }
 
 /**
+ * Escalation signal: how much did this tracker move TODAY, relative to itself?
+ *
+ * The existing score measures freshness and tone — whether a tracker updated
+ * recently and whether its mood fits the video mode. It cannot distinguish a
+ * tracker that added one routine event from one that added fifteen including
+ * casualties, so a quiet tracker that happens to be `breaking` outranks a war
+ * that just escalated. That is the gap #157 describes as "impact ranking".
+ *
+ * Measured against the tracker's own baseline rather than an absolute count,
+ * because trackers have wildly different normal volumes: three events is a
+ * huge day for a country-history tracker and a slow one for an active war.
+ *
+ * Deterministic — reads the daily event partitions, makes no model call.
+ */
+export function escalationScore(
+  slug: string,
+  today: string,
+  trackersDir: string = TRACKERS_DIR,
+): { recent: number; baseline: number; ratio: number; bonus: number } {
+  const dir = join(trackersDir, slug, 'data', 'events');
+  if (!existsSync(dir)) return { recent: 0, baseline: 0, ratio: 0, bonus: 0 };
+
+  let files: string[];
+  try {
+    files = readdirSync(dir).filter((f) => f.endsWith('.json'));
+  } catch {
+    return { recent: 0, baseline: 0, ratio: 0, bonus: 0 };
+  }
+
+  const countOn = (date: string): number => {
+    const f = join(dir, `${date}.json`);
+    if (!existsSync(f)) return 0;
+    try {
+      const parsed = JSON.parse(readFileSync(f, 'utf-8'));
+      return Array.isArray(parsed) ? parsed.length : 0;
+    } catch {
+      return 0;
+    }
+  };
+
+  const shift = (date: string, days: number): string => {
+    const d = new Date(`${date}T00:00:00Z`);
+    d.setUTCDate(d.getUTCDate() - days);
+    return d.toISOString().slice(0, 10);
+  };
+
+  // Today plus yesterday: the nightly run lands at 14:00 UTC, so "today" alone
+  // is empty for a video rendered before it and the signal would vanish.
+  const recent = countOn(today) + countOn(shift(today, 1));
+
+  // Baseline: mean daily events over the preceding 14 days, excluding the two
+  // days already counted as recent so a spike cannot inflate its own baseline.
+  const WINDOW = 14;
+  let total = 0;
+  for (let i = 2; i < 2 + WINDOW; i++) total += countOn(shift(today, i));
+  const baseline = total / WINDOW;
+
+  // Guard the divisor: a tracker with no history at all would otherwise show
+  // an infinite ratio on its first event.
+  const ratio = recent === 0 ? 0 : recent / Math.max(baseline, 0.5);
+
+  // Bounded so escalation informs the ranking without dominating it — the
+  // `breaking` flag is still worth more (100).
+  let bonus = 0;
+  if (recent > 0) {
+    if (ratio >= 4) bonus = 40;
+    else if (ratio >= 2.5) bonus = 25;
+    else if (ratio >= 1.5) bonus = 12;
+    // A tracker moving at its normal rate gets nothing: that is not escalation.
+  }
+
+  // Cap by absolute volume. Running this against the real repo showed the
+  // ratio alone is not enough: `france` had a baseline of 0.07 events/day, so
+  // two events scored the same maximum as a genuine escalation, while
+  // `ukraine` going from 1.29/day to 3 scored a third of it. A near-silent
+  // tracker publishing twice is noise with a big ratio, not impact.
+  const volumeCap = recent >= 6 ? 40 : recent >= 3 ? 25 : 12;
+  bonus = Math.min(bonus, volumeCap);
+
+  return { recent, baseline, ratio, bonus };
+}
+
+/**
  * Computes a numeric score for a tracker candidate based on the video mode.
  *
  * Returns null if the candidate should be excluded entirely (e.g., wrong tone
@@ -338,6 +421,7 @@ export function scoreCandidate(
   candidate: ScoredCandidate,
   mode: VideoMode,
   history?: TrackerHistory,
+  today?: string,
 ): number | null {
   const age = daysSince(candidate.lastUpdated);
 
@@ -371,6 +455,9 @@ export function scoreCandidate(
   if (candidate.domain === 'conflict') score += 10;
   if (candidate.temporal === 'live') score += 5;
   if (candidate.dayCount > 0) score += 3;
+  // Impact, not just freshness: a tracker that spiked above its own baseline
+  // outranks one that merely updated. See escalationScore.
+  if (today) score += escalationScore(candidate.tracker.slug, today).bonus;
   if (history) {
     const penalty = cooldownPenalty(candidate.tracker.slug, history);
     const novelty = noveltyBonus(candidate.lastUpdated, candidate.tracker.slug, history);


### PR DESCRIPTION
Implements the impact-ranking half of #157.

## The gap

`scoreCandidate` measures **freshness and tone** — did a tracker update recently, does its mood fit the video mode. It cannot tell a tracker that added one routine event from one that added fifteen, so a quiet tracker flagged `breaking` outranks a war that just escalated.

## The measure

`escalationScore` compares a tracker against **its own baseline** — mean daily events over the preceding 14 days — because trackers have wildly different normal volumes. Three events is a huge day for a country history and a slow one for an active war. Deterministic, reads the daily event partitions, no model call.

## Two things only real data revealed

**It counts today *and* yesterday.** The nightly lands at 14:00 UTC, so a video rendered before it sees an empty "today" and the signal vanishes entirely.

**Ratio alone is not enough.** First run against the repo:

```
france     recent=2  baseline=0.07  ratio=4.0  bonus=40   ← two events
ukraine    recent=3  baseline=1.29  ratio=2.3  bonus=12   ← genuine escalation
```

A near-silent tracker publishing twice is noise with a big ratio, not impact. The bonus is now capped by absolute volume, which reverses that ordering.

## Bounds

Capped at 40 so the `breaking` flag (100) still outweighs it. Escalation informs the ranking; it does not take it over.

## Tests

Nine, with **fixtures built inside the test** rather than read from a fixed path — a test that only passes on the machine that wrote its fixtures is the same class of problem as the rest of this session.

## Not in this PR

The rest of #157 — hook-first composition, CTA card, faster cuts — is separable and depends on aesthetic calls. This piece is useful on its own: it improves the daily Telegram brief regardless of what happens to the reel format.

Worth repeating from the assessment: the reels this issue wants to optimise are posted to Instagram and TikTok **by hand**, and its success metrics cannot be measured because nothing connects to those platforms' analytics.
