### PR TITLE
fix(video): Narration was stating a false tracker count in every video

### DIFF
--- a/.github/workflows/daily-video.yml
+++ b/.github/workflows/daily-video.yml
@@ -102,16 +102,42 @@ jobs:
             echo "AWS CLI not available — skipping narration"
             exit 0
           fi
-          # Extract tracker names from breaking data
-          TRACKERS=$(node -e "const d=require('./video/src/data/breaking.json'); console.log(d.trackers.map(t=>t.name).join('. '))")
+          # Lead story plus the other names. Reading a bare list of tracker
+          # names is an index, not a narration — the same flaw #157 identifies
+          # in the visual intro. The lead gets its actual headline.
+          LEAD=$(node -e "
+            const d=require('./video/src/data/breaking.json');
+            const t=d.trackers[0]||{};
+            console.log((t.headline||t.name||'Breaking').split(';')[0].trim());
+          ")
+          TRACKERS=$(node -e "const d=require('./video/src/data/breaking.json'); console.log(d.trackers.slice(1).map(t=>t.name).join('. '))")
+
+          # Tracker count was hardcoded as \"48 more\" and spoken aloud in every
+          # video. There are far more than 48 now, so the narration was stating
+          # a false figure daily. Counted from the repo instead.
+          TOTAL=$(node -e "
+            const fs=require('fs');
+            const n=fs.readdirSync('trackers').filter(d=>{
+              try { return JSON.parse(fs.readFileSync('trackers/'+d+'/tracker.json','utf8')).status==='active'; }
+              catch { return false; }
+            }).length;
+            console.log(Math.max(0, n-3));
+          ")
           
           # English narration
+          # SSML, limited to what the GENERATIVE engine actually supports:
+          # <break>, <s>, <p> are fully available and <prosody rate> partially.
+          # <emphasis> is NOT available on any engine — the example in #157
+          # uses it, and Polly errors on unsupported tags, which combined with
+          # this step's continue-on-error would have silently dropped narration
+          # from every video.
           aws polly synthesize-speech \
             --engine generative \
             --voice-id Matthew \
             --language-code en-US \
             --output-format mp3 \
-            --text "Breaking stories on Watchboard today. ${TRACKERS}. Track these and 48 more at watchboard dot dev. Free, open source intelligence dashboards, updated daily by AI." \
+            --text-type ssml \
+            --text "<speak><prosody rate='95%'>${LEAD}</prosody><break time='700ms'/>Also tracking today: ${TRACKERS}.<break time='500ms'/>These and ${TOTAL} more at watchboard dot dev.<break time='300ms'/>Free, open source intelligence dashboards, updated daily.</speak>" \
             video/output/narration-en.mp3 || echo "Polly EN failed (non-fatal)"
 
           # Spanish narration  
@@ -120,7 +146,8 @@ jobs:
             --voice-id Pedro \
             --language-code es-US \
             --output-format mp3 \
-            --text "Noticias de última hora en Watchboard hoy. ${TRACKERS}. Rastrea estas y 48 más en watchboard punto dev. Paneles de inteligencia gratuitos y de código abierto, actualizados diariamente por IA." \
+            --text-type ssml \
+            --text "<speak><prosody rate='95%'>${LEAD}</prosody><break time='700ms'/>También seguimos hoy: ${TRACKERS}.<break time='500ms'/>Estas y ${TOTAL} más en watchboard punto dev.<break time='300ms'/>Paneles de inteligencia gratuitos y de código abierto, actualizados a diario.</speak>" \
             video/output/narration-es.mp3 || echo "Polly ES failed (non-fatal)"
 
       - name: Merge narration into video


### PR DESCRIPTION
Implements the voice half of #157 — and found two things wrong with the existing narration on the way.

## The video has been saying a false number out loud

```
"Track these and 48 more at watchboard dot dev."
```

There are **112 active trackers**. Every video published since the count passed 48 has stated a false figure aloud, and nothing could catch it: it is a string literal inside a workflow, invisible to Zod, tests and the build. Now counted from the repo — it says **109**.

## The script was an index, not a narration

It read a bare list of tracker *names*: "Iran Conflict. Gaza War. Ukraine War." That is exactly the flaw #157 identifies in the visual intro — *"an index, not a cliffhanger"* — sitting in the one place the issue does not look. The lead tracker now gets its actual headline; the rest stay a list.

## The SSML in the issue would have broken it

#157's Option A example uses `<emphasis level="strong">`. Per [AWS's own supported-tags table](https://docs.aws.amazon.com/polly/latest/dg/supportedtags.html), **`<emphasis>` is not available on any engine** — not generative, not neural, not long-form — and *"if you use unsupported SSML tags ... you will get an error."*

Combined with this step's `continue-on-error` and its `|| echo "Polly EN failed (non-fatal)"`, adopting the example verbatim would have **silently dropped narration from every video** while the workflow stayed green. Same shape as the rest of this pipeline's history.

So this uses only what the generative engine actually supports:

| tag | generative |
| --- | --- |
| `<break>` | full |
| `<s>`, `<p>` | full |
| `<prosody rate>` | partial |
| `<emphasis>` | **not available** |

Pacing and pauses, which is most of what the issue wanted from SSML. Getting the delivery beyond that is the ElevenLabs question, and that needs an account and a bill — still yours.
