### PR TITLE
fix(nightly): Cap gap days to what the agent's turn budget can reach

### DIFF
--- a/scripts/generate-review-manifest.ts
+++ b/scripts/generate-review-manifest.ts
@@ -101,16 +101,37 @@ for (const slug of slugs) {
     }
   }
 
+  // Cap the gap list to what the agent's turn budget can actually cover.
+  //
+  // The prompt asks for at least two search strategies per gap day, and the
+  // update agent runs with --max-turns 30. A 46-day catch-up window produced
+  // 38 gap days: 76+ searches in 30 turns is arithmetically impossible, so the
+  // agent covers a prefix and the rest are silently skipped — the manifest
+  // looks thorough while most of it is unreachable.
+  //
+  // Newest first: recent gaps matter more to readers, and an old gap survives
+  // to the next catch-up run whereas a recent one becomes old.
+  const GAP_BUDGET = 12;
+  const prioritised = [...gapDays].sort().reverse();
+  const gapDaysCapped = prioritised.slice(0, GAP_BUDGET);
+  const gapDaysDropped = prioritised.slice(GAP_BUDGET);
+
   const manifest = {
     tracker: slug,
     windowStart: windowStartStr,
     windowEnd: todayStr,
     days,
     totalEvents,
-    gapDays,
+    gapDays: gapDaysCapped,
+    gapDaysDropped,
   };
 
   const manifestPath = path.join(dataDir, 'review-manifest.json');
   fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
-  console.log(`Generated manifest for ${slug}: ${days.length} days, ${gapDays.length} gaps, ${totalEvents} total events`);
+  // Say what was dropped. A silent cap reads as "covered everything" when it
+  // did not, which is the failure this whole manifest exists to prevent.
+  const dropped = gapDaysDropped.length
+    ? ` (${gapDaysDropped.length} older gaps deferred: ${gapDaysDropped[gapDaysDropped.length - 1]}..${gapDaysDropped[0]})`
+    : '';
+  console.log(`Generated manifest for ${slug}: ${days.length} days, ${gapDaysCapped.length} gaps${dropped}, ${totalEvents} total events`);
 }

--- a/tests/review-window.test.ts
+++ b/tests/review-window.test.ts
@@ -44,3 +44,50 @@ describe('review window', () => {
     expect(windowSize(365, null)).toBe(30);
   });
 });
+
+/**
+ * Widening the window without widening the turn budget just moves the failure.
+ *
+ * The prompt asks for 2+ search strategies per gap day and the agent runs with
+ * --max-turns 30. A 46-day catch-up produced 38 gap days: 76+ searches in 30
+ * turns is arithmetically impossible, so the agent covers a prefix and the rest
+ * are skipped with nothing saying so.
+ */
+function prioritiseGaps(gapDays: string[], budget = 12) {
+  const sorted = [...gapDays].sort().reverse();
+  return { kept: sorted.slice(0, budget), dropped: sorted.slice(budget) };
+}
+
+describe('gap budget', () => {
+  // Real dates: 15 July through 21 August, the span that actually produced 38
+  // gaps on `germany`.
+  const many: string[] = [];
+  for (let d = new Date('2026-07-15T00:00:00Z'); d <= new Date('2026-08-21T00:00:00Z'); d.setUTCDate(d.getUTCDate() + 1)) {
+    many.push(d.toISOString().slice(0, 10));
+  }
+
+  it('caps the gap list to what 30 turns can cover', () => {
+    expect(many.length).toBeGreaterThan(30);          // the fixture is the real problem size
+    expect(prioritiseGaps(many).kept).toHaveLength(12);
+  });
+
+  it('keeps the newest gaps, because an old gap survives to the next run', () => {
+    const { kept, dropped } = prioritiseGaps(many);
+    expect(kept[0]).toBe('2026-08-21');               // newest kept
+    expect(dropped[dropped.length - 1]).toBe('2026-07-15'); // oldest dropped
+    expect(kept[kept.length - 1] > dropped[0]).toBe(true);  // no interleaving
+  });
+
+  it('reports what it dropped rather than truncating silently', () => {
+    const { kept, dropped } = prioritiseGaps(many);
+    expect(kept.length + dropped.length).toBe(many.length);  // nothing vanishes
+    expect(dropped.length).toBeGreaterThan(0);
+  });
+
+  it('does nothing when the gaps already fit', () => {
+    const few = ['2026-08-01', '2026-08-02'];
+    const { kept, dropped } = prioritiseGaps(few);
+    expect(kept).toHaveLength(2);
+    expect(dropped).toEqual([]);
+  });
+});


### PR DESCRIPTION
Widening the review window in #251 was necessary and **not sufficient**. It made the manifest bigger without giving the agent room to act on it.

```
38 gap days x 2+ searches = 76+ searches
turn budget (--max-turns) = 30
```

Arithmetically impossible. The agent covers a prefix and the rest are skipped with nothing saying so — **the manifest reads as thorough while most of it is unreachable**. Same shape as the defects this manifest exists to catch.

## How it surfaced

I fixed the window, re-ran the nightly at `germany`, and the manifest confirmed the fix worked:

```
Generated manifest for germany: 46 days, 38 gaps, 10 total events
```

46 days instead of 7. And the Berlin Pride attack of 25 July **still did not land**. The window reached it; the budget did not.

Correct arithmetic on the layer I fixed, wrong result — which is only visible by checking the outcome rather than the fix.

## Change

Caps the gap list at **12, newest first**. A recent gap matters more to readers, and an old gap survives to the next catch-up run whereas a recent one becomes old.

Deferred days go into `gapDaysDropped` and are named in the log line:

```
Generated manifest for germany: 46 days, 12 gaps (26 older gaps deferred: 2026-07-15..2026-08-09), 10 total events
```

A silent cap reads as "covered everything" when it did not.