### PR TITLE
fix(trackers): Tag 17 trackers that breaking news could not reach

### DIFF
--- a/tests/tracker-routability.test.ts
+++ b/tests/tracker-routability.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { loadAllTrackers } from '../scripts/lib/load-trackers-node.js';
+import { buildKeywordIndices } from '../src/lib/keyword-match';
+
+/**
+ * A tracker with no keyword index is invisible to the breaking-news pipeline.
+ *
+ * The light scan builds its index from `tags` + `name` + `ai.searchContext`
+ * (see scripts/hourly-light-scan.ts). Two trackers created by init-tracker.yml
+ * came out with no `tags` at all — nothing failed, the pages rendered, the
+ * nightly updated them, and breaking news simply never routed to them.
+ *
+ * That is invisible from every other angle, which is exactly why it needs a
+ * test rather than a code review.
+ */
+const trackers = (loadAllTrackers() as any[]).filter((t) => t.status === 'active');
+const indices = buildKeywordIndices(
+  trackers.map((t) => ({
+    slug: t.slug,
+    keywords: [...(Array.isArray(t.tags) ? t.tags : []), ...(t.name ? [t.name] : [])],
+    searchContext: t.ai?.searchContext,
+  })),
+);
+
+describe('every active tracker is reachable by the breaking-news scan', () => {
+  it('loads a non-trivial corpus, so this test cannot pass vacuously', () => {
+    expect(trackers.length).toBeGreaterThan(50);
+  });
+
+  it('gives every active tracker a non-empty keyword index', () => {
+    const empty = trackers
+      .map((t) => t.slug)
+      .filter((slug) => (indices.get(slug)?.tokens.size ?? 0) === 0);
+    expect(empty, `trackers unreachable by the light scan: ${empty.join(', ')}`).toEqual([]);
+  });
+
+  it('gives every active tracker at least one tag', () => {
+    // Tags are the highest-signal part of the index: searchContext tokens are
+    // shared across many trackers and get stripped as common, so a tracker
+    // relying on searchContext alone routes poorly even when non-empty.
+    const untagged = trackers
+      .filter((t) => !Array.isArray(t.tags) || t.tags.length === 0)
+      .map((t) => t.slug);
+    expect(untagged, `trackers with no tags: ${untagged.join(', ')}`).toEqual([]);
+  });
+});

--- a/trackers/argentina/tracker.json
+++ b/trackers/argentina/tracker.json
@@ -11,6 +11,13 @@
   "tone": "neutral",
   "domain": "governance",
   "region": "south-america",
+  "tags": [
+    "argentina",
+    "milei",
+    "buenos-aires",
+    "peso",
+    "south-america"
+  ],
   "country": "AR",
   "startDate": "1536-02-02",
   "eraLabel": "1536–Present",

--- a/trackers/ayotzinapa/tracker.json
+++ b/trackers/ayotzinapa/tracker.json
@@ -10,6 +10,13 @@
   "temporal": "historical",
   "domain": "human-rights",
   "region": "north-america",
+  "tags": [
+    "ayotzinapa",
+    "guerrero",
+    "iguala",
+    "disappearances",
+    "mexico"
+  ],
   "country": "MX",
   "startDate": "2014-09-26",
   "eraLabel": "Investigation & Search",

--- a/trackers/bolivia-crisis-2026/tracker.json
+++ b/trackers/bolivia-crisis-2026/tracker.json
@@ -10,6 +10,14 @@
   "temporal": "live",
   "domain": "governance",
   "region": "south-america",
+  "tags": [
+    "bolivia",
+    "la-paz",
+    "el-alto",
+    "cob",
+    "protests",
+    "south-america"
+  ],
   "country": "BO",
   "startDate": "2026-05-14",
   "eraLabel": "2026 Crisis",

--- a/trackers/ceuta-schengen-crisis/tracker.json
+++ b/trackers/ceuta-schengen-crisis/tracker.json
@@ -10,6 +10,14 @@
   "temporal": "live",
   "domain": "governance",
   "region": "europe",
