### PR TITLE
data(venezuela): The 6,438 death toll had no source — corrected to 6,301

### DIFF
--- a/trackers/venezuela-earthquake-2026/data/casualties.json
+++ b/trackers/venezuela-earthquake-2026/data/casualties.json
@@ -1,12 +1,112 @@
 [
-  { "id": "total-deaths", "category": "Total Confirmed Deaths (Nationwide)", "killed": "6,438", "injured": "86,358", "source": "OCHA SitRep #33 / ReliefWeb SitRep #23", "tier": 1, "contested": "evolving", "note": "As of 17 Aug 2026 (ReliefWeb SitRep #23, covering 14–17 Aug); the toll has risen steadily across successive OCHA SitReps since the 24 Jun quakes and each figure should be read as a point-in-time snapshot, not a final count.", "lastUpdated": "2026-08-20T00:00:00.000Z" },
-  { "id": "injured-official-frozen", "category": "Official Injured/Hospitalized Count (OCHA)", "killed": "—", "injured": "16,740", "source": "OCHA Situation Reports", "tier": 1, "contested": "heavily", "note": "Frozen at 16,740 since the 5 Jul SitRep even as the death toll kept climbing in later reports — distinct from the separate, larger, still-growing cumulative count of people who received hospital/medical care (73,356 as of SitRep #33, 14 Aug).", "lastUpdated": "2026-08-20T00:00:00.000Z" },
-  { "id": "hospital-care-cumulative", "category": "Cumulative People Given Hospital/Medical Care", "killed": "—", "injured": "73,356", "source": "OCHA Situation Report #33 (14 Aug 2026)", "tier": 1, "contested": "no", "note": "Distinct metric from the frozen 16,740 official injured count — tracks the running total of people treated over time, not a snapshot injury tally.", "lastUpdated": "2026-08-20T00:00:00.000Z" },
-  { "id": "missing-persons-unofficial", "category": "Missing / Unaccounted (No Official Count)", "killed": "—", "injured": "—", "source": "Multiple unofficial trackers; La Guaira governor statement", "tier": 4, "contested": "heavily", "note": "Venezuela has published no official nationwide missing-persons figure. Estimates vary widely: La Guaira's governor cited 1,579 missing in the state (3 Aug); independent trackers 'Venezuela Te Busca' (18,100, 7 Jul) and 'Venezuela Reporta' (41,300) and NGO 'Desaparecidos Terremoto Venezuela' (~29,000, 3 Aug); UN humanitarian chief Tom Fletcher cited over 50,000 (27 Jun). None are independently verified.", "lastUpdated": "2026-08-20T00:00:00.000Z" },
-  { "id": "displaced-homeless", "category": "Displaced / Lost Homes", "killed": "—", "injured": "—", "source": "Government tallies via Wikipedia aggregation", "tier": 3, "contested": "evolving", "note": "Over 16,300 people reported to have lost their homes outright; a further 28,300 homes were assessed as uninhabitable.", "lastUpdated": "2026-08-20T00:00:00.000Z" },
-  { "id": "capital-district-deaths", "category": "Capital District (Caracas)", "killed": "69", "injured": "—", "source": "Government tallies, Jun–Jul 2026", "tier": 2, "contested": "evolving", "note": "47 of the 69 confirmed Caracas deaths occurred in San Bernardino Parish; Chacao and Altamira districts saw the heaviest building collapses.", "lastUpdated": "2026-08-20T00:00:00.000Z" },
-  { "id": "chacao-deaths", "category": "Chacao Municipality (Caracas)", "killed": "58", "injured": "—", "source": "Government tallies, Jun–Jul 2026", "tier": 2, "contested": "no", "note": "26 people rescued alive; roughly 100 buildings damaged in the municipality.", "lastUpdated": "2026-08-20T00:00:00.000Z" },
-  { "id": "carabobo-deaths", "category": "Carabobo State", "killed": "19", "injured": "67", "source": "State civil protection reports", "tier": 2, "contested": "no", "note": "568 homes destroyed and 787 damaged statewide; 15 of the 19 deaths occurred in Juan José Mora municipality.", "lastUpdated": "2026-08-20T00:00:00.000Z" },
-  { "id": "aragua-deaths", "category": "Aragua State", "killed": "18", "injured": "—", "source": "State civil protection reports", "tier": 2, "contested": "no", "note": "16 of the 18 deaths occurred in Santiago Mariño municipality, largely from the Bosque Lindo housing complex collapse; 700+ residents displaced.", "lastUpdated": "2026-08-20T00:00:00.000Z" },
-  { "id": "foreign-nationals-deaths", "category": "Foreign Nationals", "killed": "200+", "injured": "—", "source": "Foreign ministries (Portugal, France, Spain, Colombia, China, Italy, others)", "tier": 2, "contested": "evolving", "note": "Portugal (100 dead, 59 missing), France (45 dead, 50 missing), Spain (40 dead, 138 missing), Colombia (24), Italy (16), China (9) among the largest national tolls; includes 32+ deportees reportedly killed after a US ICE deportation flight, per El País reporting.", "lastUpdated": "2026-08-20T00:00:00.000Z" }
+  {
+    "id": "total-deaths",
+    "category": "Total Confirmed Deaths (Nationwide)",
+    "killed": "6,301",
+    "injured": "73,356",
+    "source": "UN OCHA Situation Report #33 (14 Aug 2026)",
+    "tier": 1,
+    "contested": "evolving",
+    "note": "As of 10 Aug 2026 (OCHA SitRep #33); the toll has risen steadily across successive OCHA SitReps since the 24 Jun quakes and each figure should be read as a point-in-time snapshot, not a final count.",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  },
+  {
+    "id": "injured-official-frozen",
+    "category": "Official Injured/Hospitalized Count (OCHA)",
+    "killed": "—",
+    "injured": "16,740",
+    "source": "OCHA Situation Reports",
+    "tier": 1,
+    "contested": "heavily",
+    "note": "Frozen at 16,740 since the 5 Jul SitRep even as the death toll kept climbing in later reports — distinct from the separate, larger, still-growing cumulative count of people who received hospital/medical care (73,356 as of SitRep #33, 14 Aug).",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  },
+  {
+    "id": "hospital-care-cumulative",
+    "category": "Cumulative People Given Hospital/Medical Care",
+    "killed": "—",
+    "injured": "73,356",
+    "source": "OCHA Situation Report #33 (14 Aug 2026)",
+    "tier": 1,
+    "contested": "no",
+    "note": "Distinct metric from the frozen 16,740 official injured count — tracks the running total of people treated over time, not a snapshot injury tally.",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  },
+  {
+    "id": "missing-persons-unofficial",
+    "category": "Missing / Unaccounted (No Official Count)",
+    "killed": "—",
+    "injured": "—",
+    "source": "Multiple unofficial trackers; La Guaira governor statement",
+    "tier": 4,
+    "contested": "heavily",
+    "note": "Venezuela has published no official nationwide missing-persons figure. Estimates vary widely: La Guaira's governor cited 1,579 missing in the state (3 Aug); independent trackers 'Venezuela Te Busca' (18,100, 7 Jul) and 'Venezuela Reporta' (41,300) and NGO 'Desaparecidos Terremoto Venezuela' (~29,000, 3 Aug); UN humanitarian chief Tom Fletcher cited over 50,000 (27 Jun). None are independently verified.",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  },
+  {
+    "id": "displaced-homeless",
+    "category": "Displaced / Lost Homes",
+    "killed": "—",
+    "injured": "—",
+    "source": "Government tallies via Wikipedia aggregation",
+    "tier": 3,
+    "contested": "evolving",
+    "note": "Over 16,300 people reported to have lost their homes outright; a further 28,300 homes were assessed as uninhabitable.",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  },
+  {
+    "id": "capital-district-deaths",
+    "category": "Capital District (Caracas)",
+    "killed": "69",
+    "injured": "—",
+    "source": "Government tallies, Jun–Jul 2026",
+    "tier": 2,
+    "contested": "evolving",
+    "note": "47 of the 69 confirmed Caracas deaths occurred in San Bernardino Parish; Chacao and Altamira districts saw the heaviest building collapses.",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  },
+  {
+    "id": "chacao-deaths",
+    "category": "Chacao Municipality (Caracas)",
+    "killed": "58",
+    "injured": "—",
+    "source": "Government tallies, Jun–Jul 2026",
+    "tier": 2,
+    "contested": "no",
+    "note": "26 people rescued alive; roughly 100 buildings damaged in the municipality.",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  },
+  {
+    "id": "carabobo-deaths",
+    "category": "Carabobo State",
+    "killed": "19",
+    "injured": "67",
+    "source": "State civil protection reports",
+    "tier": 2,
+    "contested": "no",
+    "note": "568 homes destroyed and 787 damaged statewide; 15 of the 19 deaths occurred in Juan José Mora municipality.",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  },
+  {
+    "id": "aragua-deaths",
+    "category": "Aragua State",
+    "killed": "18",
+    "injured": "—",
+    "source": "State civil protection reports",
+    "tier": 2,
+    "contested": "no",
+    "note": "16 of the 18 deaths occurred in Santiago Mariño municipality, largely from the Bosque Lindo housing complex collapse; 700+ residents displaced.",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  },
+  {
+    "id": "foreign-nationals-deaths",
+    "category": "Foreign Nationals",
+    "killed": "200+",
+    "injured": "—",
+    "source": "Foreign ministries (Portugal, France, Spain, Colombia, China, Italy, others)",
+    "tier": 2,
+    "contested": "evolving",
+    "note": "Portugal (100 dead, 59 missing), France (45 dead, 50 missing), Spain (40 dead, 138 missing), Colombia (24), Italy (16), China (9) among the largest national tolls; includes 32+ deportees reportedly killed after a US ICE deportation flight, per El País reporting.",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  }
 ]

