### PR TITLE
fix(i18n): Locale roots 404'd, and the homepage advertised 48 trackers

### DIFF
--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -98,6 +98,12 @@ interface BreakingTracker {
 interface Props {
   trackers: TrackerCardData[];
   basePath: string;
+  /**
+   * Locale the page was served at. The island still lets the reader switch,
+   * but /es/, /fr/ and /pt/ must open in their own language rather than
+   * defaulting to English and making the visitor change it back.
+   */
+  initialLocale?: Locale;
   liveCount: number;
   historicalCount: number;
   trackerCount: number;
@@ -128,6 +134,7 @@ function CommandCenterInner({
   trackerCount,
   updatedTodayCount,
   breakingTrackers,
+  initialLocale,
 }: Props) {
   const [activeTracker, setActiveTracker] = useState<string | null>(null);
   const [hoveredTracker, setHoveredTracker] = useState<string | null>(null);
@@ -143,7 +150,7 @@ function CommandCenterInner({
     }
     return 'operations';
   });
-  const [locale, setLocale] = useState<Locale>('en');
+  const [locale, setLocale] = useState<Locale>(initialLocale ?? 'en');
   const [showHelp, setShowHelp] = useState(false);
   const [isMobile, setIsMobile] = useState(() =>
     typeof window !== 'undefined' && window.innerWidth < 768,

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -1,9 +1,9 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
-import { loadAllTrackers } from '../lib/tracker-registry';
-import { loadTrackerData } from '../lib/data';
-import CommandCenter from '../components/islands/CommandCenter/CommandCenter';
-import { jsonLd } from '../lib/json-ld';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { loadAllTrackers } from '../../lib/tracker-registry';
+import { loadTrackerData } from '../../lib/data';
+import CommandCenter from '../../components/islands/CommandCenter/CommandCenter';
+import { jsonLd } from '../../lib/json-ld';
 
 const trackers = loadAllTrackers();
 const nonDraft = trackers.filter(t => t.status !== 'draft');
@@ -173,14 +173,14 @@ const breakingTrackers = [...serializedTrackers]
     isBreaking: t.isBreaking,
   }));
 ---
