### PR TITLE
security(csp): Remove 'unsafe-inline' via per-page script hashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check": "astro check",
     "generate-api": "tsx scripts/generate-api.ts",
     "build": "npm run generate-api && npm run copy-cesium && astro build",
-    "postbuild": "npx pagefind --site dist --glob '**/*.html'",
+    "postbuild": "npx pagefind --site dist --glob '**/*.html' && npx tsx scripts/csp-hashes.ts",
     "preview": "astro preview",
     "update-data": "tsx scripts/update-data.ts",
     "validate-data": "tsx scripts/validate-tracker-data.ts",

--- a/scripts/csp-hashes.ts
+++ b/scripts/csp-hashes.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env tsx
+/**
+ * csp-hashes.ts — replaces 'unsafe-inline' with per-page SHA-256 hashes.
+ *
+ * `'unsafe-inline'` is the hole that makes the rest of the policy decorative:
+ * an injected inline script executes regardless of every allowlist around it.
+ *
+ * Astro can do this itself, but not here. Its CSP support landed in **v6** and
+ * covers only on-demand pages — "these features only exist for pages rendered
+ * on demand using server mode, or pages that opt out of prerendering". This
+ * site is Astro 5.18 with `output: 'static'` on GitHub Pages, which is static
+ * by definition. Nonces are impossible for the same reason: a nonce must be
+ * unique per request, and these pages are files.
+ *
+ * Hashes work on static output, which is what this does. Each page gets the
+ * hashes of its own inline scripts, because pages differ.
+ *
+ * Run after `astro build`. Idempotent — a page already carrying hashes and no
+ * 'unsafe-inline' is left alone.
+ *
+ * Usage:
+ *   npx tsx scripts/csp-hashes.ts [dist] [--dry-run]
+ */
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Matches every <script> element and captures its attributes and body. */
+const SCRIPT_RE = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+
+export function sha256Base64(body: string): string {
+  return createHash('sha256').update(body, 'utf8').digest('base64');
+}
+
+/**
+ * Hashes of every inline script in the document.
+ *
+ * Scripts with a `src` are covered by the host allowlist and must NOT be
+ * hashed — a hash on an external script is meaningless and CSP ignores it.
+ * JSON-LD blocks ARE hashed: CSP treats `application/ld+json` as a script
+ * element, so leaving them out breaks structured data the moment
+ * 'unsafe-inline' goes away. That is easy to miss and silently costs SEO.
+ */
+export function collectHashes(html: string): string[] {
+  const hashes = new Set<string>();
+  for (const m of html.matchAll(SCRIPT_RE)) {
+    const attrs = m[1] ?? '';
+    const body = m[2] ?? '';
+    if (/\bsrc\s*=/.test(attrs)) continue;
+    if (body.trim().length === 0) continue;
+    hashes.add(`'sha256-${sha256Base64(body)}'`);
+  }
+  return [...hashes];
+}
+
+/** Rewrites the page's CSP meta: drops 'unsafe-inline', adds the hashes. */
+export function rewriteCsp(html: string, hashes: string[]): { html: string; changed: boolean } {
+  const metaRe = /(<meta\s+http-equiv="Content-Security-Policy"\s+content=")([^"]*)(")/i;
+  const m = html.match(metaRe);
+  if (!m) return { html, changed: false };
+
+  const policy = m[2];
+  const directives = policy.split(';').map((d) => d.trim()).filter(Boolean);
+  let touched = false;
+
+  const next = directives.map((d) => {
+    if (!d.startsWith('script-src')) return d;
+    const parts = d.split(/\s+/).filter((p) => p !== "'unsafe-inline'" && !p.startsWith("'sha256-"));
+    touched = true;
+    return [...parts, ...hashes].join(' ');
+  });
+
+  if (!touched) return { html, changed: false };
+  return { html: html.replace(metaRe, `$1${next.join('; ')}$3`), changed: true };
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (p.endsWith('.html')) out.push(p);
+  }
+  return out;
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const dist = resolve(args.find((a) => !a.startsWith('--')) ?? join(ROOT, 'dist'));
+
+  const files = walk(dist);
+  let rewritten = 0;
+  let totalHashes = 0;
+  let noMeta = 0;
+
+  for (const file of files) {
+    const html = readFileSync(file, 'utf-8');
+    const hashes = collectHashes(html);
+    const { html: next, changed } = rewriteCsp(html, hashes);
+    if (!changed) { noMeta++; continue; }
+    totalHashes += hashes.length;
+    rewritten++;
+    if (!dryRun) writeFileSync(file, next);
+  }
+
+  console.log(`[csp] ${files.length} pages scanned`);
+  console.log(`[csp] ${rewritten} rewritten, ${totalHashes} script hashes total`);
+  if (noMeta) console.log(`[csp] ${noMeta} without a CSP meta tag (left alone)`);
+  if (dryRun) console.log('[csp] dry run — nothing written');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/tests/csp-hashes.test.ts
+++ b/tests/csp-hashes.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { collectHashes, rewriteCsp, sha256Base64 } from '../scripts/csp-hashes';
+
+/**
+ * `'unsafe-inline'` is the hole that makes the rest of the policy decorative:
+ * an injected inline script executes regardless of every allowlist around it.
+ *
+ * Astro cannot do this here — its CSP support is v6 and covers only on-demand
+ * pages, while this site is 5.18 with `output: 'static'` on GitHub Pages.
+ * Nonces are impossible for the same reason: a nonce must be unique per
+ * request, and these pages are files. Hashes are what works on static output.
+ */
+const CSP = `<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.example; style-src 'self' 'unsafe-inline'">`;
+
+describe('collectHashes', () => {
+  it('hashes an inline script', () => {
+    const html = `${CSP}<script>console.log(1)</script>`;
+    expect(collectHashes(html)).toEqual([`'sha256-${sha256Base64('console.log(1)')}'`]);
+  });
+
+  it('skips scripts with src — a hash there is meaningless and CSP ignores it', () => {
+    expect(collectHashes(`<script src="/app.js"></script>`)).toEqual([]);
+  });
+
+  it('DOES hash JSON-LD, which CSP treats as a script element', () => {
+    // Missing this silently breaks structured data the moment 'unsafe-inline'
+    // is removed, and costs SEO without any visible error.
+    const html = `<script type="application/ld+json">{"a":1}</script>`;
+    expect(collectHashes(html)).toEqual([`'sha256-${sha256Base64('{"a":1}')}'`]);
+  });
+
+  it('deduplicates identical scripts', () => {
+    const html = `<script>x()</script><script>x()</script>`;
+    expect(collectHashes(html)).toHaveLength(1);
+  });
+
+  it('ignores empty script tags', () => {
+    expect(collectHashes(`<script></script><script>   </script>`)).toEqual([]);
+  });
+
+  it('is whitespace-exact, because the browser hashes the body verbatim', () => {
+    expect(sha256Base64('a()')).not.toBe(sha256Base64('a() '));
+  });
+});
+
+describe('rewriteCsp', () => {
+  it('removes unsafe-inline and adds the hashes to script-src only', () => {
+    const { html, changed } = rewriteCsp(CSP, ["'sha256-abc'"]);
+    expect(changed).toBe(true);
+    const policy = html.match(/content="([^"]*)"/)![1];
+    const scriptSrc = policy.split(';').find((d) => d.trim().startsWith('script-src'))!;
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+    expect(scriptSrc).toContain("'sha256-abc'");
+    expect(scriptSrc).toContain('https://cdn.example');
+    // style-src keeps its own unsafe-inline: this only governs scripts.
+    expect(policy).toContain("style-src 'self' 'unsafe-inline'");
+  });
+
+  it('is idempotent — old hashes are replaced, not accumulated', () => {
+    const once = rewriteCsp(CSP, ["'sha256-one'"]).html;
+    const twice = rewriteCsp(once, ["'sha256-two'"]).html;
+    const policy = twice.match(/content="([^"]*)"/)![1];
+    expect(policy).toContain("'sha256-two'");
+    expect(policy).not.toContain("'sha256-one'");
+  });
+
+  it('leaves a page with no CSP meta untouched', () => {
+    const { html, changed } = rewriteCsp('<html><body>hi</body></html>', ["'sha256-x'"]);
+    expect(changed).toBe(false);
+    expect(html).toBe('<html><body>hi</body></html>');
+  });
+
+  it('does not touch a Report-Only meta, which is a different header', () => {
+    const ro = `<meta http-equiv="Content-Security-Policy-Report-Only" content="script-src 'unsafe-inline'">`;
+    expect(rewriteCsp(ro, ["'sha256-x'"]).changed).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes the `'unsafe-inline'` half of #241.

That directive is the hole that made the rest of the policy decorative: an injected inline script executes regardless of every allowlist around it.

## Astro cannot do this here, and it is not a version problem

Astro's CSP support landed in **v6** and covers only on-demand pages — *"these features only exist for pages rendered on demand using server mode, or pages that opt out of prerendering."* This site is **Astro 5.18 with `output: 'static'`** on GitHub Pages.

Nonces are impossible for a deeper reason than the version: **a nonce must be unique per request, and these pages are files.** Hashes are what works on static output.

## What it does

A postbuild step gives each page the SHA-256 of its own inline scripts:

```
13,493 pages scanned
13,376 rewritten, 105,366 hashes
   117 without a CSP meta, left alone
```

## Two things the tests pin down

**JSON-LD blocks are hashed.** CSP treats `application/ld+json` as a script element. Omitting them breaks structured data the moment `'unsafe-inline'` goes away — with **no visible error**, costing SEO silently.

**Scripts with `src` are not hashed.** The host allowlist covers those; a hash on an external script is meaningless and CSP ignores it.

## Verified in a browser, not by grep

A wrong hash strips a page's JavaScript without raising anything, so "no refusals" alone proves nothing — it is also what a page with no scripts looks like. Compared against production, which still has `'unsafe-inline'`:

| | built here | production |
| --- | --- | --- |
| CSP refusals | **0** | 0 |
| React roots | 2 | 2 |
| hydrated | true | true |
| interactive elements | 366 | 372 |
| JSON-LD blocks | 3 | 3 |

The React #418 hydration warning appears **identically on production**, so it predates this change.

## What is still not fixed

`img-src` must allow `https:` because event media comes from arbitrary publishers' `og:image` hosts, so image-based exfiltration remains possible. And `'unsafe-eval'` stays for Cesium. This closes the biggest hole, not every hole.

The `report-uri` half of #241 still needs a collection endpoint.
