### PR TITLE
fix(nightly): review_window_days could not widen the window it names

### DIFF
--- a/scripts/generate-review-manifest.ts
+++ b/scripts/generate-review-manifest.ts
@@ -49,8 +49,21 @@ for (const slug of slugs) {
   // 0 and silently disable gap detection on every normal night.
   const rawMax = process.env.REVIEW_WINDOW_MAX_DAYS;
   const parsedMax = rawMax ? Number(rawMax) : NaN;
-  const MAX_WINDOW_DAYS = Number.isFinite(parsedMax) && parsedMax > 0 ? parsedMax : 30;
-  const windowSize = Math.min(Math.max(daysSinceLastRun, 7), MAX_WINDOW_DAYS);
+  const explicit = Number.isFinite(parsedMax) && parsedMax > 0 ? parsedMax : null;
+
+  // An explicit value IS the window, not a ceiling on it.
+  //
+  // It used to be only a cap, which meant it could not do the one job it
+  // exists for. The window is driven by daysSinceLastRun, and any run resets
+  // lastRun to today — so a catch-up dispatched right after a normal night got
+  // max(0, 7) = 7 days no matter how large a value was passed. Raising a
+  // ceiling above a floor nothing reaches changes nothing.
+  //
+  // Found chasing a real gap: the Berlin Pride attack of 25 July 2026 was
+  // missing from `germany`, and two targeted runs with review_window_days=60
+  // both scanned 7 days and never looked at it.
+  const MAX_WINDOW_DAYS = explicit ?? 30;
+  const windowSize = explicit ?? Math.min(Math.max(daysSinceLastRun, 7), MAX_WINDOW_DAYS);
 
   const windowStart = new Date(today);
   windowStart.setDate(windowStart.getDate() - windowSize);

--- a/tests/review-window.test.ts
+++ b/tests/review-window.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * The review window decides how far back the nightly looks for missing events.
+ *
+ * `review_window_days` used to be only a *ceiling*, which meant it could not do
+ * the one job it exists for. The window is driven by `daysSinceLastRun`, and
+ * any run resets `lastRun` to today — so a catch-up dispatched right after a
+ * normal night got max(0, 7) = 7 days regardless of the value passed.
+ *
+ * Found chasing a real gap: the Berlin Pride attack of 25 July 2026 was missing
+ * from `germany`, and two targeted runs with review_window_days=60 both scanned
+ * seven days and never looked at it.
+ */
+function windowSize(daysSinceLastRun: number, explicit: number | null): number {
+  const max = explicit ?? 30;
+  return explicit ?? Math.min(Math.max(daysSinceLastRun, 7), max);
+}
+
+describe('review window', () => {
+  it('uses an explicit value as the window, not a cap on it', () => {
+    // The bug: a fresh lastRun made daysSinceLastRun 0, and 60 was ignored.
+    expect(windowSize(0, 60)).toBe(60);
+  });
+
+  it('reaches back far enough for a 26-day-old gap', () => {
+    // 25 July was 26 days before the run that was meant to catch it.
+    expect(windowSize(0, 60)).toBeGreaterThan(26);
+  });
+
+  it('leaves normal nights untouched', () => {
+    expect(windowSize(0, null)).toBe(7);
+    expect(windowSize(3, null)).toBe(7);
+    expect(windowSize(45, null)).toBe(30);
+  });
+
+  it('still floors at 7 days so a same-day rerun scans something', () => {
+    expect(windowSize(0, null)).toBe(7);
+  });
+
+  it('still caps an unattended tracker at 30 days without an explicit value', () => {
+    // A wide window inflates the manifest and the agent has a fixed turn
+    // budget, so the default cap stays.
+    expect(windowSize(365, null)).toBe(30);
+  });
+});


### PR DESCRIPTION
The window is `min(max(daysSinceLastRun, 7), MAX_WINDOW_DAYS)`, and `review_window_days` only set the second term.

But **any run resets `lastRun` to today**. So a catch-up dispatched after a normal night computes `max(0, 7) = 7` days, whatever value was passed. Raising a ceiling above a floor nothing reaches changes nothing.

```
daysSinceLastRun=0,  input=60  →   7 days   ← the bug
daysSinceLastRun=45, input=60  →  45 days
daysSinceLastRun=0,  no input  →   7 days
```

The input could not do the single job it exists for — and the comment directly above it describes exactly that job: *"Override it for a one-off catch-up run."*

## Found by chasing a gap, not by reading

The **Berlin Pride attack of 25 July 2026** — one dead, 29 injured, classified as Islamist extremist terror, covered by [AP](https://apnews.com) and CBS — was missing from `germany`.

I ran the nightly at it twice with `review_window_days=60`. Both scanned **seven days** and never looked at 25 July, which sat 26 days back. Two green runs, correct inputs, and the gap untouched.

## Change

An explicit value is now the window itself, not a cap on it. Normal nights are unchanged: no input still floors at 7 and caps at 30, because a wide window inflates the manifest and the agent has a fixed turn budget.

Five tests, including one asserting the window reaches past 26 days — the specific distance that defeated it.