### PR TITLE
feat(video): Generate hook headlines, with validation that can reject them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,12 @@ playwright-report/
 
 # Remotion Studio prep data — heavy base64 thumbnails, regenerable via prep-studio.ts
 video/src/data/studio-data.json
+# Generated per-run by scripts/generate-hook.ts — the chosen hook and the prompt
+# that produced it. Regenerated every render; committing them would create
+# merge noise on every daily video.
+video/src/data/hook.json
+video/src/data/hook-prompt.txt
+
 
 # Video pipeline output — large MP4/MP3 artifacts. Re-renderable via
 # `make video-render-all`. CI uploads them as workflow artifacts (30-day

--- a/scripts/generate-hook.ts
+++ b/scripts/generate-hook.ts
@@ -1,0 +1,184 @@
+#!/usr/bin/env tsx
+/**
+ * generate-hook.ts — writes hook headline candidates for the daily video.
+ *
+ * #157: "Videos open with 'Daily Intelligence Brief - Date' which is an index,
+ * not a cliffhanger." The hook composition (#228) opens on a headline instead,
+ * but tracker headlines are dashboard copy — several developments joined with
+ * semicolons — so the deterministic fallback can only trim, never rewrite.
+ * This produces actual hooks.
+ *
+ * Follows the same shape as generate-social-queue.ts: write a prompt, call the
+ * API directly if ANTHROPIC_API_KEY is present, otherwise leave the prompt for
+ * claude-code-action to pick up in CI.
+ *
+ * Usage:
+ *   npx tsx scripts/generate-hook.ts [--dry-run]
+ *
+ * Writes video/src/data/hook.json:
+ *   { generatedAt, tracker, candidates: [{ pattern, text }], chosen }
+ */
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { deriveHookHeadline } from '../video/src/data/hook-headline.js';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const BREAKING = join(ROOT, 'video', 'src', 'data', 'breaking.json');
+const OUT = join(ROOT, 'video', 'src', 'data', 'hook.json');
+const PROMPT_OUT = join(ROOT, 'video', 'src', 'data', 'hook-prompt.txt');
+
+/** The four openings #157 specifies, with the reason each one works. */
+export const HOOK_PATTERNS = [
+  { id: 'threat',      shape: '[Actor] just [action]. Here is why that matters.' },
+  { id: 'countdown',   shape: '[Entity] has [N days] to [decision]. The clock is ticking.' },
+  { id: 'contrarian',  shape: 'Everyone thinks [common take]. The data says otherwise.' },
+  { id: 'stakes',      shape: 'This one [event] could [big consequence].' },
+] as const;
+
+export interface HookCandidate { pattern: string; text: string }
+export interface HookFile {
+  generatedAt: string;
+  tracker: string;
+  candidates: HookCandidate[];
+  chosen: string;
+  source: 'llm' | 'derived';
+}
+
+export function buildPrompt(tracker: { name?: string; headline?: string; kpis?: unknown }): string {
+  return [
+    'You write opening lines for a 18-second vertical news video. The line is on',
+    'screen for two seconds and decides whether anyone watches the rest.',
+    '',
+    `Tracker: ${tracker.name ?? 'unknown'}`,
+    `Current headline: ${tracker.headline ?? '(none)'}`,
+    tracker.kpis ? `Key figures: ${JSON.stringify(tracker.kpis).slice(0, 600)}` : '',
+    '',
+    'Write one candidate for each of these four patterns:',
+    ...HOOK_PATTERNS.map((p) => `  ${p.id}: ${p.shape}`),
+    '',
+    'Rules:',
+    '  - Maximum 72 characters. It renders at display size; longer will not fit.',
+    '  - Use only facts present above. Do not invent numbers, dates or claims.',
+    '  - If a pattern does not fit the facts, return an empty string for it',
+    '    rather than forcing it. A dishonest hook is worse than a dull one.',
+    '  - No hashtags, no emoji, no trailing punctuation.',
+    '',
+    'Return ONLY a JSON array: [{"pattern":"threat","text":"..."}, ...]',
+  ].filter(Boolean).join('\n');
+}
+
+/** Rejects candidates that break the rules, so a bad generation cannot ship. */
+export function validateCandidates(raw: unknown): HookCandidate[] {
+  if (!Array.isArray(raw)) return [];
+  const valid = new Set(HOOK_PATTERNS.map((p) => p.id as string));
+  const out: HookCandidate[] = [];
+  for (const c of raw) {
+    if (!c || typeof c !== 'object') continue;
+    const pattern = (c as HookCandidate).pattern;
+    const text = (c as HookCandidate).text;
+    if (typeof pattern !== 'string' || typeof text !== 'string') continue;
+    if (!valid.has(pattern)) continue;
+    const trimmed = text.trim();
+    if (trimmed.length === 0) continue;          // pattern declined — expected
+    if (trimmed.length > 72) continue;           // will not render
+    if (/[#@]|[\u{1F300}-\u{1FAFF}]/u.test(trimmed)) continue;
+    out.push({ pattern, text: trimmed.replace(/[.,;:]$/, '') });
+  }
+  return out;
+}
+
+/**
+ * Pick order is deliberate, not arbitrary: threat and countdown carry a
+ * concrete fact and a reason to keep watching, contrarian needs the viewer to
+ * hold a prior, and stakes is the vaguest. Ties go to the shorter line.
+ */
+export function chooseHook(candidates: HookCandidate[], fallback: string): string {
+  const order = ['threat', 'countdown', 'stakes', 'contrarian'];
+  const ranked = [...candidates].sort((a, b) => {
+    const d = order.indexOf(a.pattern) - order.indexOf(b.pattern);
+    return d !== 0 ? d : a.text.length - b.text.length;
+  });
+  return ranked[0]?.text ?? fallback;
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes('--dry-run');
+
+  if (!existsSync(BREAKING)) {
+    console.error(`[hook] ${BREAKING} not found — run the video data fetch first`);
+    process.exit(1);
+  }
+  const data = JSON.parse(readFileSync(BREAKING, 'utf-8')) as {
+    trackers?: Array<{ name?: string; slug?: string; headline?: string; kpis?: unknown }>;
+  };
+  const lead = data.trackers?.[0];
+  if (!lead) {
+    console.error('[hook] breaking.json has no trackers');
+    process.exit(1);
+  }
+
+  const fallback = deriveHookHeadline(lead.headline, lead.name ?? 'Breaking');
+  const prompt = buildPrompt(lead);
+  mkdirSync(dirname(PROMPT_OUT), { recursive: true });
+  writeFileSync(PROMPT_OUT, prompt);
+
+  const write = (candidates: HookCandidate[], source: HookFile['source']) => {
+    const file: HookFile = {
+      generatedAt: new Date().toISOString(),
+      tracker: lead.slug ?? lead.name ?? 'unknown',
+      candidates,
+      chosen: chooseHook(candidates, fallback),
+      source,
+    };
+    writeFileSync(OUT, JSON.stringify(file, null, 2) + '\n');
+    console.log(`[hook] ${source}: "${file.chosen}"`);
+  };
+
+  if (dryRun) {
+    console.log('[hook] dry run — prompt written, no LLM call');
+    write([], 'derived');
+    return;
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    // Same contract as generate-social-queue.ts: leave the prompt for
+    // claude-code-action, and still write a usable hook so the render never
+    // blocks on the LLM being reachable.
+    console.log('[hook] No ANTHROPIC_API_KEY — wrote prompt, falling back to derived headline');
+    write([], 'derived');
+    return;
+  }
+
+  try {
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: 'claude-sonnet-4-6',
+        max_tokens: 1024,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+    if (!res.ok) throw new Error(`${res.status} ${await res.text()}`);
+    const body = await res.json() as { content?: Array<{ text?: string }> };
+    const text = body.content?.[0]?.text?.trim() ?? '';
+    const json = text.slice(text.indexOf('['), text.lastIndexOf(']') + 1);
+    write(validateCandidates(JSON.parse(json)), 'llm');
+  } catch (err) {
+    // A failed hook must never fail the video. The derived headline is worse
+    // copy but it is always correct, and a missing video is worse than a dull
+    // opening line.
+    console.warn(`[hook] generation failed, using derived headline: ${(err as Error).message}`);
+    write([], 'derived');
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/tests/generate-hook.test.ts
+++ b/tests/generate-hook.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { buildPrompt, validateCandidates, chooseHook, HOOK_PATTERNS } from '../scripts/generate-hook';
+
+/**
+ * The validation here is the load-bearing part. A generated hook is the first
+ * thing a viewer sees and it publishes unattended, so a bad generation must be
+ * rejected rather than rendered — the fallback is a trimmed real headline,
+ * which is duller but always true.
+ */
+describe('validateCandidates', () => {
+  it('accepts a well-formed candidate', () => {
+    expect(validateCandidates([{ pattern: 'threat', text: 'Iran flew 47 sorties in a day' }]))
+      .toEqual([{ pattern: 'threat', text: 'Iran flew 47 sorties in a day' }]);
+  });
+
+  it('rejects anything too long to render', () => {
+    expect(validateCandidates([{ pattern: 'threat', text: 'x'.repeat(73) }])).toEqual([]);
+  });
+
+  it('rejects hashtags and emoji, which read as marketing', () => {
+    expect(validateCandidates([{ pattern: 'threat', text: 'Big news #osint' }])).toEqual([]);
+    expect(validateCandidates([{ pattern: 'threat', text: 'Big news 🔥' }])).toEqual([]);
+  });
+
+  it('treats an empty string as the model declining the pattern', () => {
+    // The prompt tells it to decline rather than force a pattern onto facts
+    // that do not support one. That must not become an empty on-screen hook.
+    expect(validateCandidates([
+      { pattern: 'threat', text: 'Real hook here' },
+      { pattern: 'contrarian', text: '   ' },
+    ])).toEqual([{ pattern: 'threat', text: 'Real hook here' }]);
+  });
+
+  it('rejects unknown patterns', () => {
+    expect(validateCandidates([{ pattern: 'clickbait', text: 'You will not believe' }])).toEqual([]);
+  });
+
+  it('survives malformed input without throwing', () => {
+    expect(validateCandidates(null)).toEqual([]);
+    expect(validateCandidates('nope')).toEqual([]);
+    expect(validateCandidates([null, 42, { pattern: 'threat' }])).toEqual([]);
+  });
+
+  it('strips trailing punctuation', () => {
+    expect(validateCandidates([{ pattern: 'stakes', text: 'This could reshape the Gulf.' }])[0].text)
+      .toBe('This could reshape the Gulf');
+  });
+});
+
+describe('chooseHook', () => {
+  it('prefers threat over contrarian, which needs the viewer to hold a prior', () => {
+    const chosen = chooseHook([
+      { pattern: 'contrarian', text: 'Everyone thinks it is over' },
+      { pattern: 'threat', text: 'Iran flew 47 sorties' },
+    ], 'fallback');
+    expect(chosen).toBe('Iran flew 47 sorties');
+  });
+
+  it('breaks ties on length', () => {
+    const chosen = chooseHook([
+      { pattern: 'threat', text: 'A much longer opening line about it' },
+      { pattern: 'threat', text: 'Short and sharp' },
+    ], 'fallback');
+    expect(chosen).toBe('Short and sharp');
+  });
+
+  it('falls back when nothing survived validation', () => {
+    expect(chooseHook([], 'Somalia: Israel appoints ambassador')).toBe('Somalia: Israel appoints ambassador');
+  });
+});
+
+describe('buildPrompt', () => {
+  it('names every pattern and states the character budget', () => {
+    const p = buildPrompt({ name: 'Iran Conflict', headline: 'Strikes resume' });
+    for (const { id } of HOOK_PATTERNS) expect(p).toContain(id);
+    expect(p).toContain('72 characters');
+  });
+
+  it('tells the model to decline rather than invent', () => {
+    const p = buildPrompt({ name: 'x' });
+    expect(p).toContain('Do not invent');
+    expect(p).toContain('empty string');
+  });
+});


### PR DESCRIPTION
Completes the hook half of #157.

The composition variant (#228) opens on a headline instead of a logo, but tracker headlines are dashboard copy — several developments joined with semicolons — so the deterministic fallback can only trim, never rewrite. This writes real hooks against the four patterns the issue specifies: threat, countdown, contrarian, stakes.

Same contract as `generate-social-queue.ts`: write the prompt, call the API directly when `ANTHROPIC_API_KEY` is present, otherwise leave it for `claude-code-action`.

## The validation is the load-bearing part

A hook is the first thing a viewer sees, and it publishes unattended. So a bad generation is **rejected rather than rendered**:

| rejected | why |
| --- | --- |
| over 72 characters | will not render at display size |
| hashtags or emoji | reads as marketing |
| unknown pattern | model went off-script |
| empty string | the model **correctly declining** a pattern the facts do not support |

That last one matters. The prompt asks explicitly for an empty string when a pattern does not fit, because *a dishonest hook is worse than a dull one* — and for a dashboard whose whole proposition is sourced, tier-classified data, an invented opening line would undercut everything behind it.

Every rejection path lands on the derived headline. Worse copy, always true.

## A failed hook never fails the video

Network error, malformed JSON, missing key — all fall through to the derived headline with a warning. A missing daily brief is worse than a flat opening line.

## Pick order is a judgement, not an accident

`threat` → `countdown` → `stakes` → `contrarian`. The first two carry a concrete fact and a reason to keep watching; contrarian needs the viewer to already hold a prior, which is a lot to assume in two seconds. Ties go to the shorter line.

## Verification

12 tests, plus an end-to-end dry run against the real `breaking.json`:

```
[hook] derived: "MD Anderson Unveils New Cancer Breakthroughs at AACR Conference"
```

263 tests passing overall. Generated artefacts (`hook.json`, `hook-prompt.txt`) are gitignored — they change every render and would otherwise create merge noise on every daily video.
