### PR TITLE
fix(data): Wikipedia was carrying Tier 1-2 on five casualty figures

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -663,6 +663,26 @@ jobs:
             echo "error_count=0" >> $GITHUB_OUTPUT
           fi
 
+      - name: Check source tiers
+        # Zod cannot catch this: `tier` is a valid number whatever the source
+        # says. But the tier scale is the product's core promise, so a
+        # Wikipedia citation carrying tier 1 misrepresents the one thing
+        # readers are asked to trust.
+        #
+        # Non-blocking on purpose. This reports on data a model wrote
+        # overnight, and failing the nightly over a citation would be worse
+        # than the citation. It goes to the step summary where it is visible.
+        continue-on-error: true
+        run: |
+          npx tsx scripts/check-source-tiers.ts | tee /tmp/tiers.txt
+          {
+            echo "### Source tiers"
+            echo ""
+            echo '```'
+            cat /tmp/tiers.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Fix validation errors
         id: fix_agent
         if: steps.validate.outputs.valid == 'false' && steps.changes.outputs.changed == 'true'

--- a/scripts/check-source-tiers.ts
+++ b/scripts/check-source-tiers.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env tsx
+/**
+ * check-source-tiers.ts — flags data entries whose source does not support
+ * the tier they claim.
+ *
+ * The tier scale is this project's core promise: Tier 1 is official/primary,
+ * Tier 2 a major outlet, Tier 3 institutional, Tier 4 unverified. A Wikipedia
+ * citation carrying tier 1 misrepresents exactly the thing readers are asked
+ * to trust.
+ *
+ * Zod cannot catch this — `tier` is a valid number either way. It needs a
+ * semantic check, which is what this is.
+ *
+ * Exit code is 0 unless --strict is passed: this reports on data written by a
+ * model overnight, and failing the nightly over a citation would be worse than
+ * the citation.
+ *
+ * Usage:
+ *   npx tsx scripts/check-source-tiers.ts [--strict] [--json]
+ */
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const TRACKERS = join(ROOT, 'trackers');
+
+/**
+ * Sources that cannot carry a Tier 1-2 claim on their own.
+ *
+ * Wikipedia is tertiary by construction. The others are aggregators or
+ * user-generated: useful for finding a story, not for sourcing a figure at the
+ * top of the scale.
+ */
+const NOT_PRIMARY = [
+  'wikipedia', 'wikimedia', 'reddit', 'twitter.com', 'x.com',
+  'youtube', 'blogspot', 'medium.com', 'substack',
+];
+
+export interface TierFinding {
+  tracker: string;
+  file: string;
+  id: string;
+  tier: number;
+  source: string;
+  /** True when a primary-looking source is also cited, which is defensible. */
+  hasCompanion: boolean;
+}
+
+/** A source string is defensible at tier 1-2 if something else is cited too. */
+export function hasPrimaryCompanion(source: string): boolean {
+  // Compound citations like "UNAMA Quarterly Report / Pakistan ISPR / Wikipedia"
+  // carry a real primary source; the tier reflects that one.
+  const parts = source.split(/[/;,|]| and /i).map((p) => p.trim()).filter(Boolean);
+  const nonTertiary = parts.filter(
+    (p) => p.length > 2 && !NOT_PRIMARY.some((n) => p.toLowerCase().includes(n)),
+  );
+  return nonTertiary.length > 0;
+}
+
+export function checkEntry(
+  entry: Record<string, unknown>,
+  tracker: string,
+  file: string,
+): TierFinding | null {
+  const tier = entry.tier;
+  if (typeof tier !== 'number' || tier > 2) return null;
+  const source = `${entry.source ?? ''} ${JSON.stringify(entry.sources ?? '')}`;
+  if (!NOT_PRIMARY.some((n) => source.toLowerCase().includes(n))) return null;
+  return {
+    tracker,
+    file,
+    id: String(entry.id ?? entry.category ?? entry.label ?? '?'),
+    tier,
+    source: source.trim().slice(0, 120),
+    hasCompanion: hasPrimaryCompanion(source),
+  };
+}
+
+export function scanAll(trackersDir = TRACKERS): TierFinding[] {
+  const out: TierFinding[] = [];
+  if (!existsSync(trackersDir)) return out;
+  for (const slug of readdirSync(trackersDir)) {
+    const dataDir = join(trackersDir, slug, 'data');
+    if (!existsSync(dataDir)) continue;
+    for (const file of readdirSync(dataDir)) {
+      if (!file.endsWith('.json')) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(readFileSync(join(dataDir, file), 'utf-8'));
+      } catch {
+        continue;
+      }
+      if (!Array.isArray(parsed)) continue;
+      for (const entry of parsed) {
+        if (entry && typeof entry === 'object') {
+          const f = checkEntry(entry as Record<string, unknown>, slug, file);
+          if (f) out.push(f);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+function main(): void {
+  const strict = process.argv.includes('--strict');
+  const asJson = process.argv.includes('--json');
+  const findings = scanAll();
+  const bare = findings.filter((f) => !f.hasCompanion);
+
+  if (asJson) {
+    console.log(JSON.stringify({ total: findings.length, bare: bare.length, findings }, null, 2));
+  } else {
+    console.log(`[tiers] ${findings.length} entries cite a non-primary source at tier 1-2`);
+    console.log(`[tiers] ${bare.length} of those cite NOTHING else — the ones that matter`);
+    for (const f of bare.slice(0, 20)) {
+      console.log(`  ${f.tracker}/${f.file}  tier=${f.tier}  ${f.id}`);
+      console.log(`     ${f.source}`);
+    }
+  }
+  if (strict && bare.length > 0) process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/tests/source-tiers.test.ts
+++ b/tests/source-tiers.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { checkEntry, hasPrimaryCompanion, scanAll } from '../scripts/check-source-tiers';
+
+/**
+ * The tier scale is this project's core promise — Tier 1 official/primary,
+ * Tier 2 major outlet. A Wikipedia citation carrying tier 1 misrepresents
+ * exactly the thing readers are asked to trust, and Zod cannot catch it
+ * because `tier` is a valid number either way.
+ */
+describe('hasPrimaryCompanion', () => {
+  it('accepts a compound citation where something real is named', () => {
+    // The tier reflects UNAMA; Wikipedia is a convenience link.
+    expect(hasPrimaryCompanion('UNAMA Quarterly Report May 2026 / Pakistan ISPR / Wikipedia')).toBe(true);
+  });
+
+  it('rejects a citation that is only a tertiary source', () => {
+    expect(hasPrimaryCompanion('Wikipedia — 2026 Flores earthquake')).toBe(false);
+    expect(hasPrimaryCompanion('Wikipedia')).toBe(false);
+  });
+});
+
+describe('checkEntry', () => {
+  it('flags Wikipedia at tier 1', () => {
+    const f = checkEntry({ id: 'x', tier: 1, source: 'Wikipedia' }, 'demo', 'casualties.json');
+    expect(f).not.toBeNull();
+    expect(f!.hasCompanion).toBe(false);
+  });
+
+  it('ignores Wikipedia at tier 3, which is where it belongs', () => {
+    expect(checkEntry({ id: 'x', tier: 3, source: 'Wikipedia' }, 'demo', 'f.json')).toBeNull();
+  });
+
+  it('ignores a genuine primary source', () => {
+    expect(checkEntry({ id: 'x', tier: 1, source: 'UN OCHA Situation Report #33' }, 'demo', 'f.json')).toBeNull();
+  });
+
+  it('flags social platforms too, not just Wikipedia', () => {
+    expect(checkEntry({ id: 'x', tier: 2, source: 'a reddit thread' }, 'demo', 'f.json')).not.toBeNull();
+    expect(checkEntry({ id: 'x', tier: 2, source: 'posted on x.com' }, 'demo', 'f.json')).not.toBeNull();
+  });
+
+  it('does not throw on entries with no source at all', () => {
+    expect(checkEntry({ id: 'x', tier: 1 }, 'demo', 'f.json')).toBeNull();
+  });
+});
+
+describe('the repo itself', () => {
+  it('has no tier 1-2 entry sourced ONLY to a tertiary source', () => {
+    const bare = scanAll().filter((f) => !f.hasCompanion);
+    const detail = bare.map((f) => `${f.tracker}/${f.file}:${f.id} — ${f.source}`).join('\n');
+    expect(bare, `entries claiming tier 1-2 on a tertiary source alone:\n${detail}`).toEqual([]);
+  });
+});

--- a/trackers/indonesia-flores-earthquake/data/casualties.json
+++ b/trackers/indonesia-flores-earthquake/data/casualties.json
@@ -1,12 +1,112 @@
 [
-  { "id": "mainshock-total", "category": "Mainshock Fatalities & Injuries (All Regions)", "killed": "73", "injured": "1,182", "source": "BNPB", "tier": 1, "contested": "evolving", "note": "Toll rose steadily: 2 (15 Aug, CGTN) → 14 → 38 → 47 → 51 (16 Aug) → 54 (17 Aug) → 68 (17–18 Aug) → 70 (18–19 Aug) → 73 (19 Aug, Wikipedia/BNPB) as rescue teams reached remote villages.", "lastUpdated": "2026-08-20T04:15:00Z" },
-  { "id": "aftershock-ngada-casualties", "category": "17 Aug Aftershock (M5.7–5.8, Ngada Regency)", "killed": "2", "injured": "unknown", "source": "Open The Magazine", "tier": 4, "contested": "no", "note": "Aftershock-specific deaths, additive to the mainshock total.", "lastUpdated": "2026-08-20T04:15:00Z" },
-  { "id": "manggarai-regency-casualties", "category": "Manggarai Regency", "killed": "26", "injured": "unknown", "source": "Wikipedia — 2026 Flores earthquake", "tier": 2, "contested": "partial", "note": "Highest single-regency death toll; figure not yet broken down by injured count.", "lastUpdated": "2026-08-20T04:15:00Z" },
-  { "id": "east-manggarai-regency-casualties", "category": "East Manggarai Regency", "killed": "25", "injured": "unknown", "source": "Wikipedia — 2026 Flores earthquake", "tier": 2, "contested": "partial", "note": "Second-highest single-regency death toll, adjacent to Manggarai Regency.", "lastUpdated": "2026-08-20T04:15:00Z" },
-  { "id": "nagekeo-regency-casualties", "category": "Nagekeo Regency", "killed": "8", "injured": "unknown", "source": "Wikipedia — 2026 Flores earthquake", "tier": 2, "contested": "partial", "note": "Regency nearest the epicenter.", "lastUpdated": "2026-08-20T04:15:00Z" },
-  { "id": "combined-other-regencies-casualties", "category": "Sikka, Ende, Ngada & West Manggarai (combined)", "killed": "10", "injured": "unknown", "source": "Wikipedia — 2026 Flores earthquake", "tier": 2, "contested": "partial", "note": "Reported as an aggregate figure across four regencies rather than broken out individually.", "lastUpdated": "2026-08-20T04:15:00Z" },
-  { "id": "missing-persons-status", "category": "Missing / Unaccounted For", "killed": "0", "injured": "0", "source": "Local Basarnas/SAR officials", "tier": 1, "contested": "evolving", "note": "As of 18–19 Aug, local officials reported no further outstanding reports of people trapped or missing beneath rubble, though NGOs caution that 812 disabled cell sites may mask undercounting in cut-off hamlets.", "lastUpdated": "2026-08-20T04:15:00Z" },
-  { "id": "hospitalized-patients", "category": "Hospitalized / Evacuated Patients", "killed": "0", "injured": "20+", "source": "Wikipedia — 2026 Flores earthquake", "tier": 2, "contested": "no", "note": "Includes 15 patients + 5 infants treated in tents at Ende Regional Hospital and surgical patients evacuated after Ruteng's operating theatre was destroyed.", "lastUpdated": "2026-08-20T04:15:00Z" },
-  { "id": "tourists-evacuated-padar", "category": "Tourists Evacuated (Padar Island)", "killed": "0", "injured": "0", "source": "ANTARA News", "tier": 2, "contested": "no", "note": "986 tourists evacuated to Labuan Bajo; no injuries reported among the tourist population.", "lastUpdated": "2026-08-20T04:15:00Z" },
-  { "id": "independence-day-snapshot", "category": "Cumulative Toll Snapshot — Independence Day (17 Aug)", "killed": "54", "injured": "unknown", "source": "CBS News", "tier": 2, "contested": "evolving", "note": "Point-in-time figure preserved for reference; superseded by later BNPB updates as recovery operations continued.", "lastUpdated": "2026-08-20T04:15:00Z" }
+  {
+    "id": "mainshock-total",
+    "category": "Mainshock Fatalities & Injuries (All Regions)",
+    "killed": "73",
+    "injured": "1,182",
+    "source": "BNPB",
+    "tier": 1,
+    "contested": "evolving",
+    "note": "Toll rose steadily: 2 (15 Aug, CGTN) → 14 → 38 → 47 → 51 (16 Aug) → 54 (17 Aug) → 68 (17–18 Aug) → 70 (18–19 Aug) → 73 (19 Aug, Wikipedia/BNPB) as rescue teams reached remote villages.",
+    "lastUpdated": "2026-08-20T04:15:00Z"
+  },
+  {
+    "id": "aftershock-ngada-casualties",
+    "category": "17 Aug Aftershock (M5.7–5.8, Ngada Regency)",
+    "killed": "2",
+    "injured": "unknown",
+    "source": "Open The Magazine",
+    "tier": 4,
+    "contested": "no",
+    "note": "Aftershock-specific deaths, additive to the mainshock total.",
+    "lastUpdated": "2026-08-20T04:15:00Z"
+  },
+  {
+    "id": "manggarai-regency-casualties",
+    "category": "Manggarai Regency",
+    "killed": "26",
+    "injured": "unknown",
+    "source": "Wikipedia — 2026 Flores earthquake",
+    "tier": 3,
+    "contested": "partial",
+    "note": "Highest single-regency death toll; figure not yet broken down by injured count.",
+    "lastUpdated": "2026-08-20T04:15:00Z"
+  },
+  {
+    "id": "east-manggarai-regency-casualties",
+    "category": "East Manggarai Regency",
+    "killed": "25",
+    "injured": "unknown",
+    "source": "Wikipedia — 2026 Flores earthquake",
+    "tier": 3,
+    "contested": "partial",
+    "note": "Second-highest single-regency death toll, adjacent to Manggarai Regency.",
+    "lastUpdated": "2026-08-20T04:15:00Z"
+  },
+  {
+    "id": "nagekeo-regency-casualties",
+    "category": "Nagekeo Regency",
+    "killed": "8",
+    "injured": "unknown",
+    "source": "Wikipedia — 2026 Flores earthquake",
+    "tier": 3,
+    "contested": "partial",
+    "note": "Regency nearest the epicenter.",
+    "lastUpdated": "2026-08-20T04:15:00Z"
+  },
+  {
+    "id": "combined-other-regencies-casualties",
+    "category": "Sikka, Ende, Ngada & West Manggarai (combined)",
+    "killed": "10",
+    "injured": "unknown",
+    "source": "Wikipedia — 2026 Flores earthquake",
+    "tier": 3,
+    "contested": "partial",
+    "note": "Reported as an aggregate figure across four regencies rather than broken out individually.",
+    "lastUpdated": "2026-08-20T04:15:00Z"
+  },
+  {
+    "id": "missing-persons-status",
+    "category": "Missing / Unaccounted For",
+    "killed": "0",
+    "injured": "0",
+    "source": "Local Basarnas/SAR officials",
+    "tier": 1,
+    "contested": "evolving",
+    "note": "As of 18–19 Aug, local officials reported no further outstanding reports of people trapped or missing beneath rubble, though NGOs caution that 812 disabled cell sites may mask undercounting in cut-off hamlets.",
+    "lastUpdated": "2026-08-20T04:15:00Z"
+  },
+  {
+    "id": "hospitalized-patients",
+    "category": "Hospitalized / Evacuated Patients",
+    "killed": "0",
+    "injured": "20+",
+    "source": "Wikipedia — 2026 Flores earthquake",
+    "tier": 3,
+    "contested": "no",
+    "note": "Includes 15 patients + 5 infants treated in tents at Ende Regional Hospital and surgical patients evacuated after Ruteng's operating theatre was destroyed.",
+    "lastUpdated": "2026-08-20T04:15:00Z"
+  },
+  {
+    "id": "tourists-evacuated-padar",
+    "category": "Tourists Evacuated (Padar Island)",
+    "killed": "0",
+    "injured": "0",
+    "source": "ANTARA News",
+    "tier": 2,
+    "contested": "no",
+    "note": "986 tourists evacuated to Labuan Bajo; no injuries reported among the tourist population.",
+    "lastUpdated": "2026-08-20T04:15:00Z"
+  },
+  {
+    "id": "independence-day-snapshot",
+    "category": "Cumulative Toll Snapshot — Independence Day (17 Aug)",
+    "killed": "54",
+    "injured": "unknown",
+    "source": "CBS News",
+    "tier": 2,
+    "contested": "evolving",
+    "note": "Point-in-time figure preserved for reference; superseded by later BNPB updates as recovery operations continued.",
+    "lastUpdated": "2026-08-20T04:15:00Z"
+  }
 ]


### PR DESCRIPTION
Closes #240.

The tier scale is this project's core promise — Tier 1 official/primary, Tier 2 major outlet. A Wikipedia citation at Tier 2 misrepresents the one thing readers are asked to trust, and **Zod cannot catch it**: `tier` is a valid number whatever the source says.

## The count in the issue was misleading, including mine

A scan found 13 entries citing a non-primary source at tier 1-2. But eight are compound citations:

```
"UNAMA Quarterly Report May 2026 / Pakistan ISPR / Wikipedia"
```

The tier reflects a real primary source; Wikipedia is a convenience link. Those are defensible.

**Five were not** — all in the newly seeded Flores tracker, sourced to `"Wikipedia — 2026 Flores earthquake"` and nothing else, at tier 2. Reclassified to tier 3.

```
before   13 entries flagged,  5 citing nothing else
after    8 entries flagged,   0 citing nothing else
```

## The guard

`check-source-tiers.ts` makes that distinction rather than counting every mention, so it does not cry wolf on compound citations. A repo-wide test asserts no tier 1-2 entry rests on a tertiary source alone.

Wired into the nightly finalize phase, **non-blocking**: this reports on data a model wrote overnight, and failing the nightly over a citation would be worse than the citation. It lands in the step summary where it is visible.

Also catches reddit, x.com, youtube and substack — seeds will reach for whatever is at hand, and Wikipedia was just the first one to show up.

274 tests passing.