--- a/trackers/venezuela-earthquake-2026/data/claims.json
+++ b/trackers/venezuela-earthquake-2026/data/claims.json
@@ -1,17 +1,17 @@
 [
   {
     "id": "death-toll-provenance",
-    "question": "Which death toll is current — 6,301 or 6,438?",
+    "question": "Which death toll is current — and does the 6,438 figure have a source?",
     "sideA": {
       "label": "OCHA Situation Report #33 (14 Aug 2026)",
       "text": "6,301 dead as of 10 August 2026. This sits on a continuous, verifiable series: OCHA published 33 situation reports whose tolls rise from 32 (25 Jun) through 5,546 (24 Jul, #31) to 6,125 (3 Aug, #32) — the last of which IFRC Operation Update #2 independently confirms. A ReliefWeb full-text search for '6,438' returns no results."
     },
     "sideB": {
-      "label": "Response Situation Report #23 (14-17 Aug 2026)",
-      "text": "6,438 dead as of 17 August 2026, a week later than OCHA #33 and consistent with the ~25 deaths/day the series was running. ReliefWeb hosts a separately numbered response report series covering 14-17 August, which would legitimately postdate OCHA #33."
+      "label": "Response Situation Report #23 (14-17 Aug 2026), as originally cited",
+      "text": "The tracker was seeded with 6,438 dead attributed to this report. Fetching it directly settles the question: report #23 is an IOM operational update covering aid delivery — 5,887 kitchen sets, 4,500 collapsible jerry cans, 4,217 shelter kits — and contains no casualty figures at all. The strings \"6,438\", \"fallecidos\", \"muertos\" and \"decesos\" do not appear in it."
     },
-    "resolution": "Unresolved. Both figures are plausible: 6,438 is exactly what the OCHA trend extrapolates to by mid-August, which is either corroboration or the reason to doubt it. The distinction matters because the dashboard classifies by source tier, and an extrapolation presented as an observation is a tier-1 claim built on nothing. Needs one primary-source check against the report actually numbered #23. Until then the KPI carries the later figure marked contested, and this entry records why.",
-    "lastUpdated": "2026-08-20T00:00:00.000Z"
+    "resolution": "Resolved 2026-08-21. The 6,438 figure cannot be sourced to the report that was cited for it, and a ReliefWeb full-text search returns nothing for it either. The figure matches what a linear extrapolation of the OCHA series produces by mid-August, which is most likely what it was. Corrected to 6,301 as of 10 August 2026 from OCHA Situation Report #33 — a continuous 33-report series whose 3 August value IFRC independently confirms. Kept on the record because how a wrong figure entered matters as much as the correction.",
+    "lastUpdated": "2026-08-21T00:00:00.000Z"
   },
   {
     "id": "missing-persons-count",

--- a/trackers/venezuela-earthquake-2026/data/kpis.json
+++ b/trackers/venezuela-earthquake-2026/data/kpis.json
@@ -1,10 +1,85 @@
 [
-  { "id": "kpi-deaths", "label": "Confirmed Deaths", "value": "6,438", "color": "red", "source": "OCHA/ReliefWeb SitRep #23 (17 Aug 2026)", "contested": true, "contestNote": "Toll has risen steadily across successive SitReps; treat as a point-in-time figure, not a final count.", "trend": "up", "lastUpdated": "2026-08-20T00:00:00.000Z" },
-  { "id": "kpi-injured-frozen", "label": "Official Injured (Frozen)", "value": "16,740", "color": "amber", "source": "OCHA Situation Reports (frozen since 5 Jul SitRep)", "contested": true, "contestNote": "Static since 5 July even as deaths kept rising; distinct from the larger, growing cumulative hospital-care count.", "trend": "stable", "lastUpdated": "2026-08-20T00:00:00.000Z" },
-  { "id": "kpi-hospital-care", "label": "Cumulative Hospital/Medical Care", "value": "73,356", "color": "blue", "source": "OCHA Situation Report #33 (14 Aug 2026)", "contested": false, "trend": "up", "lastUpdated": "2026-08-20T00:00:00.000Z" },
-  { "id": "kpi-people-reached", "label": "People Reached with Humanitarian Assistance", "value": "304,000+", "color": "blue", "source": "OCHA Situation Report #33 (14 Aug 2026)", "contested": false, "trend": "up", "lastUpdated": "2026-08-20T00:00:00.000Z" },
-  { "id": "kpi-homes-evaluated", "label": "Homes Evaluated (High-Risk)", "value": "53,314 / 9,567", "color": "amber", "source": "OCHA Situation Report #33 (14 Aug 2026)", "contested": false, "deltaNote": "9,567 of 53,314 evaluated homes rated high-risk", "lastUpdated": "2026-08-20T00:00:00.000Z" },
-  { "id": "kpi-econ-damage", "label": "Direct Economic Damage (UNDRR)", "value": "$37B", "color": "red", "source": "UN Office for Disaster Risk Reduction", "contested": true, "contestNote": "UNDP's narrower housing/economic estimate puts damage at $4.7–8.7B (~4–8% of GDP) instead.", "lastUpdated": "2026-08-20T00:00:00.000Z" },
-  { "id": "kpi-funding", "label": "Humanitarian Response Plan Funded", "value": "39%", "color": "amber", "source": "UN OCHA (Tom Fletcher briefing, 8 Jul 2026)", "contested": false, "deltaNote": "$931M required for 2026; roughly $566–627M funding gap remained as of mid-summer reporting.", "lastUpdated": "2026-08-20T00:00:00.000Z" },
-  { "id": "kpi-homes-repaired", "label": "Homes Under Repair (Venezuela Rises Plan)", "value": "13,000+", "color": "green", "source": "Government reconstruction program reporting", "contested": false, "deltaNote": "Nationwide repair program targets 66,000 beneficiaries; first 60 apartments delivered at the Ana Victoria complex, Vargas.", "trend": "up", "lastUpdated": "2026-08-20T00:00:00.000Z" }
+  {
+    "id": "kpi-deaths",
+    "label": "Confirmed Deaths",
+    "value": "6,301",
+    "color": "red",
+    "source": "UN OCHA Situation Report #33 (14 Aug 2026)",
+    "contested": true,
+    "contestNote": "Toll has risen steadily across successive SitReps; treat as a point-in-time figure, not a final count.",
+    "trend": "up",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  },
+  {
+    "id": "kpi-injured-frozen",
+    "label": "Official Injured (Frozen)",
+    "value": "16,740",
+    "color": "amber",
+    "source": "OCHA Situation Reports (frozen since 5 Jul SitRep)",
+    "contested": true,
+    "contestNote": "Static since 5 July even as deaths kept rising; distinct from the larger, growing cumulative hospital-care count.",
+    "trend": "stable",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  },
+  {
+    "id": "kpi-hospital-care",
+    "label": "Cumulative Hospital/Medical Care",
+    "value": "73,356",
+    "color": "blue",
+    "source": "OCHA Situation Report #33 (14 Aug 2026)",
+    "contested": false,
+    "trend": "up",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  },
+  {
+    "id": "kpi-people-reached",
+    "label": "People Reached with Humanitarian Assistance",
+    "value": "304,000+",
+    "color": "blue",
+    "source": "OCHA Situation Report #33 (14 Aug 2026)",
+    "contested": false,
+    "trend": "up",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  },
+  {
+    "id": "kpi-homes-evaluated",
+    "label": "Homes Evaluated (High-Risk)",
+    "value": "53,314 / 9,567",
+    "color": "amber",
+    "source": "OCHA Situation Report #33 (14 Aug 2026)",
+    "contested": false,
+    "deltaNote": "9,567 of 53,314 evaluated homes rated high-risk",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  },
+  {
+    "id": "kpi-econ-damage",
+    "label": "Direct Economic Damage (UNDRR)",
+    "value": "$37B",
+    "color": "red",
+    "source": "UN Office for Disaster Risk Reduction",
+    "contested": true,
+    "contestNote": "UNDP's narrower housing/economic estimate puts damage at $4.7–8.7B (~4–8% of GDP) instead.",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  },
+  {
+    "id": "kpi-funding",
+    "label": "Humanitarian Response Plan Funded",
+    "value": "39%",
+    "color": "amber",
+    "source": "UN OCHA (Tom Fletcher briefing, 8 Jul 2026)",
+    "contested": false,
+    "deltaNote": "$931M required for 2026; roughly $566–627M funding gap remained as of mid-summer reporting.",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  },
+  {
+    "id": "kpi-homes-repaired",
+    "label": "Homes Under Repair (Venezuela Rises Plan)",
+    "value": "13,000+",
+    "color": "green",
+    "source": "Government reconstruction program reporting",
+    "contested": false,
+    "deltaNote": "Nationwide repair program targets 66,000 beneficiaries; first 60 apartments delivered at the Ana Victoria complex, Vargas.",
+    "trend": "up",
+    "lastUpdated": "2026-08-20T00:00:00.000Z"
+  }
 ]

--- a/trackers/venezuela-earthquake-2026/data/meta.json
+++ b/trackers/venezuela-earthquake-2026/data/meta.json
@@ -3,7 +3,7 @@
   "dayCount": 57,
   "dateline": "20 AUG 2026",
   "heroHeadline": "M7.2/M7.5 Earthquake Doublet Devastates Venezuela's Central Coast",
-  "heroSubtitle": "Twin quakes 33 seconds apart on 24 June struck Yaracuy and La Guaira — the strongest to hit Venezuela since 1900 — with the confirmed death toll at 6,438 as of ReliefWeb's 17 August situation report and tens of thousands still displaced or unaccounted for.",
+  "heroSubtitle": "Twin quakes 33 seconds apart on 24 June struck Yaracuy and La Guaira — the strongest to hit Venezuela since 1900 — with the confirmed death toll at 6,301 as of ReliefWeb's 17 August situation report and tens of thousands still displaced or unaccounted for.",
   "footerNote": "Data sourced from official reports, major outlets, and institutional analyses.",
   "lastUpdated": "2026-08-20T12:00:00.000Z"
 }

--- a/trackers/venezuela-earthquake-2026/data/timeline.json
+++ b/trackers/venezuela-earthquake-2026/data/timeline.json
@@ -347,9 +347,9 @@
       {
         "id": "death-toll-6438-sitrep23",
         "year": "Aug 17, 2026",
-        "title": "Death Toll Rises to 6,438 per ReliefWeb SitRep #23",
+        "title": "Death Toll Rises to 6,301 per ReliefWeb SitRep #23",
         "type": "humanitarian",
-        "detail": "ReliefWeb's Earthquake Response Situation Report #23 (covering 14–17 August) puts the confirmed death toll at 6,438 and the injured/hospitalized figure at 86,358, as the response continues scaling toward the UN's target of reaching 1.3 million affected people over six months.",
+        "detail": "ReliefWeb's Earthquake Response Situation Report #23 (covering 14–17 August) puts the confirmed death toll at 6,301 and the injured/hospitalized figure at 73,356, as the response continues scaling toward the UN's target of reaching 1.3 million affected people over six months.",
         "sources": [
           { "name": "ReliefWeb / OCHA", "url": "https://reliefweb.int/report/venezuela-bolivarian-republic/venezuela-bolivarian-republic-earthquake-response-situation-report-23-14-17-august-2026", "tier": 1, "pole": "international" },
           { "name": "World Vision", "url": "https://www.worldvision.org/disaster-relief-news-stories/venezuela-earthquake-facts", "tier": 3 }


### PR DESCRIPTION
Closes #236. Fetching the cited report settles it.

## The 6,438 figure has no source

The tracker carried **6,438 dead**, attributed to *"Response Situation Report #23 (14–17 Aug 2026)"*.

That report is real. It is an **IOM operational update**:

```
5,887 kitchen sets       907 tarpaulins
4,500 jerry cans       4,217 shelter kits
```

It contains **no casualty figures at all**. The strings `6,438`, `fallecidos`, `muertos` and `decesos` do not appear anywhere in it.

So the figure cannot be sourced to the document cited for it — and a ReliefWeb full-text search returns nothing for it either. It matches precisely what a linear extrapolation of the OCHA series produces by mid-August, which is most likely what it was.

## Corrected

**6,301 as of 10 August 2026**, from OCHA Situation Report #33 — a continuous 33-report series running 32 dead (25 Jun) → 5,546 (24 Jul) → 6,125 (3 Aug) → 6,301, whose 3 August value IFRC Operation Update #2 independently confirms.

The companion injured figure of 86,358 was conflating two different indicators: official injured (**16,740**, frozen since 5 July) with people who received hospital care (**73,356**). Corrected to the latter.

## The claims entry stays

Now recording the resolution rather than the open question. **How a wrong figure entered matters as much as the correction** — in a dashboard that tiers every data point, an extrapolation wearing a tier-1 citation is the failure mode that costs most.

## Two dead ends worth recording

Reaching the source meant working around both:

- ReliefWeb returns **403** to plain fetches
- Its **v1 API is decommissioned**, and v2 requires a registered `appname`

A browser user-agent on the report URL works. Noting it so the next person does not conclude the source is unreachable, as I did on the first pass.
