### PR TITLE
data(germany): Add the Berlin CSD attack, after three workflow fixes failed to

### DIFF
--- a/trackers/germany/data/events/2026-07-25.json
+++ b/trackers/germany/data/events/2026-07-25.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "berlin-csd-attack-2026",
+    "year": "2026",
+    "title": "Vehicle-Ramming and Stabbing Attack Near Berlin Christopher Street Day",
+    "type": "security",
+    "detail": "One person was killed and 29 injured in a vehicle-ramming and stabbing attack near the Christopher Street Day parade in Berlin on 25 July 2026. The 21-year-old male suspect was shot and killed by police the following day after rushing at officers. Interior Minister Alexander Dobrindt said the attack was believed to be an act of Islamist extremist terrorism. Germany's deadliest attack on an LGBTQ+ gathering.",
+    "sources": [
+      {
+        "name": "Associated Press",
+        "url": "https://apnews.com/",
+        "tier": 2,
+        "note": "Germany says fatal Berlin Pride attack believed to be an act of Islamic extremist terror, 26 July 2026"
+      },
+      {
+        "name": "CBS News",
+        "url": "https://www.cbsnews.com/",
+        "tier": 2,
+        "note": "Initial casualty report, 25 July 2026"
+      }
+    ],
+    "media": []
+  }
+]


### PR DESCRIPTION
**25 July 2026**: one killed, 29 injured in a vehicle-ramming and stabbing attack near the Christopher Street Day parade in Berlin. The 21-year-old suspect was shot dead by police the next day; Interior Minister Dobrindt said it was believed to be Islamist extremist terrorism.

Germany's deadliest attack on an LGBTQ+ gathering, and the repo had **nothing**.

## Three attempts through the pipeline, each fixing a real bug, none producing the event

**1.** `review_window_days` only raised a ceiling, so the window stayed at 7 days and never reached 25 July — 26 days back. Fixed in #251.

**2.** The fixed window produced 46 days and 38 gap days, against a 30-turn budget and a prompt asking 2+ searches per gap. Fixed in #252 by capping the list.

**3.** That cap prioritises **newest-first** — correct for routine catch-up — which put 25 July squarely in the deferred range:

```
Generated manifest for germany: 41 days, 12 gaps
  (21 older gaps deferred: 2026-07-11..2026-08-01)
```

**The cap I added to fix attempt 2 actively excluded the event I was chasing.**

## Why this is written directly rather than fixed a fourth time

Newest-first is right for a nightly and wrong for a targeted backfill of a known old gap. That is a genuine design tension, not a bug — and I have now made three changes chasing one event, each of which moved the failure rather than removed it.

The sources were verifiable the entire time. Writing the event is the honest action; a fourth workflow change to reach one known date would be motion.

The tension is recorded on #238 for whoever wants to add a targeted-gap mode.