+  "tags": [
+    "ceuta",
+    "spain",
+    "morocco",
+    "schengen",
+    "migration",
+    "european-union"
+  ],
   "country": "ES",
   "geoSecondary": [
     "MA",

--- a/trackers/chernobyl-disaster/tracker.json
+++ b/trackers/chernobyl-disaster/tracker.json
@@ -10,6 +10,13 @@
   "temporal": "historical",
   "domain": "disaster",
   "region": "europe",
+  "tags": [
+    "chernobyl",
+    "pripyat",
+    "nuclear",
+    "ukraine",
+    "radiation"
+  ],
   "country": "UA",
   "startDate": "1986-04-26",
   "eraLabel": "1986 Nuclear Catastrophe & Legacy",

--- a/trackers/culiacanazo/tracker.json
+++ b/trackers/culiacanazo/tracker.json
@@ -10,6 +10,13 @@
   "temporal": "historical",
   "domain": "security",
   "region": "north-america",
+  "tags": [
+    "culiacan",
+    "sinaloa",
+    "ovidio-guzman",
+    "cartel",
+    "mexico"
+  ],
   "country": "MX",
   "startDate": "2019-10-17",
   "eraLabel": "2019 & 2023 Operations",

--- a/trackers/fukushima-disaster/tracker.json
+++ b/trackers/fukushima-disaster/tracker.json
@@ -10,6 +10,13 @@
   "temporal": "historical",
   "domain": "disaster",
   "region": "east-asia",
+  "tags": [
+    "fukushima",
+    "daiichi",
+    "nuclear",
+    "tepco",
+    "japan"
+  ],
   "country": "JP",
   "startDate": "2011-03-11",
   "eraLabel": "Disaster & Decommissioning",

--- a/trackers/iran-conflict/tracker.json
+++ b/trackers/iran-conflict/tracker.json
@@ -10,6 +10,14 @@
   "temporal": "live",
   "domain": "conflict",
   "region": "middle-east",
+  "tags": [
+    "iran",
+    "israel",
+    "hormuz",
+    "irgc",
+    "nuclear",
+    "middle-east"
+  ],
   "country": "IR",
   "startDate": "2026-02-28",
   "eraLabel": "Crisis & War 2026",

--- a/trackers/iran/tracker.json
+++ b/trackers/iran/tracker.json
@@ -10,6 +10,13 @@
   "temporal": "historical",
   "domain": "governance",
   "region": "middle-east",
+  "tags": [
+    "iran",
+    "tehran",
+    "khamenei",
+    "persia",
+    "middle-east"
+  ],
   "country": "IR",
   "startDate": "-0550-01-01",
   "eraLabel": "550 BCE – Present",

--- a/trackers/mencho-cjng/tracker.json
+++ b/trackers/mencho-cjng/tracker.json
@@ -10,6 +10,13 @@
   "temporal": "live",
   "domain": "security",
   "region": "north-america",
+  "tags": [
+    "cjng",
+    "mencho",
+    "jalisco",
+    "cartel",
+    "mexico"
+  ],
   "country": "MX",
   "startDate": "2026-02-01",
   "eraLabel": "Post-Mencho Era 2026",

--- a/trackers/mh17-shootdown/tracker.json
+++ b/trackers/mh17-shootdown/tracker.json
@@ -10,6 +10,13 @@
   "temporal": "historical",
   "domain": "conflict",
   "region": "europe",
+  "tags": [
+    "mh17",
+    "donbas",
+    "buk",
+    "malaysia-airlines",
+    "ukraine"
+  ],
   "country": "UA",
   "startDate": "2014-07-17",
   "eraLabel": "Crash & Investigation",

--- a/trackers/myanmar-civil-war/tracker.json
+++ b/trackers/myanmar-civil-war/tracker.json
@@ -10,6 +10,13 @@
   "temporal": "live",
   "domain": "conflict",
   "region": "southeast-asia",
+  "tags": [
+    "myanmar",
+    "tatmadaw",
+    "rakhine",
+    "rohingya",
+    "southeast-asia"
+  ],
   "country": "MM",
   "startDate": "2021-02-01",
   "eraLabel": "Post-Coup Conflict",

--- a/trackers/nigeria/tracker.json
+++ b/trackers/nigeria/tracker.json
@@ -11,6 +11,13 @@
   "tone": "historical",
   "domain": "governance",
   "region": "africa",
+  "tags": [
+    "nigeria",
+    "abuja",
+    "lagos",
+    "boko-haram",
+    "africa"
+  ],
   "country": "NG",
   "startDate": "-500-01-01",
   "eraLabel": "Nok to Tinubu",

--- a/trackers/september-11/tracker.json
+++ b/trackers/september-11/tracker.json
@@ -10,6 +10,13 @@
   "temporal": "historical",
   "domain": "conflict",
   "region": "north-america",
+  "tags": [
+    "september-11",
+    "al-qaeda",
+    "world-trade-center",
+    "pentagon",
+    "terrorism"
+  ],
   "country": "US",
   "startDate": "2001-09-11",
   "endDate": "2001-12-31",

--- a/trackers/taiwan-conflict/tracker.json
+++ b/trackers/taiwan-conflict/tracker.json
@@ -10,6 +10,13 @@
   "temporal": "live",
   "domain": "conflict",
   "region": "east-asia",
+  "tags": [
+    "taiwan",
+    "strait",
+    "pla",
+    "tsai",
+    "east-asia"
+  ],
   "country": "TW",
   "startDate": "2022-08-02",
   "eraLabel": "Cross-Strait Crisis 2022–Present",

--- a/trackers/tlatelolco-1968/tracker.json
+++ b/trackers/tlatelolco-1968/tracker.json
@@ -10,6 +10,13 @@
   "temporal": "historical",
   "domain": "human-rights",
   "region": "north-america",
+  "tags": [
+    "tlatelolco",
+    "1968",
+    "mexico",
+    "student-movement",
+    "human-rights"
+  ],
   "country": "MX",
   "startDate": "1968-10-02",
   "eraLabel": "Massacre & Coverup",

--- a/trackers/yemen-conflict/tracker.json
+++ b/trackers/yemen-conflict/tracker.json
@@ -10,6 +10,14 @@
   "temporal": "live",
   "domain": "conflict",
   "region": "middle-east",
+  "tags": [
+    "yemen",
+    "houthi",
+    "red-sea",
+    "saudi-arabia",
+    "middle-east",
+    "civil-war"
+  ],
   "country": "YE",
   "startDate": "2026-08-06",
   "eraLabel": "Regional War Widening 2026",


### PR DESCRIPTION
Found while validating the newly created trackers.

The light scan builds its keyword index from `tags` + `name` + `ai.searchContext`. **Seventeen active trackers had no `tags` at all** — fifteen pre-existing, including **`iran-conflict`**, plus two just created by `init-tracker.yml`.

Nothing failed. The pages rendered, the nightly updated them, breaking news simply never routed to them. Invisible from every angle except a measurement.

## Measured, before and after

```
"Iran says IRGC forces on alert as Hormuz tensions rise"
   before   iran-conflict 0.32   discarded
   after    iran-conflict 0.95   routes

"Milei government faces peso pressure in Buenos Aires"
   before   argentina 0.32       discarded
   after    argentina 0.95       routes
```

Two of four probes went from discarded to routing. The other two already worked — `taiwan-conflict` and `nigeria` happened to have distinctive enough names.

## A side effect of my own earlier change

That **0.32 is exactly one matched token**. Which means the substance gate added in #215 — requiring two tokens before a candidate routes — was *discarding these trackers' own headlines*.

That gate was right: 84% of the deferred queue was single-token noise like `car` matching CAR-T therapy. But it made untagged trackers strictly worse, and I did not notice at the time. This fixes the cause rather than loosening the gate.

## The tags

Drawn from each tracker's own subject — actors, places and terms a real headline about it would use, not generic domain labels:

| tracker | tags |
| --- | --- |
| `iran-conflict` | iran, israel, hormuz, irgc, nuclear, middle-east |
| `culiacanazo` | culiacan, sinaloa, ovidio-guzman, cartel, mexico |
| `mh17-shootdown` | mh17, donbas, buk, malaysia-airlines, ukraine |

## The guard

A test asserting every active tracker has a non-empty keyword index **and** at least one tag — with an explicit check that the corpus loaded, so it cannot pass vacuously if the loader ever returns nothing.

Tags matter more than the index being merely non-empty: `searchContext` tokens are shared across many trackers and get stripped as common, so a tracker relying on them alone routes poorly even when its index has entries.

266 tests passing.