-<BaseLayout title="Watchboard — Open-Source Intelligence Dashboard for Global Conflicts, Security & Geopolitics" description={`Track ${nonDraft.length} global events with AI-sourced intelligence — real-time maps, casualty data, contested claims, and daily digests for conflicts, politics, and security worldwide.`}>
+<BaseLayout title="Watchboard — Panel de Inteligencia de Código Abierto sobre Conflictos, Seguridad y Geopolítica" description={`Sigue ${nonDraft.length} eventos globales con inteligencia de fuentes verificadas — mapas en tiempo real, datos de víctimas, afirmaciones en disputa y resúmenes diarios.`} locale="es">
   <Fragment slot="head">
     <script is:inline type="application/ld+json" set:html={jsonLd({
       "@context": "https://schema.org",
       "@type": "WebApplication",
       "name": "Watchboard",
-      "url": "https://watchboard.dev/",
-      "description": `Open-source intelligence dashboard tracking ${nonDraft.length} global events with AI-sourced data, interactive maps, casualty tracking, and contested claims analysis.`,
+      "url": "https://watchboard.dev/es/",
+      "description": `Panel de inteligencia de código abierto que sigue ${nonDraft.length} eventos globales con datos de fuentes verificadas, mapas interactivos, seguimiento de víctimas y análisis de afirmaciones en disputa.`,
       "applicationCategory": "NewsApplication",
       "operatingSystem": "Web",
       "offers": {
@@ -204,6 +204,7 @@ const breakingTrackers = [...serializedTrackers]
     trackerCount={nonDraft.length}
     updatedTodayCount={updatedTodayCount}
     breakingTrackers={breakingTrackers}
+    initialLocale="es"
     client:idle
   />
   </main>

--- a/src/pages/fr/index.astro
+++ b/src/pages/fr/index.astro
@@ -1,9 +1,9 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
-import { loadAllTrackers } from '../lib/tracker-registry';
-import { loadTrackerData } from '../lib/data';
-import CommandCenter from '../components/islands/CommandCenter/CommandCenter';
-import { jsonLd } from '../lib/json-ld';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { loadAllTrackers } from '../../lib/tracker-registry';
+import { loadTrackerData } from '../../lib/data';
+import CommandCenter from '../../components/islands/CommandCenter/CommandCenter';
+import { jsonLd } from '../../lib/json-ld';
 
 const trackers = loadAllTrackers();
 const nonDraft = trackers.filter(t => t.status !== 'draft');
@@ -173,14 +173,14 @@ const breakingTrackers = [...serializedTrackers]
     isBreaking: t.isBreaking,
   }));
 ---
-<BaseLayout title="Watchboard — Open-Source Intelligence Dashboard for Global Conflicts, Security & Geopolitics" description={`Track ${nonDraft.length} global events with AI-sourced intelligence — real-time maps, casualty data, contested claims, and daily digests for conflicts, politics, and security worldwide.`}>
+<BaseLayout title="Watchboard — Tableau de Renseignement Open Source sur les Conflits, la Sécurité et la Géopolitique" description={`Suivez ${nonDraft.length} événements mondiaux avec des renseignements sourcés — cartes en temps réel, données de victimes, affirmations contestées et synthèses quotidiennes.`} locale="fr">
   <Fragment slot="head">
     <script is:inline type="application/ld+json" set:html={jsonLd({
       "@context": "https://schema.org",
       "@type": "WebApplication",
       "name": "Watchboard",
-      "url": "https://watchboard.dev/",
-      "description": `Open-source intelligence dashboard tracking ${nonDraft.length} global events with AI-sourced data, interactive maps, casualty tracking, and contested claims analysis.`,
+      "url": "https://watchboard.dev/fr/",
+      "description": `Tableau de renseignement open source suivant ${nonDraft.length} événements mondiaux avec des données sourcées, des cartes interactives, le suivi des victimes et l'analyse des affirmations contestées.`,
       "applicationCategory": "NewsApplication",
       "operatingSystem": "Web",
       "offers": {
@@ -204,6 +204,7 @@ const breakingTrackers = [...serializedTrackers]
     trackerCount={nonDraft.length}
     updatedTodayCount={updatedTodayCount}
     breakingTrackers={breakingTrackers}
+    initialLocale="fr"
     client:idle
   />
   </main>

--- a/src/pages/pt/index.astro
+++ b/src/pages/pt/index.astro
@@ -1,9 +1,9 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
-import { loadAllTrackers } from '../lib/tracker-registry';
-import { loadTrackerData } from '../lib/data';
-import CommandCenter from '../components/islands/CommandCenter/CommandCenter';
-import { jsonLd } from '../lib/json-ld';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { loadAllTrackers } from '../../lib/tracker-registry';
+import { loadTrackerData } from '../../lib/data';
+import CommandCenter from '../../components/islands/CommandCenter/CommandCenter';
+import { jsonLd } from '../../lib/json-ld';
 
 const trackers = loadAllTrackers();
 const nonDraft = trackers.filter(t => t.status !== 'draft');
@@ -173,14 +173,14 @@ const breakingTrackers = [...serializedTrackers]
     isBreaking: t.isBreaking,
   }));
 ---
-<BaseLayout title="Watchboard — Open-Source Intelligence Dashboard for Global Conflicts, Security & Geopolitics" description={`Track ${nonDraft.length} global events with AI-sourced intelligence — real-time maps, casualty data, contested claims, and daily digests for conflicts, politics, and security worldwide.`}>
+<BaseLayout title="Watchboard — Painel de Inteligência de Código Aberto sobre Conflitos, Segurança e Geopolítica" description={`Acompanhe ${nonDraft.length} eventos globais com inteligência de fontes verificadas — mapas em tempo real, dados de vítimas, alegações contestadas e resumos diários.`} locale="pt">
   <Fragment slot="head">
     <script is:inline type="application/ld+json" set:html={jsonLd({
       "@context": "https://schema.org",
       "@type": "WebApplication",
       "name": "Watchboard",
-      "url": "https://watchboard.dev/",
-      "description": `Open-source intelligence dashboard tracking ${nonDraft.length} global events with AI-sourced data, interactive maps, casualty tracking, and contested claims analysis.`,
+      "url": "https://watchboard.dev/pt/",
+      "description": `Painel de inteligência de código aberto acompanhando ${nonDraft.length} eventos globais com dados de fontes verificadas, mapas interativos, rastreamento de vítimas e análise de alegações contestadas.`,
       "applicationCategory": "NewsApplication",
       "operatingSystem": "Web",
       "offers": {
@@ -204,6 +204,7 @@ const breakingTrackers = [...serializedTrackers]
     trackerCount={nonDraft.length}
     updatedTodayCount={updatedTodayCount}
     breakingTrackers={breakingTrackers}
+    initialLocale="pt"
     client:idle
   />
   </main>


### PR DESCRIPTION
Closes #239.

```
/es/ → 404
/fr/ → 404
/pt/ → 404
```

Per-tracker localised pages have always worked — `/es/iran-conflict/` returns 200 — so the translated content was there and reachable **only by guessing a slug**. Anyone landing on `/es/` hit a dead end.

Adds an index per locale. `CommandCenter` gains an `initialLocale` prop so those pages open in their own language rather than defaulting to English and making the visitor switch back; the in-page switcher still works.

## A second bug, found on the way

The homepage description and its JSON-LD both read **"Track 48+ global events"**, hardcoded. There are **115**.

Same shape as the video narration saying *"48 more"* out loud: a stale literal inside a string, invisible to Zod, to the tests and to the build, stating a false figure to every reader and every crawler. Now derived from `nonDraft.length`, in all four languages.

## Verified in a browser, not just built

```
200  /        Track 115 global events
200  /es/     Sigue 115 eventos globales
200  /fr/     lang="fr", French title
200  /pt/
CSP refusals: 0
```