### PR TITLE
docs: OSIRIS competitive analysis (v2) and adoption program plan

### DIFF
--- a/docs/competitive-analysis-osiris.md
+++ b/docs/competitive-analysis-osiris.md
@@ -7,8 +7,13 @@ OSIRIS pertenece a la misma familia que World Monitor (SPA con mapa
 WebGL y decenas de feeds en vivo), así que este documento se centra en
 lo que OSIRIS hace distinto y en qué de eso conviene adoptar.
 
-**Última actualización:** 7 de septiembre de 2026
-**OSIRIS analizado:** rama `master`, ~301 commits
+La versión 2 se basa en lectura directa del código fuente de ambos
+repositorios (clon de OSIRIS en `master`, 69 rutas API, 36 componentes,
+49 librerías; Watchboard en `feead12`). El plan de ejecución derivado
+está en `docs/superpowers/plans/2026-09-07-osiris-adoption-program.md`.
+
+**Última actualización:** 7 de septiembre de 2026 (v2)
+**OSIRIS analizado:** rama `master`, commit `d2c08c8` (2026-09-06)
 **Watchboard:** `feead12` (main)
 
 ---
@@ -16,25 +21,56 @@ lo que OSIRIS hace distinto y en qué de eso conviene adoptar.
 ## Resumen ejecutivo
 
 OSIRIS y Watchboard resuelven problemas distintos con arquitecturas
-opuestas. OSIRIS es un **visor de sensores**: agrega 16 capas en vivo
-(aviones, sismos, incendios, CCTV, sanciones, Telegram) sobre un mapa
-MapLibre y no guarda historia ni cura nada. Watchboard es un **archivo
-curado**: 125 trackers con línea de tiempo, tiers de fuente y datos
-versionados en git, actualizados por IA.
+opuestas. OSIRIS es un **visor de sensores**: agrega 33 capas
+conmutables (aviones, sismos, incendios, CCTV, sanciones, Telegram,
+malware, mercados) sobre un mapa MapLibre y no guarda historia ni cura
+nada. Watchboard es un **archivo curado**: 125 trackers con línea de
+tiempo, tiers de fuente y datos versionados en git, actualizados por IA.
 
-Lo que vale la pena tomar de OSIRIS no son sus capas (la mayoría están
-fuera de misión) sino **cinco patrones de producto e ingeniería** que
-encajan en el backlog actual sin cambiar la arquitectura estática:
+La lectura del código cambia varias conclusiones de la v1:
 
-1. Dossier contextual por clic en el mapa (Nominatim + Wikidata).
-2. URL compartible con estado de vista, sin esperar el ADR de nanostores.
-3. Caché de fuentes en vivo con dedupe en vuelo y "stale-on-error".
-4. Frente de guerra en vivo (DeepState) y alertas GDACS como capas nuevas.
-5. Panel de alertas con severidad, alimentado por el light scan que ya existe.
+- El "risk score" y el "machine assessment" de OSIRIS **no son IA**: el
+  score es `1 + 2 por palabra clave` sobre una lista de 24 términos, y
+  el assessment es una cadena constante que se emite cuando el score
+  llega a 8. El LLM (Gemini 2.0 Flash) solo se usa bajo demanda en
+  botones "AI overview" y en un briefing, sin caché.
+- Los **enlaces compartibles de OSIRIS están rotos**: `SharePanel`
+  genera `lat/lon/zoom/layers`, pero al cargar la página solo se lee
+  `layers`. Toda URL compartida pierde la ubicación y geolocaliza por IP.
+- OSIRIS tiene **más pruebas de lo que aparenta** (38 archivos, ~533
+  aserciones) pero ninguna ejercita un handler HTTP, y las primitivas de
+  seguridad (`ssrf-guard`, `stealthFetch`) tienen cero cobertura.
+- OSIRIS trae **decisiones de ingeniería excelentes documentadas en
+  comentarios** (caché con stale-on-error, dedupe con rollback en
+  fallo, "el primer barrido no es un evento", "no renderizar una caja
+  rota") junto con prácticas que no hay que copiar (spoofing de
+  `X-Forwarded-For` desde un pool de IPs residenciales, envío de la IP
+  del visitante a un Umami interno, TLS deshabilitado en el proxy de
+  cámaras).
+- Watchboard tiene su propia deuda de credibilidad en las capas "en
+  vivo" del globo: **cinco de las nueve son arrays estáticos**
+  congelados en febrero-marzo de 2026 y específicos del tracker de Irán
+  (zonas de exclusión aérea, GPS jamming, blackouts, clima de 14
+  ciudades), duplicados entre Cesium y Leaflet, sin fecha visible.
 
-Lo que **no** conviene tomar: el toolkit RECON (port scan, WHOIS, SSL),
-CCTV en vivo, rastreo de wallets y la dependencia de un servidor Next.js
-con llamadas LLM sin caché.
+Lo que vale la pena tomar de OSIRIS son **patrones de producto e
+ingeniería**, no sus capas. Están priorizados en el plan de ejecución
+como nueve épicas; las cinco de mayor retorno:
+
+1. Estado de vista en la URL, hecho bien (leer y escribir los cuatro
+   parámetros).
+2. Caché de fuentes en vivo con dedupe, stale-on-error y estado
+   "degradado" visible.
+3. Panel de alertas con severidad, alimentado por el light scan.
+4. Dossier contextual por clic en el mapa (Nominatim + Wikidata +
+   trackers del país).
+5. Capas geoespaciales nuevas con procedencia: frente DeepState,
+   alertas GDACS, GeoJSON estático de infraestructura.
+
+Lo que **no** conviene tomar: el toolkit RECON (20 herramientas de
+consulta en vivo a terceros), CCTV, cripto, navegación turn-by-turn,
+mercados, el servidor Next.js con 69 rutas, el LLM sin caché y las
+técnicas de evasión de rate limits.
 
 ---
 
@@ -43,17 +79,22 @@ con llamadas LLM sin caché.
 | Atributo | OSIRIS | Watchboard |
 |---|---|---|
 | Repositorio | `simplifaisoul/osiris` | `ArtemioPadilla/watchboard` |
-| Stars / forks | ~8.6k / ~1.8k | dos órdenes de magnitud menos |
-| Commits | ~301 | ~1,500+ |
+| Stars / forks | ~8.6k / ~1.8k | 19 / 5 |
+| Commits | ~301 | ~1,500 |
+| Creado | 2026 | 2026-03-04 |
 | Licencia | MIT | MIT |
-| Framework | Next.js 16 (App Router, Turbopack) | Astro 5 + islas React |
-| Mapa | MapLibre GL JS (WebGL) | Leaflet 2D + CesiumJS 3D |
-| Backend | 44 rutas API en Next.js + contenedor `intel/` | Ninguno (GitHub Pages) + Worker para push |
-| Hosting | Vercel Edge, Docker (GHCR), CasaOS | GitHub Pages, Cloudflare Worker |
-| IA | Gemini 2.0 Flash bajo demanda, sin caché | Claude Code Action nocturno, datos versionados |
-| Tests | 4 archivos `*.test.ts` visibles en `components/` | 26 archivos de test + Playwright e2e |
+| Framework | Next.js 16.2 (App Router, Turbopack), React 19 | Astro 5.18 + islas React 19 |
+| Mapa | MapLibre GL 5.24 (WebGL, custom layer para satélites) | Leaflet 2D + CesiumJS 1.139 3D |
+| Backend | 69 `route.ts` en 44 directorios + contenedor `intel/` (Express, 776 líneas) | Ninguno (GitHub Pages) + Worker Cloudflare para push |
+| Hosting | Vercel, Docker multi-stage (GHCR, amd64+arm64), CasaOS | GitHub Pages, Worker en `push.watchboard.dev` |
+| IA | Gemini 2.0 Flash bajo demanda, 8 llaves en round-robin, sin caché | Claude Code Action nocturno + Sonnet en triage cada 6 h, datos versionados |
+| Componente más grande | `OsirisMap.tsx` 2,983 líneas, 49 effects, 95 `addLayer` | `CommandCenter.tsx` 1,348 líneas |
+| Tests | 38 archivos, ~533 aserciones, ninguno sobre handlers HTTP | 25 archivos vitest, ~269 casos, 2 specs Playwright (sin workflow) |
+| CI | 1 workflow (`docker-publish.yml`) | 21 workflows |
 | Datos históricos | No | Sí (timeline por eras, eventos diarios) |
 | Tiers de fuente | No | Tier 1-4 en cada dato |
+| i18n | Solo inglés | en/es/fr/pt |
+| Docs de API pública | `/docs` con catálogo de 56 endpoints (13 sin documentar) | `/api` y `/skill` ya publicadas |
 
 ---
 
@@ -62,38 +103,88 @@ con llamadas LLM sin caché.
 ### OSIRIS
 
 ```
-Navegador (Next.js client, MapLibre GL, Framer Motion)
+Navegador (page.tsx: 55 useState, 20 useEffect, un dataRef + contador de versión)
+  |
+  +-- OsirisMap (MapLibre): 35 fuentes GeoJSON creadas vacías una vez,
+  |     actualizadas con setData; sin clustering; decimación de vuelos
+  |     (1 de cada 10 comerciales); custom WebGL layer para satélites
+  +-- 33 capas booleanas, 11 activas por defecto
+  +-- Polling: sismos 15 min, noticias 30 min, vuelos 5 min,
+  |     marítimo y ciberataques cada 10 s SIN pausa con pestaña oculta
+  +-- Malware por SSE (snapshot / delta / retire)
   |
   v  fetch /api/*
-Next.js API routes (44)            -> proxies con Cache-Control s-maxage
-  |   flights, earthquakes, fires, gdelt (GDACS), frontlines (DeepState),
-  |   country-risk, region-dossier, osint (Telegram), sanctions, crypto,
-  |   markets, cloudflare-radar, malware, scanner, entity/expand, ai
-  |
-  +-> intel/ (contenedor Node separado: grafo de entidades, scanner)
-  +-> ~20 APIs públicas sin llave (OpenSky, USGS, NASA FIRMS/EONET,
-      NOAA SWPC, N2YO, NVD, OpenSanctions, blockstream, t.me/s/)
+Next.js API routes (69)
+  |   34 con Cache-Control s-maxage/swr, 8 no-store, 5 con caché en memoria,
+  |   ~18 sin cabecera alguna
+  +-> sourceCache.ts: TTL + dedupe en vuelo + stale-on-error (98 líneas)
+  +-> ssrf-guard.ts: 14 CIDR IPv4, 15 prefijos IPv6, redirects manuales
+  +-> stealthFetch.ts: rota 10 User-Agents y FALSIFICA X-Forwarded-For
+  +-> intel/ (Express :4000): grafo de entidades, OFAC + Wikidata
+  +-> ~20 APIs públicas sin llave
 ```
 
-Características:
-- Todo es tiempo real; nada se persiste. Cerrar la pestaña borra el estado.
-- Las 13 "zonas de conflicto" y los 39 puertos son datos estáticos en código.
-- `country-risk` es una tabla hardcodeada (35 China, 90 Palestina) más un
-  bono por sismos M4.5+ del día. No hay modelo detrás.
-- El LLM (Gemini) se llama bajo demanda para "AI overview" y briefing
-  diario; sin caché, sin curación, sin verificación de fuentes.
-- Caché por ruta con `s-maxage` + `stale-while-revalidate` y una
-  `sourceCache` en memoria con TTL, dedupe de peticiones concurrentes y
-  fallback al último dato bueno si la fuente falla.
-- Rate limiting por IP y `ssrf-guard` en los proxies.
+Hallazgos relevantes del código:
+
+- **El store de datos es un `useRef` + contador de versión**, no estado
+  React. Mantiene la identidad del objeto estable entre renders; a cambio
+  rompe un `useMemo` que depende de `data` (nunca se invalida).
+- **`loadLayerOnce` marca la capa como cargada antes del `await` y borra
+  la marca si falla**, así un error de red no deja la capa vacía para
+  siempre. Patrón a copiar.
+- **Probe de capacidades**: el cliente consulta `?probe=1` y `LayerPanel`
+  oculta las capas cuya llave no está configurada. Hace que "sin llave"
+  no se vea como "roto".
+- **Las 13 "zonas de conflicto"** son 15 registros estáticos con URLs de
+  Liveuamap. **`country-risk`** es una tabla hardcodeada (35 China, 90
+  Palestina) más un bono por sismos M4.5+ del día.
+- **Nominatim se llama desde el navegador** en búsqueda y en reverse
+  geocoding al pasar el cursor (debounce 3 s, LRU 500). El código intenta
+  fijar `User-Agent`, cabecera que el navegador descarta.
+- **`middleware.ts` no hace seguridad**: envía dos eventos Umami por
+  vista de página, uno de ellos con la IP del visitante como payload,
+  por HTTP plano a un host interno.
+- **Caché**: cada ruta declara su `s-maxage` según la volatilidad del
+  dato; `sourceCache` sirve el último dato bueno con reintento a 60 s
+  cuando falla el upstream; `chainFeeds` baja el TTL a 90 s cuando la
+  respuesta es parcial para no fijar un brief degradado.
 
 ### Watchboard
 
 Ver `competitive-analysis-worldmonitor.md`. Resumen: Astro SSG, datos en
 `trackers/{slug}/data/*.json` validados con Zod, pipeline nocturno de
-tres fases, globo Cesium con capas en vivo (vuelos OpenSky, satélites
-Celestrak, sismos USGS, clima Open-Meteo, GPS jamming, blackouts), light
-scan cada 15 min, RSS, API JSON estática, servidor MCP, push, video diario.
+tres fases, globo Cesium con nueve hooks de capa, light scan cada 15 min
+(scoring determinista) y heavy scan cada 6 h (Sonnet), RSS, API JSON
+estática, servidor MCP con 7 herramientas, push, video diario.
+
+Hallazgos relevantes del código que el plan debe corregir:
+
+- **Capas "en vivo" del globo**: solo `useFlights`, `useEarthquakes`,
+  `useSatellites`, `useWeather` y `useShips` hacen red. `useNoFlyZones`,
+  `useGpsJamming`, `useInternetBlackout` son arrays literales con
+  `startDate: '2026-02-28'`, atribuidos a "NetBlocks / IODA" o "ADSB
+  anomaly reports" como cadena, no como feed. Los mismos datos están
+  duplicados en `MapOverlayData.ts` para Leaflet.
+- **Bounding box fijo** en vuelos y sismos (lat 12-42, lon 24-65: Medio
+  Oriente) aunque el tracker sea de México o Brasil. Clima de 14 ciudades
+  del Golfo hardcodeadas.
+- **Ningún hook pausa con `document.hidden`**; ninguno usa
+  `AbortController`; ninguno cachea. `useFlights` es el único con enum
+  de estado (`idle/loading/ok/rate-limited/error`) y backoff; sismos y
+  clima hacen `if (!res.ok) return;` y la capa queda vacía en silencio,
+  el patrón que documenta `silent-failure-patterns.md`.
+- **Estado de URL**: un solo escritor (`#geo`/`#domain` en
+  `CommandCenter.tsx:196`). Cero `URLSearchParams`. La cámara vive en
+  `useCesiumCamera` de forma imperativa, sin serializar.
+- **`public/_health/status.json`** se genera en cada deploy y **nadie lo
+  lee**. `MetricsDashboard` solo conoce `success | failure`; no existe un
+  estado "degradado" en todo el código.
+- **Sin Dockerfile, sin ADRs.** BL-001 y BL-003 piden un ADR que no tiene
+  plantilla.
+- **Gazetteer gratis**: 5,876 puntos con lat/lon en los `map-points.json`
+  de 125 trackers; 109 declaran `country`, 125 `region` y `map.center`.
+- **Docs de API ya existen** (`/api`, `/skill`), así que el gap de la v1
+  sobre "página de documentación" se retira: es trabajo aditivo.
 
 ### Trade-offs
 
@@ -103,9 +194,10 @@ scan cada 15 min, RSS, API JSON estática, servidor MCP, push, video diario.
 | Profundidad | Ninguna: no hay historia ni contexto | Timeline, KPIs, claims, casualties por tema |
 | Costo infra | Vercel + contenedor `intel/` (pide Patreon) | Cero |
 | Confiabilidad | Cae cuando cae una API upstream | Datos en git nunca caen |
-| Calidad de dato | Crudo, sin tiers | Curado, tier 1-4, cuatro polos |
-| Distribución | Docker/GHCR/CasaOS, fácil de auto-hospedar | Solo la web |
-| Descubribilidad | 8.6k stars, Discord, "Palantir alternative" | Nicho, sin narrativa de posicionamiento |
+| Calidad de dato | Crudo; "risk score" por palabras clave | Curado, tier 1-4, cuatro polos |
+| Honestidad de UI | Mixta: excelente en cámaras y satélites, mala en "AI Analysis" | Buena en datos curados, mala en capas estáticas sin fecha |
+| Distribución | Docker/GHCR/CasaOS, comunidad self-hosting | Solo la web |
+| Descubribilidad | 8.6k stars, Discord, narrativa "Palantir alternative" | Nicho, sin narrativa |
 
 ---
 
@@ -115,278 +207,209 @@ scan cada 15 min, RSS, API JSON estática, servidor MCP, push, video diario.
 
 | Feature | OSIRIS | Watchboard | Evaluación |
 |---|---|---|---|
-| Vuelos en vivo | OpenSky, capa global | OpenSky en globo y mapa, filtro militar por callsign | Paridad |
-| Sismos | USGS 2.5+ | USGS 2.5+ en globo | Paridad |
-| Satélites | N2YO (llave) | Celestrak TLE + satellite.js, sin llave | Ventaja WB |
-| Globo 3D | No (solo mapa 2D) | Cesium con misiles, modo cinemático, misiones lunares | Ventaja WB |
+| Vuelos en vivo | adsb.fi + adsb.lol + OpenSky; decimación 1/10; watchlist por icao24 | OpenSky en globo y mapa, filtro militar por callsign | Paridad; OSIRIS más robusto en fuentes |
+| Sismos | USGS 2.5+ cada 15 min | USGS 2.5+ una vez por fecha, bbox fijo | Paridad funcional; WB sin polling ni estado |
+| Satélites | ~19k TLE Celestrak, SGP4 real, órbita bajo demanda, shader propio | 6 grupos Celestrak + satellite.js, cap 200 Starlink | Paridad; `orbit.ts` de OSIRIS es mejor (antimeridiano, no interpola) |
+| Globo 3D | No (MapLibre globe projection) | Cesium con misiles, misiones lunares, modo cinemático | Ventaja WB |
 | Multi-tema | Un dashboard global | 125 trackers independientes | Ventaja WB mayor |
-| Timeline / eventos | No | Eras, particiones diarias, media | Ventaja WB mayor |
+| Timeline / eventos | No | Eras, particiones diarias, media, permalinks por evento | Ventaja WB mayor |
 | Tiers de fuente | No | Tier 1-4 + polos | Ventaja WB mayor |
-| Pipeline IA | Gemini bajo demanda, sin verificación | Claude nocturno + fix agent + build gate | Ventaja WB mayor |
-| Telegram | Scraping t.me/s/ + geoparsing | `pollTelegram()` en light scan, sin geoparsing | Paridad parcial (ver Gap 6) |
-| Alertas | Panel LiveAlerts con severidad | Telegram + push por tracker, sin panel en la web | Paridad parcial (ver Gap 5) |
-| Atajos de teclado | Panel de shortcuts | Panel `?` | Paridad |
-| RSS / API / MCP | Nada | 4 feeds RSS, API JSON, servidor MCP | Ventaja WB |
-| Broadcast / stories / video | Nada | BroadcastOverlay, MobileStoryCarousel, video diario | Ventaja WB |
-| Métricas de ingesta | `/api/health` declarativo (no prueba nada) | MetricsDashboard con calendario de uptime | Ventaja WB |
-| i18n | Solo inglés | en/es/fr/pt | Ventaja WB |
-| Compartir vista | URL con lat/lon/zoom/layers | No hay deep links | Gap (ver Gap 2) |
+| Pipeline IA | Gemini bajo demanda, sin caché ni verificación | Claude nocturno + fix agent + build gate + Sonnet triage | Ventaja WB mayor |
+| Telegram | Scraping t.me/s/ de 4 canales + geoparsing de 15 topónimos | `pollTelegram()` de 5 canales, sin geoparsing | Paridad parcial |
+| Alertas | LiveAlerts con severidad 8/6/4 | Telegram + push por tracker; sin panel web | Gap (épica E3) |
+| Atajos de teclado | 13 reales, 8 documentados, colisión en `S` | 11 en tabla `SHORTCUTS`, panel `?` | Ventaja WB (documentados y sin colisión) |
+| RSS / API / MCP | `/docs` con catálogo, SSE "SDK" sin auth | 4 RSS, API JSON, MCP 7 tools, `/api` y `/skill` | Ventaja WB |
+| Broadcast / stories / video | Nada | BroadcastOverlay, stories, video diario | Ventaja WB |
+| Métricas de ingesta | `/api/health` declarativo; "ONLINE" hardcodeado en verde | MetricsDashboard con calendario de uptime | Ventaja WB |
+| Error boundaries | `ErrorBoundary.tsx` genérico | `IslandErrorBoundary` en 3 islas | Paridad (ambos solo errores de render) |
+| Self-hosting | Dockerfile 3 etapas, compose, nginx, CasaOS, GHCR multi-arch | Nada | Gap (épica E8) |
+| Compartir vista | Genera `lat/lon/zoom/layers`, solo lee `layers` | Nada | Gap en ambos (épica E1) |
 
 ### Gaps: lo que OSIRIS tiene y Watchboard no
 
-Cada gap indica qué hace OSIRIS, cómo se traduce a Watchboard, esfuerzo
-estimado (XS <2h, S medio día, M 1-2 días, L 3-5 días) y si requiere
-backend.
+Cada gap se convierte en una épica del plan de ejecución. Aquí se
+describe el hallazgo; allí, las historias y tareas.
 
-#### Gap 1: Dossier contextual por clic en el mapa
+#### Gap 1: Dossier contextual por clic (épica E4)
 
-**Severidad:** Alta. **Backend:** No.
+Clic derecho en OSIRIS llama `/api/region-dossier?lat&lng`: Nominatim
+reverse, luego Wikipedia REST y Wikidata SPARQL en paralelo con
+`Promise.allSettled`; caché 1 h. En Watchboard el único handler de clic
+del globo está en `useConflictData.ts:15` (entidades), y Leaflet solo
+tiene clics en marcadores (`LeafletMap.tsx:397`). No existe clic de
+fondo que capture lat/lon. El precedente más cercano es
+`handleGeoClick` en `CommandCenter.tsx:311` (polígono de país en el
+homepage). Especificaciones previas a leer:
+`docs/superpowers/specs/2026-04-07-globe-click-to-drill-design.md` y
+`2026-04-03-geographic-hierarchy-design.md`.
 
-En OSIRIS, clic derecho en cualquier punto del mapa llama a
-`/api/region-dossier`: Nominatim (reverse geocoding) y luego, en
-paralelo, Wikipedia REST y Wikidata SPARQL para país, capital, población,
-jefe de estado y bandera. Cachea una hora.
+#### Gap 2: URL compartible (épica E1)
 
-**Traducción a Watchboard.** El mismo gesto sobre el globo del homepage
-o el mapa de un tracker abriría un panel con: los trackers cuyo
-`country` coincide con el país resuelto, sus últimos eventos, y los
-datos de Wikidata. Esto convierte el globo en un índice espacial de los
-125 trackers, que hoy solo se navegan por lista. El campo `country` ya
-existe en `tracker.json` (lo usa `tracker-feeds.ts`).
+OSIRIS lo hace mal y eso es la lección: `SharePanel.tsx:17-34` escribe
+cuatro parámetros y `page.tsx:336-345` lee uno. El criterio de
+aceptación de Watchboard debe ser un test de ida y vuelta. La cámara de
+Cesium vive en `useCesiumCamera.ts` (imperativa); los toggles de capa
+en un `useState` en `CesiumGlobe.tsx:129-136`; los del mapa 2D en
+`IntelMap.tsx:66-75`. Todo es local a la isla, así que **la dependencia
+de BL-003 sobre el ADR de nanostores (BL-001) es falsa**: baja de M-H a
+S.
 
-- Nominatim se puede llamar desde el cliente respetando su política de
-  uso (1 req/s, `User-Agent` identificable). Wikidata SPARQL también.
-- Reusar `FloatingFactCard` / `CesiumInfoPanel` para el panel.
-- Cachear por país en `sessionStorage`.
+#### Gap 3: Caché de fuentes en vivo (épica E2)
 
-**Esfuerzo:** M. Encaja con el tema "Country trackers" de M4.
+`sourceCache.ts` de OSIRIS: TTL, dedupe en vuelo, stale-on-error con
+reintento a 60 s, tope de 500 claves. Watchboard tiene un precedente
+propio en `useTrackerDetail.ts:16-17` (mapas `CACHE` e `IN_FLIGHT` a
+nivel de módulo). El punto de inserción es el bloque de nueve hooks en
+`CesiumGlobe.tsx:489-497`. El enum `FlightStatus` de `useFlights.ts:54`
+se generaliza a todas las fuentes. Cierra BL-020.
 
-#### Gap 2: URL compartible con estado de vista
+#### Gap 4: Capas geoespaciales con procedencia (épica E5)
 
-**Severidad:** Alta. **Backend:** No.
+Verificado el 7 de septiembre de 2026:
 
-`SharePanel.tsx` de OSIRIS codifica cuatro parámetros: `lat`, `lon`,
-`zoom`, `layers` (lista separada por comas). Nada más. Al abrir la URL
-el mapa aterriza en el mismo estado.
+| Fuente | CORS | Tamaño | Caché upstream | Licencia |
+|---|---|---|---|---|
+| `deepstatemap.live/api/history/last` | `*` | 628 KB, 29 polígonos | `max-age=300` | No declarada; pedir permiso |
+| `gdacs.org/xml/rss.xml` | ninguno | 1.3 MB, 428 items | ninguno | CC BY 4.0 (UE) |
+| `nominatim.openstreetmap.org/reverse` | `*` | <1 KB | ninguno | ODbL; política 1 req/s |
 
-**Traducción a Watchboard.** El backlog tiene BL-003 (deep links) como
-M-H y bloqueado por el ADR de nanostores para búsqueda. OSIRIS demuestra
-que la versión mínima no necesita estado compartido entre islas: el
-globo y el mapa ya poseen su cámara y sus toggles de capa. Leer
-`URLSearchParams` al montar y escribir con `history.replaceState` al
-cambiar es local a `CesiumGlobe.tsx` y `IntelMap.tsx`.
+DeepState se puede consumir desde el navegador; GDACS necesita ingesta
+del lado del scan (cada 15 min) y publicar un JSON recortado. Los
+GeoJSON estáticos de OSIRIS (cables submarinos 665 KB, dos copias
+idénticas; ~55 plantas nucleares) modelan lo que Watchboard debería
+tener como capas con `_provenance`. Cierra el ítem 1.1 del análisis de
+World Monitor.
 
-- Parámetros propuestos: `lat`, `lon`, `alt` (Cesium) o `zoom` (Leaflet),
-  `layers`, `event` (slug de evento para abrir su panel; `event-slug.ts`
-  ya existe), `date` (para el scrubber de timeline).
-- Sirve de base para OG images dinámicas y para que el light scan
-  incluya enlaces que aterricen en el punto exacto.
+#### Gap 5: Panel de alertas (épica E3)
 
-**Esfuerzo:** S. Desbloquea BL-003 sin esperar BL-001.
+`LiveAlerts.tsx` mezcla noticias (severidad por score), sismos (por
+magnitud) y 23 streams hardcodeados. Watchboard ya produce la señal en
+`hourly-light-scan.ts` (`HIGH_THRESHOLD 0.85`, `MODERATE 0.25`) y la
+escribe en `public/_hourly/triage-log.json`, pero ese archivo pesa 4.4
+MB: el panel necesita un `alerts.json` recortado. La taxonomía de
+severidad puede reusar `useFactCards.ts:9` (KINETIC / INFRASTRUCTURE /
+CIVILIAN IMPACT / ESCALATION).
 
-#### Gap 3: Caché de fuentes en vivo con dedupe y stale-on-error
+#### Gap 6: Geoparsing (épica E6)
 
-**Severidad:** Media-alta. **Backend:** No.
+OSIRIS mapea 15 topónimos a centroides. Watchboard tiene 5,876 puntos
+con nombre en sus propios datos. `Candidate` (`hourly-types.ts:63-74`)
+no tiene campo geo.
 
-`sourceCache.ts` de OSIRIS implementa tres cosas que Watchboard no tiene
-en sus hooks de globo: TTL configurable, una sola petición en vuelo por
-clave (dos componentes que piden vuelos comparten la promesa) y, si la
-fuente falla, servir el último dato bueno con reintento a 60 s en vez
-de dejar la capa en cero. El README reporta "75% menos peticiones edge"
-al relajar polling de datos estables a 15-30 min y cargar por viewport.
+#### Gap 7: Índice de actividad honesto (épica E7)
 
-**Estado en Watchboard.** `useMapFlights.ts` y `useFlights.ts` llaman a
-OpenSky cada 15 s con un bounding box fijo (12-42N, 24-65E) aunque el
-usuario mire otra región. OpenSky anónimo tiene cupo diario de créditos
-y ese ritmo lo agota en minutos de sesión larga. No se pausa cuando la
-pestaña está oculta. Si OpenSky devuelve 429 la capa desaparece sin
-aviso, exactamente el patrón que documenta `silent-failure-patterns.md`.
+`country-risk` de OSIRIS es una tabla. Watchboard puede calcularlo de
+eventos de 7 días, flags `breaking`, deltas de KPI (BL-024) y frescura
+del digest, y **mostrar los factores**, no solo el número.
 
-**Propuesta.** Un `src/lib/live-source-cache.ts` compartido por
-`useFlights`, `useEarthquakes`, `useSatellites`, `useWeather`:
+#### Gap 8: Self-hosting (épica E8)
 
-- TTL por fuente (vuelos 30-60 s, sismos 5 min, TLE 6 h).
-- Dedupe en vuelo por clave (`fuente + bbox`).
-- Último dato bueno + flag `degraded` que la UI muestre como chip ámbar
-  en el HUD (cierra BL-020 "API health indicator").
-- Bbox derivado de la cámara actual, no fijo.
-- Pausa con `document.visibilityState === 'hidden'`.
+OSIRIS: Dockerfile de 3 etapas, `output: standalone`, usuario no root,
+compose con nginx (gzip para JSON de 4 MB, proxy de tiles cacheado 365
+días), bloque `x-casaos`, workflow GHCR amd64+arm64 con `concurrency`.
+Su documentación deriva: README cita `.env.template` y el archivo es
+`.env.example`; DOCKER.md dice que solo se leen dos variables y el
+código lee 17; `FIRMS_API_KEY` y `N2YO_API_KEY` están documentadas y no
+se leen nunca. Lección: **generar la lista de variables desde el
+código**, no a mano. Watchboard no tiene Dockerfile; `npm run build`
+requiere `copy-cesium` (7.5 MB) y `generate-api`.
 
-**Esfuerzo:** S-M. Ahorra cuota de API y hace visible la degradación.
+#### Gap 9: Herramientas de dibujo y AOI (épica E9, diferida)
 
-#### Gap 4: Frente de guerra en vivo y alertas de desastres
-
-**Severidad:** Media. **Backend:** Depende de CORS.
-
-OSIRIS expone dos capas sin llave que sí son relevantes para trackers
-existentes:
-
-- **DeepState frontlines** (`deepstatemap.live/api/history/last`):
-  GeoJSON de la línea de frente en Ucrania, cacheado 30 min. Para el
-  tracker de Ucrania sería la capa más valiosa del mapa: hoy el mapa
-  muestra puntos curados, no el frente.
-- **GDACS** (`gdacs.org/xml/rss.xml`): alertas geocodificadas de sismos,
-  inundaciones, ciclones, volcanes. Alimentaría los trackers de Sahel,
-  Myanmar, Sudán y cualquier tracker de desastre, y es un candidato
-  natural para el light scan (los eventos ya vienen con coordenadas).
-
-**Consideraciones.** Verificar CORS y términos de uso de DeepState antes
-de llamarlo desde el navegador; si no permite CORS, un handler en
-`worker/handlers/` con allowlist de hosts (el `ssrf-guard` de OSIRIS es
-el patrón) y `Cache-Control` de 30 min. NASA FIRMS y EONET requieren
-llave o son globales y ruidosos; dejarlos para después.
-
-**Esfuerzo:** M por capa. DeepState primero, GDACS segundo.
-
-#### Gap 5: Panel de alertas con severidad en la web
-
-**Severidad:** Media. **Backend:** No.
-
-`LiveAlerts.tsx` de OSIRIS mezcla noticias con `risk_score` 0-10,
-sismos por magnitud y streams en vivo, con pestañas por tipo y colores
-por severidad (CRITICAL ≥8, HIGH ≥6, ELEVATED ≥4). Al pasar el cursor
-vuela al punto en el mapa.
-
-**Estado en Watchboard.** El light scan ya produce exactamente esa
-señal: `scoreCandidate()` da 0-1, con umbral 0.85 para alerta y
-`MODERATE_THRESHOLD` para pendiente, y todo queda en
-`public/_hourly/triage-log.json`. Pero esa señal solo llega a Telegram y
-a la página de auditoría; el homepage no la muestra.
-
-**Propuesta.** Un panel colapsable en `CommandCenter` que lea
-`triage-log.json` en runtime (como ya hace `TriageLogBoard`), filtre
-`update` y `new_tracker` con score ≥ umbral, muestre severidad por color
-y vuele al tracker al hacer clic. Los sismos M≥4.5 de `useEarthquakes`
-pueden entrar como segunda pestaña.
-
-**Esfuerzo:** S. Reusa datos y componentes existentes.
-
-#### Gap 6: Geoparsing de candidatos del light scan
-
-**Severidad:** Media-baja. **Backend:** No.
-
-OSIRIS geoparsea posts de Telegram contra diccionarios multilingües y
-los pinta en el mapa. Watchboard ya lee los mismos canales con
-`pollTelegram()` pero los candidatos no tienen coordenadas hasta que el
-heavy scan los convierte en eventos.
-
-**Propuesta.** Construir el gazetteer desde los propios datos: los
-`map-points.json` de los 125 trackers ya tienen nombre + lat/lon, y
-`geo-utils.ts` tiene helpers. Añadir a `keyword-match.ts` un paso que
-asigne el punto más cercano por nombre y guardar `lat/lon` en
-`pending-candidates.json`. Con eso los candidatos aparecen en el globo
-antes de la triage IA y el panel del Gap 5 puede volar a ellos.
-
-**Esfuerzo:** M.
-
-#### Gap 7: Índice de actividad por tracker en lugar de riesgo hardcodeado
-
-**Severidad:** Baja. **Backend:** No.
-
-`country-risk` en OSIRIS es una tabla estática más sismos. Watchboard
-puede hacerlo honestamente: eventos de los últimos 7 días, cuántos
-marcados `breaking`, deltas de KPI (BL-024), frescura del digest.
-Calculado en build en `generate-api.ts` y expuesto en
-`public/api/v1/trackers.json`, alimentaría el orden de la sidebar, el
-carrusel de stories y la selección de trackers del video diario
-(`hero-selection.ts` ya hace una versión de esto).
-
-**Esfuerzo:** M. Hacer junto con BL-024.
-
-#### Gap 8: Imagen Docker para auto-hospedaje
-
-**Severidad:** Baja para producto, alta para crecimiento. **Backend:** No.
-
-OSIRIS publica una imagen en GHCR (~220 MB) con instalación de un clic
-en CasaOS. Una parte considerable de sus stars viene del ecosistema de
-self-hosting. Watchboard es estático: un `Dockerfile` multi-stage que
-haga `npm run build` y sirva `dist/` con nginx pesaría menos y se
-publicaría desde `deploy.yml`.
-
-**Esfuerzo:** S. Palanca de distribución barata; añadir a awesome-selfhosted.
-
-#### Gap 9: AOI y "watch" con detección de cambios
-
-**Severidad:** Baja. **Backend:** No.
-
-OSIRIS permite dibujar un polígono y responde "qué hay dentro" barriendo
-todas las capas (`aoi.ts`, con rechazo por bounding box antes del ray
-casting), y `watch.ts` convierte barridos repetidos en eventos
-enter/exit con una ventana rodante de 100.
-
-Para Watchboard el caso de uso es más débil: los datos curados cambian
-una vez al día y ya hay push por tracker. La versión útil sería "dibuja
-un área, te digo qué trackers y eventos caen dentro", como filtro
-espacial del directorio. Diferir hasta que exista el Gap 1.
-
-**Esfuerzo:** M-L.
+`draw.ts` es un reducer puro con cuatro modos que colapsan a un anillo
+GeoJSON; `aoi.ts` barre 11 capas con rechazo por bounding box antes del
+ray casting; `aoi-export.ts` persiste en `localStorage` validando cada
+registro y descartando solo los corruptos. Para Watchboard el caso de
+uso es "dibuja un área y te digo qué trackers y eventos caen dentro".
+`watch.ts` (enter/exit) no aplica a un archivo estático, salvo la regla
+"la primera pasada no es un evento".
 
 ### Lo que no conviene tomar
 
 | Feature OSIRIS | Razón para no adoptarla |
 |---|---|
-| RECON toolkit (port scan, WHOIS, SSL, IP intel, CVE) | Fuera de misión, doble uso, exposición legal. Watchboard es periodismo de datos, no reconocimiento de red |
-| CCTV en vivo (17k cámaras) | Sin relación con trackers temáticos; costo de mantenimiento alto, riesgo de privacidad |
-| Rastreo de wallets y ChainBrief | Otro producto |
-| Servidor Next.js con 44 proxies | Rompe el modelo de cero infraestructura que es la ventaja de confiabilidad de Watchboard |
-| LLM bajo demanda sin caché (Gemini) | Costo por visitante, sin verificación de fuentes, sin tiers. El modelo nocturno con datos versionados es superior para un archivo |
-| `country-risk` estático | Números inventados con apariencia de modelo. Ver Gap 7 para la versión honesta |
-| StyleStudio (theming por usuario) | Cesium ya tiene 7 modos visuales; bajo retorno |
-
----
-
-## Roadmap sugerido
-
-Ordenado por retorno sobre esfuerzo y por dependencias. Los IDs BL-* y
-las referencias a milestones son del `BACKLOG.md` y `product-roadmap.md`.
-
-```
-Fase A — Quick wins (una semana)
-  Gap 2  URL compartible en globo y mapa            [S]   desbloquea BL-003
-  Gap 5  Panel de alertas desde triage-log          [S]
-  Gap 3  live-source-cache + chip "degraded"        [S-M] cierra BL-020
-  Gap 8  Dockerfile + imagen GHCR                   [S]
-
-Fase B — Contexto espacial (M3-M4)
-  Gap 1  Dossier por clic (Nominatim + Wikidata)    [M]   tema country trackers
-  Gap 4  DeepState frontline en tracker Ucrania     [M]
-  Gap 4  GDACS como fuente del light scan           [M]
-
-Fase C — Señal (M4+)
-  Gap 7  Índice de actividad por tracker            [M]   junto con BL-024
-  Gap 6  Geoparsing de candidatos                   [M]
-  Gap 9  Filtro espacial del directorio             [M-L] después de Gap 1
-```
+| RECON toolkit (20 módulos: port scan, vuln sweep, Shodan, WHOIS, leaks, infostealer, teléfono) | Consultas en vivo a terceros, doble uso, exposición legal. Dos módulos llaman a Shodan y XposedOrNot directo desde el navegador del usuario |
+| `WorldRemote` (Bluetooth + escaneo de puertos locales vía WebRTC) | Fuera de misión y sin UI de consentimiento |
+| CCTV (48 adaptadores, ~19k cámaras) | Sin relación con trackers temáticos; el proxy deshabilita TLS (`rejectUnauthorized=false`) y sigue redirects sin revalidar allowlist |
+| Cripto / ChainBrief / TokenPanel | Otro producto; el TokenPanel promociona el token del proyecto |
+| Navegación turn-by-turn (`DirectionsBar`, 1,048 líneas) | App de consumo injertada; nada de OSINT |
+| Mercados (Yahoo Finance con UA falso) | Live-only; scraping |
+| `stealthFetch` (rotación de UA + `X-Forwarded-For` falsificado) | Evasión de rate limits; envenena logs de terceros; problema de términos de uso antes que técnico |
+| Servidor Next.js con 69 rutas | Rompe el modelo de cero infraestructura |
+| LLM bajo demanda sin caché | Costo por visitante; `/api/ai/overview` sin rate limit llama a Gemini con llaves del servidor en cada petición anónima |
+| `risk_score` + `machine_assessment` | Conteo de palabras presentado como análisis; los tiers de Watchboard existen para evitar exactamente esto |
+| `country-risk` estático | Números inventados con apariencia de modelo |
+| StyleStudio (28 controles) | Cesium ya tiene 7 modos visuales; el modelo de tokens sí es bueno (ver lecciones) |
+| Telemetría de IP en middleware | PII enviada a un host interno por HTTP plano |
 
 ---
 
 ## Lecciones de ingeniería transferibles
 
-Independientes de features, tres decisiones de OSIRIS valen la pena
-copiar como convención:
+Independientes de features, con la cita del código donde viven:
 
-1. **Nunca dejar una capa en cero en silencio.** El comentario de
-   `sourceCache.ts` ("keep serving the last good index rather than
-   dropping the layer to zero") es la misma regla que
-   `silent-failure-patterns.md` aprendió por el camino difícil. Aplicarla
-   a todos los hooks de datos en vivo.
-2. **Cabeceras de caché explícitas por fuente.** Cada ruta de OSIRIS
-   declara `s-maxage` y `stale-while-revalidate` acordes a la
-   volatilidad del dato. Si Watchboard añade handlers en el Worker
-   (Gap 4), adoptar la misma disciplina y un allowlist de hosts.
-3. **Baseline silencioso.** `watch.ts` no reporta nada en la primera
-   pasada para no generar falsas alertas de "entrada". El light scan
-   podría aplicar el mismo principio al añadir una fuente nueva: primera
-   corrida solo siembra, no alerta.
+1. **Nunca dejar una capa en cero en silencio.** `sourceCache.ts:11-15`:
+   "keep serving the last good index rather than dropping the layer to
+   zero cameras". `loadLayerOnce` (`page.tsx:700-706`) borra la marca
+   de "ya cargado" si la petición falla. Es la misma regla que
+   `silent-failure-patterns.md` aprendió por el camino difícil.
+2. **Fallo parcial explícito, no global.** `chainFeeds.ts:11-13`: "one
+   dead upstream must never blank the brief, so every collector
+   resolves to an empty section plus a stated reason". `ChainBrief`
+   muestra un bloque "DEGRADED SOURCES" como elemento de primera clase.
+3. **Procedencia visible en texto generado.** `AiOverview.tsx:127-130`
+   etiqueta el resultado como `GEMINI 2.0 FLASH` o `HEURISTIC ANALYST`
+   y tiene un digest determinista de respaldo para que el botón nunca
+   falle.
+4. **Taxonomía epistémica.** El módulo de username separa confirmado /
+   no verificable / bloqueado / no aplicable en vez de colapsar
+   "desconocido" en "no encontrado". Encaja con los tiers y el campo
+   `contested` de Watchboard.
+5. **Identificadores reciclados.** `camera-feed.ts:108-115`: Skyline
+   reutiliza IDs numéricos y una cámara retirada muestra otro lugar bajo
+   el mismo rótulo. "A wrong picture under a confident label is worse
+   than no picture". Aplica a `og:image` y thumbnails de Watchboard.
+6. **No renderizar una caja rota.** `CctvPreviews.tsx:196-198`; y el
+   handshake `postMessage` de YouTube para detectar "video unavailable"
+   dentro de un iframe que cargó bien.
+7. **Compresión para display, valor real en el readout.**
+   `satellite-layer.ts:49-51`: la altitud se comprime en una curva
+   sqrt para que quepa en el frustum, y el popup muestra la real.
+8. **Elegir con las mismas matemáticas con que se dibuja.** El picking
+   de satélites reutiliza el vertex shader escribiendo `gl_InstanceID`
+   para que no haya dos fuentes de verdad que deriven.
+9. **La primera pasada no es un evento.** `watch.ts:11-19`. Aplicar al
+   light scan al añadir una fuente nueva: primera corrida solo siembra.
+10. **Tokens de tema en dos mecanismos separados.**
+    `style-tokens.ts:1-16`: paleta como custom properties inline (gana
+    siempre), lo demás en una sola hoja inyectada condicional; `null`
+    significa "no tocar".
+11. **Pruebas de red opt-in.** `const liveIt = process.env.RUN_LIVE_TESTS
+    === '1' ? it : it.skip;` repetido en 10 archivos y `npm run
+    test:live`. Watchboard no tiene esta convención y la necesitará para
+    DeepState, GDACS y Nominatim.
+12. **Probe de capacidades.** Ocultar capas cuya llave no existe en vez
+    de mostrarlas rotas (`LayerPanel.tsx:224-227`). Aplica a la capa de
+    barcos, que hoy exige llave AIS en `localStorage`.
+13. **Cabeceras de caché por fuente y allowlist de hosts** en cualquier
+    proxy. Si Watchboard añade handlers al Worker, mirar
+    `functions/api/push/_shared.ts:30` (ya tiene allowlist de orígenes)
+    y no repetir los errores del proxy de cámaras de OSIRIS.
 
 ---
 
 ## Fuentes
 
-- README, `SECURITY.md` y árbol de `src/` de `simplifaisoul/osiris`
-  (rama `master`), consultados el 7 de septiembre de 2026.
-- Rutas leídas: `api/region-dossier`, `api/gdelt`, `api/frontlines`,
-  `api/country-risk`, `api/entity/expand`, `api/health`.
-- Componentes leídos: `IntelFeed`, `LiveAlerts`, `SharePanel`,
-  `ViewPresets`, `ChainBrief`, `StyleStudio`.
-- Librerías leídas: `ai-engine.ts`, `aoi.ts`, `watch.ts`, `sourceCache.ts`.
+- Clon de `simplifaisoul/osiris` en `master` (`d2c08c8`, 2026-09-06):
+  `src/app/page.tsx`, `OsirisMap.tsx`, 36 componentes, 49 librerías, 69
+  rutas, `intel/server.js`, `middleware.ts`, `Dockerfile`,
+  `docker-compose.yml`, `nginx/nginx.conf`, README, DOCKER.md,
+  SECURITY.md, 38 archivos de test.
+- Watchboard `feead12`: `src/components/islands/CesiumGlobe/*`,
+  `IntelMap.tsx`, `useMapOverlays.ts`, `MapOverlayData.ts`,
+  `CommandCenter/*`, `scripts/hourly-*.ts`, `src/lib/keyword-match.ts`,
+  `worker/`, `functions/`, `scripts/generate-api.ts`,
+  `scripts/generate-health.ts`, `BACKLOG.md`, `TECH_DEBT.md`,
+  `docs/product-roadmap.md`.
+- Verificación de cabeceras CORS y caché de DeepState, GDACS y
+  Nominatim el 7 de septiembre de 2026.

--- a/docs/competitive-analysis-osiris.md
+++ b/docs/competitive-analysis-osiris.md
@@ -1,0 +1,392 @@
+# Análisis competitivo: Watchboard vs OSIRIS
+
+Comparación entre Watchboard y OSIRIS (`simplifaisoul/osiris`), un
+dashboard OSINT en tiempo real que se posiciona como "alternativa open
+source a Palantir". Complementa `competitive-analysis-worldmonitor.md`:
+OSIRIS pertenece a la misma familia que World Monitor (SPA con mapa
+WebGL y decenas de feeds en vivo), así que este documento se centra en
+lo que OSIRIS hace distinto y en qué de eso conviene adoptar.
+
+**Última actualización:** 7 de septiembre de 2026
+**OSIRIS analizado:** rama `master`, ~301 commits
+**Watchboard:** `feead12` (main)
+
+---
+
+## Resumen ejecutivo
+
+OSIRIS y Watchboard resuelven problemas distintos con arquitecturas
+opuestas. OSIRIS es un **visor de sensores**: agrega 16 capas en vivo
+(aviones, sismos, incendios, CCTV, sanciones, Telegram) sobre un mapa
+MapLibre y no guarda historia ni cura nada. Watchboard es un **archivo
+curado**: 125 trackers con línea de tiempo, tiers de fuente y datos
+versionados en git, actualizados por IA.
+
+Lo que vale la pena tomar de OSIRIS no son sus capas (la mayoría están
+fuera de misión) sino **cinco patrones de producto e ingeniería** que
+encajan en el backlog actual sin cambiar la arquitectura estática:
+
+1. Dossier contextual por clic en el mapa (Nominatim + Wikidata).
+2. URL compartible con estado de vista, sin esperar el ADR de nanostores.
+3. Caché de fuentes en vivo con dedupe en vuelo y "stale-on-error".
+4. Frente de guerra en vivo (DeepState) y alertas GDACS como capas nuevas.
+5. Panel de alertas con severidad, alimentado por el light scan que ya existe.
+
+Lo que **no** conviene tomar: el toolkit RECON (port scan, WHOIS, SSL),
+CCTV en vivo, rastreo de wallets y la dependencia de un servidor Next.js
+con llamadas LLM sin caché.
+
+---
+
+## Vista general de los repositorios
+
+| Atributo | OSIRIS | Watchboard |
+|---|---|---|
+| Repositorio | `simplifaisoul/osiris` | `ArtemioPadilla/watchboard` |
+| Stars / forks | ~8.6k / ~1.8k | dos órdenes de magnitud menos |
+| Commits | ~301 | ~1,500+ |
+| Licencia | MIT | MIT |
+| Framework | Next.js 16 (App Router, Turbopack) | Astro 5 + islas React |
+| Mapa | MapLibre GL JS (WebGL) | Leaflet 2D + CesiumJS 3D |
+| Backend | 44 rutas API en Next.js + contenedor `intel/` | Ninguno (GitHub Pages) + Worker para push |
+| Hosting | Vercel Edge, Docker (GHCR), CasaOS | GitHub Pages, Cloudflare Worker |
+| IA | Gemini 2.0 Flash bajo demanda, sin caché | Claude Code Action nocturno, datos versionados |
+| Tests | 4 archivos `*.test.ts` visibles en `components/` | 26 archivos de test + Playwright e2e |
+| Datos históricos | No | Sí (timeline por eras, eventos diarios) |
+| Tiers de fuente | No | Tier 1-4 en cada dato |
+
+---
+
+## Arquitectura
+
+### OSIRIS
+
+```
+Navegador (Next.js client, MapLibre GL, Framer Motion)
+  |
+  v  fetch /api/*
+Next.js API routes (44)            -> proxies con Cache-Control s-maxage
+  |   flights, earthquakes, fires, gdelt (GDACS), frontlines (DeepState),
+  |   country-risk, region-dossier, osint (Telegram), sanctions, crypto,
+  |   markets, cloudflare-radar, malware, scanner, entity/expand, ai
+  |
+  +-> intel/ (contenedor Node separado: grafo de entidades, scanner)
+  +-> ~20 APIs públicas sin llave (OpenSky, USGS, NASA FIRMS/EONET,
+      NOAA SWPC, N2YO, NVD, OpenSanctions, blockstream, t.me/s/)
+```
+
+Características:
+- Todo es tiempo real; nada se persiste. Cerrar la pestaña borra el estado.
+- Las 13 "zonas de conflicto" y los 39 puertos son datos estáticos en código.
+- `country-risk` es una tabla hardcodeada (35 China, 90 Palestina) más un
+  bono por sismos M4.5+ del día. No hay modelo detrás.
+- El LLM (Gemini) se llama bajo demanda para "AI overview" y briefing
+  diario; sin caché, sin curación, sin verificación de fuentes.
+- Caché por ruta con `s-maxage` + `stale-while-revalidate` y una
+  `sourceCache` en memoria con TTL, dedupe de peticiones concurrentes y
+  fallback al último dato bueno si la fuente falla.
+- Rate limiting por IP y `ssrf-guard` en los proxies.
+
+### Watchboard
+
+Ver `competitive-analysis-worldmonitor.md`. Resumen: Astro SSG, datos en
+`trackers/{slug}/data/*.json` validados con Zod, pipeline nocturno de
+tres fases, globo Cesium con capas en vivo (vuelos OpenSky, satélites
+Celestrak, sismos USGS, clima Open-Meteo, GPS jamming, blackouts), light
+scan cada 15 min, RSS, API JSON estática, servidor MCP, push, video diario.
+
+### Trade-offs
+
+| Dimensión | Ventaja OSIRIS | Ventaja Watchboard |
+|---|---|---|
+| Frescura | Segundos a minutos | Nocturno + light scan de 15 min |
+| Profundidad | Ninguna: no hay historia ni contexto | Timeline, KPIs, claims, casualties por tema |
+| Costo infra | Vercel + contenedor `intel/` (pide Patreon) | Cero |
+| Confiabilidad | Cae cuando cae una API upstream | Datos en git nunca caen |
+| Calidad de dato | Crudo, sin tiers | Curado, tier 1-4, cuatro polos |
+| Distribución | Docker/GHCR/CasaOS, fácil de auto-hospedar | Solo la web |
+| Descubribilidad | 8.6k stars, Discord, "Palantir alternative" | Nicho, sin narrativa de posicionamiento |
+
+---
+
+## Matriz de features
+
+### Paridad o ventaja Watchboard
+
+| Feature | OSIRIS | Watchboard | Evaluación |
+|---|---|---|---|
+| Vuelos en vivo | OpenSky, capa global | OpenSky en globo y mapa, filtro militar por callsign | Paridad |
+| Sismos | USGS 2.5+ | USGS 2.5+ en globo | Paridad |
+| Satélites | N2YO (llave) | Celestrak TLE + satellite.js, sin llave | Ventaja WB |
+| Globo 3D | No (solo mapa 2D) | Cesium con misiles, modo cinemático, misiones lunares | Ventaja WB |
+| Multi-tema | Un dashboard global | 125 trackers independientes | Ventaja WB mayor |
+| Timeline / eventos | No | Eras, particiones diarias, media | Ventaja WB mayor |
+| Tiers de fuente | No | Tier 1-4 + polos | Ventaja WB mayor |
+| Pipeline IA | Gemini bajo demanda, sin verificación | Claude nocturno + fix agent + build gate | Ventaja WB mayor |
+| Telegram | Scraping t.me/s/ + geoparsing | `pollTelegram()` en light scan, sin geoparsing | Paridad parcial (ver Gap 6) |
+| Alertas | Panel LiveAlerts con severidad | Telegram + push por tracker, sin panel en la web | Paridad parcial (ver Gap 5) |
+| Atajos de teclado | Panel de shortcuts | Panel `?` | Paridad |
+| RSS / API / MCP | Nada | 4 feeds RSS, API JSON, servidor MCP | Ventaja WB |
+| Broadcast / stories / video | Nada | BroadcastOverlay, MobileStoryCarousel, video diario | Ventaja WB |
+| Métricas de ingesta | `/api/health` declarativo (no prueba nada) | MetricsDashboard con calendario de uptime | Ventaja WB |
+| i18n | Solo inglés | en/es/fr/pt | Ventaja WB |
+| Compartir vista | URL con lat/lon/zoom/layers | No hay deep links | Gap (ver Gap 2) |
+
+### Gaps: lo que OSIRIS tiene y Watchboard no
+
+Cada gap indica qué hace OSIRIS, cómo se traduce a Watchboard, esfuerzo
+estimado (XS <2h, S medio día, M 1-2 días, L 3-5 días) y si requiere
+backend.
+
+#### Gap 1: Dossier contextual por clic en el mapa
+
+**Severidad:** Alta. **Backend:** No.
+
+En OSIRIS, clic derecho en cualquier punto del mapa llama a
+`/api/region-dossier`: Nominatim (reverse geocoding) y luego, en
+paralelo, Wikipedia REST y Wikidata SPARQL para país, capital, población,
+jefe de estado y bandera. Cachea una hora.
+
+**Traducción a Watchboard.** El mismo gesto sobre el globo del homepage
+o el mapa de un tracker abriría un panel con: los trackers cuyo
+`country` coincide con el país resuelto, sus últimos eventos, y los
+datos de Wikidata. Esto convierte el globo en un índice espacial de los
+125 trackers, que hoy solo se navegan por lista. El campo `country` ya
+existe en `tracker.json` (lo usa `tracker-feeds.ts`).
+
+- Nominatim se puede llamar desde el cliente respetando su política de
+  uso (1 req/s, `User-Agent` identificable). Wikidata SPARQL también.
+- Reusar `FloatingFactCard` / `CesiumInfoPanel` para el panel.
+- Cachear por país en `sessionStorage`.
+
+**Esfuerzo:** M. Encaja con el tema "Country trackers" de M4.
+
+#### Gap 2: URL compartible con estado de vista
+
+**Severidad:** Alta. **Backend:** No.
+
+`SharePanel.tsx` de OSIRIS codifica cuatro parámetros: `lat`, `lon`,
+`zoom`, `layers` (lista separada por comas). Nada más. Al abrir la URL
+el mapa aterriza en el mismo estado.
+
+**Traducción a Watchboard.** El backlog tiene BL-003 (deep links) como
+M-H y bloqueado por el ADR de nanostores para búsqueda. OSIRIS demuestra
+que la versión mínima no necesita estado compartido entre islas: el
+globo y el mapa ya poseen su cámara y sus toggles de capa. Leer
+`URLSearchParams` al montar y escribir con `history.replaceState` al
+cambiar es local a `CesiumGlobe.tsx` y `IntelMap.tsx`.
+
+- Parámetros propuestos: `lat`, `lon`, `alt` (Cesium) o `zoom` (Leaflet),
+  `layers`, `event` (slug de evento para abrir su panel; `event-slug.ts`
+  ya existe), `date` (para el scrubber de timeline).
+- Sirve de base para OG images dinámicas y para que el light scan
+  incluya enlaces que aterricen en el punto exacto.
+
+**Esfuerzo:** S. Desbloquea BL-003 sin esperar BL-001.
+
+#### Gap 3: Caché de fuentes en vivo con dedupe y stale-on-error
+
+**Severidad:** Media-alta. **Backend:** No.
+
+`sourceCache.ts` de OSIRIS implementa tres cosas que Watchboard no tiene
+en sus hooks de globo: TTL configurable, una sola petición en vuelo por
+clave (dos componentes que piden vuelos comparten la promesa) y, si la
+fuente falla, servir el último dato bueno con reintento a 60 s en vez
+de dejar la capa en cero. El README reporta "75% menos peticiones edge"
+al relajar polling de datos estables a 15-30 min y cargar por viewport.
+
+**Estado en Watchboard.** `useMapFlights.ts` y `useFlights.ts` llaman a
+OpenSky cada 15 s con un bounding box fijo (12-42N, 24-65E) aunque el
+usuario mire otra región. OpenSky anónimo tiene cupo diario de créditos
+y ese ritmo lo agota en minutos de sesión larga. No se pausa cuando la
+pestaña está oculta. Si OpenSky devuelve 429 la capa desaparece sin
+aviso, exactamente el patrón que documenta `silent-failure-patterns.md`.
+
+**Propuesta.** Un `src/lib/live-source-cache.ts` compartido por
+`useFlights`, `useEarthquakes`, `useSatellites`, `useWeather`:
+
+- TTL por fuente (vuelos 30-60 s, sismos 5 min, TLE 6 h).
+- Dedupe en vuelo por clave (`fuente + bbox`).
+- Último dato bueno + flag `degraded` que la UI muestre como chip ámbar
+  en el HUD (cierra BL-020 "API health indicator").
+- Bbox derivado de la cámara actual, no fijo.
+- Pausa con `document.visibilityState === 'hidden'`.
+
+**Esfuerzo:** S-M. Ahorra cuota de API y hace visible la degradación.
+
+#### Gap 4: Frente de guerra en vivo y alertas de desastres
+
+**Severidad:** Media. **Backend:** Depende de CORS.
+
+OSIRIS expone dos capas sin llave que sí son relevantes para trackers
+existentes:
+
+- **DeepState frontlines** (`deepstatemap.live/api/history/last`):
+  GeoJSON de la línea de frente en Ucrania, cacheado 30 min. Para el
+  tracker de Ucrania sería la capa más valiosa del mapa: hoy el mapa
+  muestra puntos curados, no el frente.
+- **GDACS** (`gdacs.org/xml/rss.xml`): alertas geocodificadas de sismos,
+  inundaciones, ciclones, volcanes. Alimentaría los trackers de Sahel,
+  Myanmar, Sudán y cualquier tracker de desastre, y es un candidato
+  natural para el light scan (los eventos ya vienen con coordenadas).
+
+**Consideraciones.** Verificar CORS y términos de uso de DeepState antes
+de llamarlo desde el navegador; si no permite CORS, un handler en
+`worker/handlers/` con allowlist de hosts (el `ssrf-guard` de OSIRIS es
+el patrón) y `Cache-Control` de 30 min. NASA FIRMS y EONET requieren
+llave o son globales y ruidosos; dejarlos para después.
+
+**Esfuerzo:** M por capa. DeepState primero, GDACS segundo.
+
+#### Gap 5: Panel de alertas con severidad en la web
+
+**Severidad:** Media. **Backend:** No.
+
+`LiveAlerts.tsx` de OSIRIS mezcla noticias con `risk_score` 0-10,
+sismos por magnitud y streams en vivo, con pestañas por tipo y colores
+por severidad (CRITICAL ≥8, HIGH ≥6, ELEVATED ≥4). Al pasar el cursor
+vuela al punto en el mapa.
+
+**Estado en Watchboard.** El light scan ya produce exactamente esa
+señal: `scoreCandidate()` da 0-1, con umbral 0.85 para alerta y
+`MODERATE_THRESHOLD` para pendiente, y todo queda en
+`public/_hourly/triage-log.json`. Pero esa señal solo llega a Telegram y
+a la página de auditoría; el homepage no la muestra.
+
+**Propuesta.** Un panel colapsable en `CommandCenter` que lea
+`triage-log.json` en runtime (como ya hace `TriageLogBoard`), filtre
+`update` y `new_tracker` con score ≥ umbral, muestre severidad por color
+y vuele al tracker al hacer clic. Los sismos M≥4.5 de `useEarthquakes`
+pueden entrar como segunda pestaña.
+
+**Esfuerzo:** S. Reusa datos y componentes existentes.
+
+#### Gap 6: Geoparsing de candidatos del light scan
+
+**Severidad:** Media-baja. **Backend:** No.
+
+OSIRIS geoparsea posts de Telegram contra diccionarios multilingües y
+los pinta en el mapa. Watchboard ya lee los mismos canales con
+`pollTelegram()` pero los candidatos no tienen coordenadas hasta que el
+heavy scan los convierte en eventos.
+
+**Propuesta.** Construir el gazetteer desde los propios datos: los
+`map-points.json` de los 125 trackers ya tienen nombre + lat/lon, y
+`geo-utils.ts` tiene helpers. Añadir a `keyword-match.ts` un paso que
+asigne el punto más cercano por nombre y guardar `lat/lon` en
+`pending-candidates.json`. Con eso los candidatos aparecen en el globo
+antes de la triage IA y el panel del Gap 5 puede volar a ellos.
+
+**Esfuerzo:** M.
+
+#### Gap 7: Índice de actividad por tracker en lugar de riesgo hardcodeado
+
+**Severidad:** Baja. **Backend:** No.
+
+`country-risk` en OSIRIS es una tabla estática más sismos. Watchboard
+puede hacerlo honestamente: eventos de los últimos 7 días, cuántos
+marcados `breaking`, deltas de KPI (BL-024), frescura del digest.
+Calculado en build en `generate-api.ts` y expuesto en
+`public/api/v1/trackers.json`, alimentaría el orden de la sidebar, el
+carrusel de stories y la selección de trackers del video diario
+(`hero-selection.ts` ya hace una versión de esto).
+
+**Esfuerzo:** M. Hacer junto con BL-024.
+
+#### Gap 8: Imagen Docker para auto-hospedaje
+
+**Severidad:** Baja para producto, alta para crecimiento. **Backend:** No.
+
+OSIRIS publica una imagen en GHCR (~220 MB) con instalación de un clic
+en CasaOS. Una parte considerable de sus stars viene del ecosistema de
+self-hosting. Watchboard es estático: un `Dockerfile` multi-stage que
+haga `npm run build` y sirva `dist/` con nginx pesaría menos y se
+publicaría desde `deploy.yml`.
+
+**Esfuerzo:** S. Palanca de distribución barata; añadir a awesome-selfhosted.
+
+#### Gap 9: AOI y "watch" con detección de cambios
+
+**Severidad:** Baja. **Backend:** No.
+
+OSIRIS permite dibujar un polígono y responde "qué hay dentro" barriendo
+todas las capas (`aoi.ts`, con rechazo por bounding box antes del ray
+casting), y `watch.ts` convierte barridos repetidos en eventos
+enter/exit con una ventana rodante de 100.
+
+Para Watchboard el caso de uso es más débil: los datos curados cambian
+una vez al día y ya hay push por tracker. La versión útil sería "dibuja
+un área, te digo qué trackers y eventos caen dentro", como filtro
+espacial del directorio. Diferir hasta que exista el Gap 1.
+
+**Esfuerzo:** M-L.
+
+### Lo que no conviene tomar
+
+| Feature OSIRIS | Razón para no adoptarla |
+|---|---|
+| RECON toolkit (port scan, WHOIS, SSL, IP intel, CVE) | Fuera de misión, doble uso, exposición legal. Watchboard es periodismo de datos, no reconocimiento de red |
+| CCTV en vivo (17k cámaras) | Sin relación con trackers temáticos; costo de mantenimiento alto, riesgo de privacidad |
+| Rastreo de wallets y ChainBrief | Otro producto |
+| Servidor Next.js con 44 proxies | Rompe el modelo de cero infraestructura que es la ventaja de confiabilidad de Watchboard |
+| LLM bajo demanda sin caché (Gemini) | Costo por visitante, sin verificación de fuentes, sin tiers. El modelo nocturno con datos versionados es superior para un archivo |
+| `country-risk` estático | Números inventados con apariencia de modelo. Ver Gap 7 para la versión honesta |
+| StyleStudio (theming por usuario) | Cesium ya tiene 7 modos visuales; bajo retorno |
+
+---
+
+## Roadmap sugerido
+
+Ordenado por retorno sobre esfuerzo y por dependencias. Los IDs BL-* y
+las referencias a milestones son del `BACKLOG.md` y `product-roadmap.md`.
+
+```
+Fase A — Quick wins (una semana)
+  Gap 2  URL compartible en globo y mapa            [S]   desbloquea BL-003
+  Gap 5  Panel de alertas desde triage-log          [S]
+  Gap 3  live-source-cache + chip "degraded"        [S-M] cierra BL-020
+  Gap 8  Dockerfile + imagen GHCR                   [S]
+
+Fase B — Contexto espacial (M3-M4)
+  Gap 1  Dossier por clic (Nominatim + Wikidata)    [M]   tema country trackers
+  Gap 4  DeepState frontline en tracker Ucrania     [M]
+  Gap 4  GDACS como fuente del light scan           [M]
+
+Fase C — Señal (M4+)
+  Gap 7  Índice de actividad por tracker            [M]   junto con BL-024
+  Gap 6  Geoparsing de candidatos                   [M]
+  Gap 9  Filtro espacial del directorio             [M-L] después de Gap 1
+```
+
+---
+
+## Lecciones de ingeniería transferibles
+
+Independientes de features, tres decisiones de OSIRIS valen la pena
+copiar como convención:
+
+1. **Nunca dejar una capa en cero en silencio.** El comentario de
+   `sourceCache.ts` ("keep serving the last good index rather than
+   dropping the layer to zero") es la misma regla que
+   `silent-failure-patterns.md` aprendió por el camino difícil. Aplicarla
+   a todos los hooks de datos en vivo.
+2. **Cabeceras de caché explícitas por fuente.** Cada ruta de OSIRIS
+   declara `s-maxage` y `stale-while-revalidate` acordes a la
+   volatilidad del dato. Si Watchboard añade handlers en el Worker
+   (Gap 4), adoptar la misma disciplina y un allowlist de hosts.
+3. **Baseline silencioso.** `watch.ts` no reporta nada en la primera
+   pasada para no generar falsas alertas de "entrada". El light scan
+   podría aplicar el mismo principio al añadir una fuente nueva: primera
+   corrida solo siembra, no alerta.
+
+---
+
+## Fuentes
+
+- README, `SECURITY.md` y árbol de `src/` de `simplifaisoul/osiris`
+  (rama `master`), consultados el 7 de septiembre de 2026.
+- Rutas leídas: `api/region-dossier`, `api/gdelt`, `api/frontlines`,
+  `api/country-risk`, `api/entity/expand`, `api/health`.
+- Componentes leídos: `IntelFeed`, `LiveAlerts`, `SharePanel`,
+  `ViewPresets`, `ChainBrief`, `StyleStudio`.
+- Librerías leídas: `ai-engine.ts`, `aoi.ts`, `watch.ts`, `sourceCache.ts`.

--- a/docs/superpowers/plans/2026-09-07-osiris-adoption-program.md
+++ b/docs/superpowers/plans/2026-09-07-osiris-adoption-program.md
@@ -1,0 +1,889 @@
+# Programa: lecciones de OSIRIS aplicadas a Watchboard
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking. Cada historia es una unidad de entrega independiente (una rama, un PR); cada épica es un milestone.
+
+**Fecha:** 2026-09-07
+**Estado:** Draft, pendiente de priorización por Prometeo
+**Spec:** `docs/competitive-analysis-osiris.md` (v2)
+**Autor:** análisis de código de `simplifaisoul/osiris@d2c08c8` y `watchboard@feead12`
+
+**Goal:** Cerrar los nueve gaps identificados frente a OSIRIS sin abandonar el modelo estático de Watchboard: estado de vista compartible, fuentes en vivo confiables con estado degradado visible, panel de alertas, dossier por clic, capas geoespaciales con procedencia, geoparsing del light scan, índice de actividad honesto, imagen Docker y procedencia visible en texto generado por IA.
+
+**Architecture:** Todo el trabajo es cliente estático + scripts de build + scan, salvo un handler opcional en el Worker de Cloudflare para fuentes sin CORS. No se añade servidor. Las librerías nuevas van a `src/lib/` como funciones puras con tests vitest; los componentes se enganchan en los puntos ya existentes (`CesiumGlobe.tsx:489-497` para hooks de capa, `layout-presets.ts:7-14` para paneles del globo, `CommandCenter.tsx:882-891` para overlays del homepage, `hourly-types.ts:63-74` para el pipeline).
+
+**Tech Stack:** Astro 5, React 19, Cesium 1.139, Leaflet 1.9, Zod 3, vitest 4, Playwright, Cloudflare Worker, GitHub Actions.
+
+---
+
+## Cómo leer este plan
+
+- **Épica (E#)**: objetivo de producto, cierra ítems del `BACKLOG.md` o del roadmap.
+- **Historia (E#.H#)**: entregable independiente con criterios de aceptación GIVEN/WHEN/THEN. Cumple INVEST.
+- **Tarea**: paso de implementación con archivo destino. Se marca con `- [ ]`.
+- **Esfuerzo**: XS < 2 h, S medio día, M 1-2 días, L 3-5 días.
+- **Procedencia**: cada épica cita el archivo de OSIRIS del que toma el patrón y el archivo de Watchboard donde se inserta.
+
+Clave de esfuerzo y prioridad igual que en `BACKLOG.md`.
+
+---
+
+## Principios del programa
+
+Derivados de las lecciones en `competitive-analysis-osiris.md`. Se
+aplican a toda historia; un PR que los viole no pasa revisión.
+
+1. **Ninguna capa queda en cero en silencio.** Toda fuente en vivo
+   expone un estado (`ok | stale | rate-limited | error | disabled`) y
+   la UI lo muestra. Un `if (!res.ok) return;` sin estado es un bug.
+2. **Toda capa dice qué es.** Datos curados estáticos llevan fecha de
+   instantánea y fuente visibles; datos en vivo llevan "actualizado hace
+   X". Nunca se presenta un array literal como feed.
+3. **Toda cifra derivada muestra sus factores.** Un índice, un score o
+   una severidad va acompañado de la lista de entradas que lo produjo.
+4. **Todo texto generado lleva procedencia.** Modelo o heurística, y
+   fecha.
+5. **Las pruebas de red son opt-in.** `RUN_LIVE_TESTS=1` activa tests
+   que tocan DeepState, GDACS, Nominatim; por defecto se saltan.
+6. **Nada de evasión.** Sin rotación de User-Agent, sin `X-Forwarded-For`
+   inventado, sin desactivar TLS. Si una fuente bloquea, se pide permiso
+   o se descarta.
+7. **La primera pasada no es un evento.** Fuentes nuevas en el scan
+   siembran estado en su primera corrida y no alertan.
+
+---
+
+## Mapa de épicas
+
+| ID | Épica | Fase | Esfuerzo | Depende de | Cierra |
+|---|---|---|---|---|---|
+| E0 | Fundamentos: ADR, tests live opt-in, registro de capas | A | S | — | Prerrequisito de BL-001/BL-003 |
+| E1 | Estado de vista compartible en URL | A | S-M | E0 | BL-003 (rebajado de M-H a S) |
+| E2 | Fuentes en vivo confiables y estado degradado | A | M | E0 | BL-020, parte de TD-024 |
+| E3 | Panel de alertas con severidad | A | S | E2 (chip de estado) | Roadmap "What changed today" parcial |
+| E8 | Distribución self-host (Docker, GHCR) | A | S | — | Ítem 1.5 de análisis World Monitor |
+| E4 | Dossier contextual por clic | B | M | E1, E0 | Tema "country trackers" M4 |
+| E5 | Capas geoespaciales con procedencia | B | M-L | E2, E0 | Ítem 1.1 de análisis World Monitor |
+| E9 | Procedencia y honestidad en UI | B | S-M | E2 | BL-021 parcial |
+| E6 | Geoparsing de candidatos | C | M | E3, E5 | — |
+| E7 | Índice de actividad por tracker | C | M | — | BL-024 |
+| E10 | Filtro espacial (AOI) del directorio | C (diferida) | M-L | E4 | — |
+
+Esfuerzo total estimado: 25 a 35 días de desarrollo. Fase A cabe en dos
+semanas; B en tres; C en tres.
+
+---
+
+## E0 — Fundamentos
+
+**Objetivo:** dejar listas las convenciones que las demás épicas
+necesitan y que hoy no existen: plantilla de ADR, tests de red opt-in,
+registro declarativo de capas.
+
+**Procedencia OSIRIS:** convención `liveIt` (`src/lib/httpJson.test.ts:15`), `vitest.config.ts` con `testTimeout: 30000`.
+
+### E0.H1 — Convención de ADR
+
+Como mantenedor, quiero una plantilla de ADR y dos ADR iniciales, para
+que BL-001 y BL-003 dejen de estar bloqueados por "necesita ADR" sin
+saber qué es un ADR en este repo.
+
+**Criterios de aceptación**
+
+- GIVEN `docs/adr/` WHEN abro `0000-template.md` THEN tiene secciones Contexto, Decisión, Consecuencias, Alternativas, Estado.
+- GIVEN `docs/adr/0001-url-view-state-is-island-local.md` WHEN lo leo THEN explica por qué el estado de vista no requiere nanostores y cita `CesiumGlobe.tsx:119-166` e `IntelMap.tsx:42-75`.
+- GIVEN `docs/adr/0002-live-layer-registry.md` THEN define el contrato de `LiveLayerSpec` (ver E0.H3).
+
+**Tareas** (XS)
+
+- [ ] Crear `docs/adr/0000-template.md`
+- [ ] Crear `docs/adr/0001-url-view-state-is-island-local.md`
+- [ ] Crear `docs/adr/0002-live-layer-registry.md`
+- [ ] Enlazar `docs/adr/` desde `CONTRIBUTING.md` y `CLAUDE.md` (sección Architecture)
+- [ ] Actualizar `BACKLOG.md`: BL-003 pasa de M-H a S, elimina "depende de BL-001"; BL-001 referencia el ADR-0001 como modelo
+
+### E0.H2 — Tests de red opt-in
+
+Como desarrollador, quiero que los tests que tocan APIs externas se
+salten por defecto y se activen con `RUN_LIVE_TESTS=1`, para que CI no
+dependa de DeepState o Nominatim.
+
+**Criterios de aceptación**
+
+- GIVEN `npm test` sin la variable WHEN corre un test marcado `liveIt` THEN aparece como skipped.
+- GIVEN `RUN_LIVE_TESTS=1 npm run test:live` THEN el test corre con timeout de 30 s.
+
+**Tareas** (XS)
+
+- [ ] Crear `tests/helpers/live.ts` exportando `liveIt` y `liveDescribe`
+- [ ] Añadir script `test:live` a `package.json`
+- [ ] Añadir `testTimeout` condicional en `vitest.config.ts`
+- [ ] Documentar en `CONTRIBUTING.md`
+
+### E0.H3 — Registro declarativo de capas en vivo
+
+Como desarrollador, quiero un registro único que describa cada capa
+(id, etiqueta, URL, licencia, atribución, TTL, CORS, tipo de renderer,
+si es instantánea curada o feed), para que los toggles, el chip de
+estado, el CSP y la página de fuentes se deriven de un solo lugar.
+
+**Criterios de aceptación**
+
+- GIVEN `src/lib/live-layers.ts` WHEN importo `LIVE_LAYERS` THEN cada entrada valida contra `LiveLayerSpecSchema` (Zod) en un test.
+- GIVEN una capa con `kind: 'snapshot'` THEN tiene `snapshotDate` obligatorio; con `kind: 'feed'` tiene `ttlMs` y `url`.
+- GIVEN el test `live-layers.test.ts` WHEN comparo los hosts de todas las URLs con `connect-src` de `src/layouts/BaseLayout.astro` THEN no falta ninguno (test que falla si alguien añade una fuente sin actualizar CSP).
+
+**Tareas** (S)
+
+- [ ] Crear `src/lib/live-layers.ts` con `LiveLayerSpecSchema`, tipo `LiveLayerSpec`, `LIVE_LAYERS` (inicialmente: flights, earthquakes, satellites, weather, ships, nfz, gps-jamming, blackouts)
+- [ ] Marcar nfz / gps-jamming / blackouts / weather-grid como `kind: 'snapshot'` con `snapshotDate: '2026-02-28'` y `scope: ['iran-conflict']`
+- [ ] Crear `src/lib/live-layers.test.ts` incluyendo la comprobación de CSP contra `BaseLayout.astro` y `public/_headers`
+- [ ] Extraer a `scripts/lib/csp-hosts.ts` una función que lea los hosts del meta CSP para reutilizarla en el test y en `csp-hashes.ts`
+
+---
+
+## E1 — Estado de vista compartible en URL
+
+**Objetivo:** que una URL del globo, del mapa 2D o del homepage
+reproduzca la vista exacta: cámara, capas activas, evento abierto,
+fecha del scrubber.
+
+**Procedencia OSIRIS:** `SharePanel.tsx:17-34` (genera), `page.tsx:336-380` (lee solo `layers`, escribe con debounce 1.5 s y `replaceState`). El bug de OSIRIS define nuestro test: ida y vuelta completa.
+
+**Inserción Watchboard:** `useCesiumCamera.ts` (cámara imperativa, sin serializar), `CesiumGlobe.tsx:129-136` (toggles), `CesiumGlobe.tsx:388-428` (`handleViewerReady`, vista inicial), `IntelMap.tsx:66-75`, `CommandCenter.tsx:145-198` (único precedente de `replaceState`).
+
+### E1.H1 — Librería pura de estado de vista
+
+Como desarrollador, quiero `encodeViewState` / `decodeViewState` puras
+y testeadas, para que globo, mapa y homepage compartan formato.
+
+**Criterios de aceptación**
+
+- GIVEN un `ViewState` `{lat, lon, alt?, zoom?, heading?, pitch?, layers[], event?, date?}` WHEN lo codifico y decodifico THEN obtengo un objeto igual con lat/lon a 4 decimales, alt a entero, heading/pitch a 1 decimal.
+- GIVEN `?lat=abc` THEN `decodeViewState` ignora el campo inválido y no lanza.
+- GIVEN `layers=flights,quakes` THEN solo se aceptan ids presentes en `LIVE_LAYERS` o en las categorías del tracker; los desconocidos se descartan.
+- GIVEN lat fuera de [-90, 90] o lon fuera de [-180, 180] THEN se descarta.
+
+**Tareas** (S)
+
+- [ ] Crear `src/lib/view-state.ts` con `ViewStateSchema` (Zod), `encodeViewState(state): URLSearchParams`, `decodeViewState(search, allowedLayers): Partial<ViewState>`, `mergeIntoUrl(state)` que preserva otros parámetros
+- [ ] Crear `src/lib/view-state.test.ts` con ida y vuelta, BVA en rangos, layers desconocidos, parámetros ajenos preservados
+- [ ] Añadir `writeViewStateDebounced(state, 500)` con `history.replaceState` (nunca `pushState`, para no llenar el historial)
+
+### E1.H2 — Globo: leer y escribir la vista
+
+Como lector, quiero copiar la URL del globo y que quien la abra vea la
+misma cámara y capas, para compartir un hallazgo exacto.
+
+**Criterios de aceptación**
+
+- GIVEN `/{tracker}/globe/?lat=33.3&lon=44.4&alt=250000&heading=90&pitch=-45&layers=flights,satellites` WHEN carga THEN la cámara aterriza ahí (tolerancia 1 %) y solo esas capas están activas; el preset inicial NO se aplica.
+- GIVEN muevo la cámara WHEN pasan 500 ms sin movimiento THEN la URL se actualiza sin entrada nueva en el historial.
+- GIVEN `?event={slug}` THEN se abre el panel de ese evento y la cámara vuela a su punto si tiene coordenadas.
+- GIVEN `?date=2026-03-05` THEN el scrubber de tiempo se posiciona en esa fecha.
+- GIVEN un test Playwright en `e2e/globe-share.spec.ts` WHEN navego con parámetros THEN `viewer.camera` reporta los valores esperados.
+
+**Tareas** (S-M)
+
+- [ ] `useCesiumCamera.ts`: exponer `getCameraState(): {lat, lon, alt, heading, pitch}` y suscribir `camera.moveEnd` con debounce
+- [ ] `CesiumGlobe.tsx:388-428`: en `handleViewerReady`, si `decodeViewState` trae cámara, usar `flyToPosition({duration: 0})` en lugar del preset
+- [ ] `CesiumGlobe.tsx:129-136`: inicializar toggles desde `layers` de la URL; escribir al cambiar
+- [ ] Manejar `event` con `event-slug.ts` y el `onSelect` existente de `useConflictData`
+- [ ] Manejar `date` con el estado de `currentDate`
+- [ ] Añadir `e2e/globe-share.spec.ts`
+- [ ] Añadir el workflow `e2e.yml` (Playwright en PR, solo specs `*-share.spec.ts` al principio) porque hoy ningún workflow ejecuta Playwright (BL-022)
+
+### E1.H3 — Mapa 2D: leer y escribir la vista
+
+Como lector, quiero lo mismo en el mapa Leaflet del tracker.
+
+**Criterios de aceptación**
+
+- GIVEN `/{tracker}/?lat=&lon=&zoom=&layers=` WHEN carga THEN el mapa centra y hace zoom ahí y activa esas capas.
+- GIVEN muevo el mapa THEN la URL se actualiza con debounce; el hash `#map` de navegación de secciones se preserva.
+
+**Tareas** (S)
+
+- [ ] `IntelMap.tsx:42-75`: leer estado inicial desde URL; `LeafletMap.tsx` expone `onMoveEnd` con centro y zoom
+- [ ] `MapLayerToggles.tsx`: al alternar, escribir `layers`
+- [ ] Test unitario de la fusión con el hash existente en `view-state.test.ts`
+
+### E1.H4 — Botón "Compartir vista" y homepage
+
+Como lector, quiero un botón que copie la URL con estado y un aviso
+"Enlace copiado", para no tener que editar la barra de direcciones.
+
+**Criterios de aceptación**
+
+- GIVEN el globo o el mapa WHEN pulso "Compartir" THEN el portapapeles contiene la URL actual con estado y aparece un toast 2 s.
+- GIVEN el homepage `/?tracker={slug}` THEN el tracker queda seleccionado y el globo vuela a él; el `#geo` existente sigue funcionando.
+- GIVEN el atajo `S` en el globo THEN copia la URL (documentar en el panel `?`).
+
+**Tareas** (XS-S)
+
+- [ ] Componente `src/components/islands/shared/ShareViewButton.tsx` (usa `navigator.clipboard`, fallback `execCommand`)
+- [ ] Montar en `CesiumControls.tsx` y `MapLayerToggles.tsx`
+- [ ] `CommandCenter.tsx:145-198`: aceptar `?tracker=` además de `#geo`/`#domain`, y escribirlo en `handleSelect`
+- [ ] Añadir fila a `SHORTCUTS` en `CommandCenter.tsx:40-52` y al panel del globo
+- [ ] i18n en/es/fr/pt para "Compartir vista" y "Enlace copiado"
+
+### E1.H5 — Documentación y roadmap
+
+**Tareas** (XS)
+
+- [ ] `docs/product-roadmap.md`: mover "Shareable deep links" a M3 con esfuerzo S y estado ✅ al cerrar
+- [ ] `src/data/roadmap-items.ts`: reflejar el cambio (protocolo de doble escritura en `product-roadmap.md:121-127`)
+- [ ] `CLAUDE.md`: párrafo sobre `view-state.ts` en Utilities
+
+---
+
+## E2 — Fuentes en vivo confiables y estado degradado
+
+**Objetivo:** que cada hook de capa en vivo use una caché común con
+dedupe, TTL, stale-on-error, pausa con pestaña oculta y bounding box
+derivado de la cámara, y que la UI muestre cuando una fuente está
+degradada. Además, etiquetar como instantánea curada lo que hoy se
+presenta como capa en vivo.
+
+**Procedencia OSIRIS:** `sourceCache.ts` (TTL 30 min, dedupe en vuelo, stale-on-error con reintento 60 s, tope 500 claves), `page.tsx:534-562` (`skipWhenHidden`), `page.tsx:700-706` (rollback en fallo), `ChainBrief.tsx:219-226` (bloque DEGRADED SOURCES), `LayerPanel.tsx:224-227` (probe de capacidades).
+
+**Inserción Watchboard:** `CesiumGlobe.tsx:489-497` (los nueve hooks), `useFlights.ts:54` (enum `FlightStatus`, único existente), `useFlights.ts:85` y `useMapFlights.ts:38` (bbox fijo, 15 s), `useEarthquakes.ts:55` y `useWeather.ts:77` (`return` silencioso), `useMapOverlays.ts:159-231`, `useTrackerDetail.ts:16-57` (precedente de caché en módulo), `CesiumHud.tsx`, `MapLayerToggles.tsx:102-106`, `MapOverlayData.ts` (duplicado de datos estáticos).
+
+### E2.H1 — Librería `live-source`
+
+Como desarrollador, quiero `fetchLiveSource(spec, params)` con caché,
+dedupe, stale-on-error y estado, para que ningún hook reimplemente la
+lógica de red.
+
+**Criterios de aceptación**
+
+- GIVEN dos llamadas concurrentes con la misma clave WHEN la primera está en vuelo THEN la segunda recibe la misma promesa (una sola petición de red).
+- GIVEN una entrada con TTL vigente THEN se devuelve sin red y `status: 'ok'`.
+- GIVEN el upstream responde 429 THEN se devuelve el último dato bueno con `status: 'rate-limited'` y `retryAfterMs` doblando desde 30 s hasta 120 s.
+- GIVEN el upstream falla y no hay dato previo THEN `status: 'error'`, `data: null`, y el próximo intento es a 60 s, no al TTL completo.
+- GIVEN un dato con más de `ttlMs * 2` de antigüedad THEN `status: 'stale'`.
+- GIVEN `document.visibilityState === 'hidden'` WHEN vence el TTL THEN no se refresca hasta `visibilitychange` a visible.
+- GIVEN un `AbortSignal` abortado THEN la petición se cancela y no se escribe en caché.
+- GIVEN una respuesta vacía (array de 0 elementos) THEN cuenta como fallo de refresco y se conserva el dato previo (regla de OSIRIS `sourceCache.ts:64-68`).
+- Todo lo anterior cubierto con `vi.useFakeTimers()` en `live-source.test.ts`.
+
+**Tareas** (M)
+
+- [ ] Crear `src/lib/live-source.ts`: tipos `LiveStatus`, `LiveResult<T>`, `fetchLiveSource`, `subscribeLiveSource` (para hooks), `getLiveStatus(key)`, tope de 200 claves
+- [ ] Crear `src/lib/use-live-source.ts`: hook React `useLiveSource(spec, params, {enabled, intervalMs})` que devuelve `{data, status, updatedAt, error, refresh}` y respeta `visibilitychange`
+- [ ] Crear `src/lib/live-source.test.ts` (fake timers, fetch mock) con los casos anteriores
+- [ ] Documentar la regla "respuesta vacía = fallo" en el header del archivo
+
+### E2.H2 — Vuelos: un solo hook, bbox de cámara, cadencia sana
+
+Como lector, quiero que la capa de vuelos muestre los aviones de la
+región que estoy mirando y no consuma la cuota de OpenSky en minutos.
+
+**Criterios de aceptación**
+
+- GIVEN el globo centrado en México WHEN activo vuelos THEN el bbox de la consulta cubre el viewport actual (con margen 10 %), no Medio Oriente.
+- GIVEN vuelos activos WHEN pasan 30 s THEN se refresca; con pestaña oculta no.
+- GIVEN OpenSky responde 429 THEN los aviones previos siguen visibles con estado "limitado" en el HUD.
+- GIVEN `useFlights.ts` y `useMapFlights.ts` THEN comparten `src/lib/flights-source.ts` (parseo, patrones militares) y ya no duplican la lista `MILITARY_PATTERNS`.
+
+**Tareas** (S-M)
+
+- [ ] Crear `src/lib/flights-source.ts` con `parseOpenSky`, `isMilitaryCallsign`, `openSkyUrl(bbox)`
+- [ ] Reescribir `CesiumGlobe/useFlights.ts` sobre `useLiveSource`, bbox de `camera.computeViewRectangle()`, intervalo 30 s, cuantizar bbox a 1° para que la clave de caché sea estable
+- [ ] Reescribir `useMapFlights.ts` igual, bbox de `map.getBounds()`
+- [ ] Test unitario de `flights-source.test.ts` (parseo, cuantización de bbox)
+- [ ] Verificar cuota: documentar en el header que OpenSky anónimo da 400 créditos/día y que 30 s con bbox pequeño cabe
+
+### E2.H3 — Sismos, clima, satélites, overlays 2D sobre `live-source`
+
+Como lector, quiero que si USGS o Open-Meteo fallan la capa diga "sin
+datos desde hace X" en vez de desaparecer.
+
+**Criterios de aceptación**
+
+- GIVEN USGS devuelve 503 WHEN la capa de sismos ya tenía datos THEN siguen visibles con estado `stale`; si no tenía, el toggle muestra "error".
+- GIVEN un tracker con `map.center` en Brasil THEN el bbox de sismos cubre Brasil.
+- GIVEN clima WHEN el tracker no es de Irán THEN la grilla de ciudades se calcula a partir de `map.bounds` (grilla 3×3 dentro del bbox), no de las 14 ciudades hardcodeadas.
+- GIVEN `useMapOverlays.ts` THEN ya no contiene `.catch(() => {})` sin estado.
+
+**Tareas** (M)
+
+- [ ] `useEarthquakes.ts`: usar `useLiveSource`, bbox de tracker (`map.bounds`) o de cámara, eliminar `if (!res.ok) return;`
+- [ ] `useWeather.ts`: grilla derivada de bounds; conservar las 14 ciudades solo como override opcional en `tracker.json` (`globe.weatherPoints`)
+- [ ] `useSatellites.ts`: TLE con TTL 6 h en caché; `Promise.allSettled` reporta qué grupo falló en `status`
+- [ ] `useMapOverlays.ts:159-231`: migrar sismos y clima
+- [ ] Extender `TrackerConfigSchema` con `globe.weatherPoints?` (opcional) en `tracker-config.ts`
+
+### E2.H4 — Chip de estado de fuentes (cierra BL-020)
+
+Como lector, quiero ver en el HUD y en los toggles si una fuente está
+viva, retrasada o caída.
+
+**Criterios de aceptación**
+
+- GIVEN el globo THEN el HUD muestra por cada capa activa un punto verde (ok), ámbar (stale o rate-limited, con "hace X min") o rojo (error), reutilizando las clases `.freshness-indicator/.fresh/.stale` de `global.css:220`.
+- GIVEN el mapa 2D THEN `MapLayerToggles` muestra el mismo estado junto al contador.
+- GIVEN una capa `kind: 'snapshot'` THEN el chip dice "Instantánea · 28 feb 2026" en gris, nunca verde.
+- GIVEN todas las fuentes ok THEN no hay ruido: el chip se colapsa a un solo punto verde.
+
+**Tareas** (S)
+
+- [ ] Componente `src/components/islands/shared/SourceStatusChip.tsx` (props: `LiveLayerSpec`, `LiveStatus`, `updatedAt`)
+- [ ] Montar en `CesiumHud.tsx` y `MapLayerToggles.tsx:102-106`
+- [ ] Contenedor "Fuentes degradadas" colapsable en `CesiumControls.tsx` que lista solo las que no están ok (patrón ChainBrief)
+- [ ] i18n de los estados
+- [ ] Marcar BL-020 como hecho en `BACKLOG.md`
+
+### E2.H5 — Instantáneas curadas: un solo origen y fecha visible
+
+Como mantenedor, quiero que zonas de exclusión aérea, GPS jamming y
+blackouts vivan una sola vez, con fecha y fuente, para que Cesium y
+Leaflet no diverjan y el lector sepa que no es tiempo real.
+
+**Criterios de aceptación**
+
+- GIVEN `MapOverlayData.ts` y los tres hooks estáticos THEN los datos se leen del mismo archivo `src/data/snapshots/{nfz,gps-jamming,blackouts}.json`, validados por Zod en build.
+- GIVEN cada archivo THEN tiene `_provenance: {source, url?, snapshotDate, scope: [trackers], note}`.
+- GIVEN un tracker fuera de `scope` THEN la capa no aparece en sus toggles.
+- GIVEN TD-024 (datos duplicados) THEN se actualiza el registro de deuda con la parte resuelta.
+
+**Tareas** (S)
+
+- [ ] Crear `src/data/snapshots/*.json` + `src/lib/snapshot-schema.ts`
+- [ ] Reescribir `useNoFlyZones.ts`, `useGpsJamming.ts`, `useInternetBlackout.ts` y `MapOverlayData.ts` para importar del JSON
+- [ ] Filtrar por `scope` en `CesiumControls.tsx:21` y `MapLayerToggles.tsx:16-25`
+- [ ] Test `snapshot-schema.test.ts`
+- [ ] Actualizar `TECH_DEBT.md` (TD-024)
+
+### E2.H6 — Consumir `_health/status.json`
+
+Como mantenedor, quiero que el archivo de salud que se genera en cada
+deploy tenga al menos un consumidor.
+
+**Criterios de aceptación**
+
+- GIVEN `/metrics/` THEN una franja superior muestra `lastBuild`, número de trackers con `digestGap` y estado `healthy`, leídos de `/_health/status.json`.
+- GIVEN el archivo no existe (deploy viejo) THEN la franja no aparece y no hay error en consola.
+
+**Tareas** (XS)
+
+- [ ] `MetricsDashboard.tsx`: fetch de `${BASE}/_health/status.json` con try/catch y franja `HealthStrip`
+- [ ] Añadir estado `degraded` al tipo de run en `MetricsDashboard.tsx:10` y a `MetricsRunSchema` (para runs con fix agent exitoso tras fallo Zod)
+
+---
+
+## E3 — Panel de alertas con severidad
+
+**Objetivo:** mostrar en el homepage (y en la pestaña FEED móvil) las
+alertas del light scan con severidad, filtros y vuelo al tracker.
+
+**Procedencia OSIRIS:** `LiveAlerts.tsx` (pestañas all/news/quakes, severidad 8/6/4, portal para maximizar), `IntelFeed.tsx:17-29` (clases por severidad). NO se adopta su scoring por palabras clave.
+
+**Inserción Watchboard:** `hourly-light-scan.ts:35-57` (umbrales), `triage-log.ts` (4.4 MB, demasiado para el cliente), `TriageLogBoard.tsx` (ya hace fetch y filtra), `CommandCenter.tsx:882-891`, `useFactCards.ts:9` (taxonomía), `MobileFeedTab.tsx`.
+
+### E3.H1 — `alerts.json` recortado desde el light scan
+
+Como desarrollador, quiero que el light scan escriba un archivo pequeño
+con las últimas alertas, para que el homepage no descargue 4.4 MB.
+
+**Criterios de aceptación**
+
+- GIVEN una corrida del light scan THEN escribe `public/_hourly/alerts.json` con `{generated, entries[≤60]}`, ≤ 60 KB, solo decisiones `update` y `new_tracker` de las últimas 72 h.
+- GIVEN cada entrada THEN tiene `{id, timestamp, tracker, title, url, source, sourceTier, score, severity, feedOrigin, geo?}`.
+- GIVEN la función pura `buildAlertsFile(entries, now)` THEN está testeada con 3 casos: vacío, > 60 entradas (se recortan las más viejas), entradas de más de 72 h (se excluyen).
+
+**Tareas** (S)
+
+- [ ] `src/lib/alert-severity.ts`: `severityFromScore(score, tier)` → `critical ≥ 0.85 tier ≤ 2 | high ≥ 0.85 | elevated ≥ MODERATE | low`; exportar umbrales desde `keyword-match.ts` para no duplicarlos
+- [ ] `src/lib/alerts-file.ts`: `buildAlertsFile`
+- [ ] `hourly-light-scan.ts`: llamar a `buildAlertsFile` tras escribir el triage log; commit del archivo en `light-scan.yml` (verificar que el `git add` incluya la ruta, ver post-mortem en ese workflow)
+- [ ] Tests `alert-severity.test.ts`, `alerts-file.test.ts`
+- [ ] Añadir `alerts.json` a `public/_headers` con `max-age=300`
+
+### E3.H2 — `AlertsPanel` en el homepage
+
+Como lector, quiero un panel con las alertas recientes, filtrable por
+severidad y tipo, que al hacer clic vuele al tracker.
+
+**Criterios de aceptación**
+
+- GIVEN el homepage WHEN pulso `A` o el botón "Alertas" THEN se abre un panel lateral con las entradas de `alerts.json`, ordenadas por tiempo, con color por severidad y "hace X min".
+- GIVEN una entrada WHEN hago clic THEN `handleSelect(tracker)` se dispara y el globo vuela; con clic en el icono de enlace se abre la fuente en pestaña nueva.
+- GIVEN filtros `Todas | Críticas | Nuevas fuentes | Sismos` THEN la lista responde; "Sismos" toma de `useLiveSource(earthquakes)` con magnitud ≥ 4.5 (E2).
+- GIVEN `alerts.json` no existe o falla THEN el panel muestra "Sin alertas recientes" y la última hora de scan conocida (`FreshnessBadge`).
+- GIVEN el panel abierto WHEN llega una entrada nueva (poll cada 5 min, pausado con pestaña oculta) THEN aparece arriba con animación breve y el contador del botón sube.
+- GIVEN una entrada con `geo` (E6) THEN muestra un pin y el clic vuela al punto, no al centro del tracker.
+
+**Tareas** (S-M)
+
+- [ ] `src/components/islands/CommandCenter/AlertsPanel.tsx`
+- [ ] Montar en `CommandCenter.tsx` junto a `ComparePanel` (`:882-891`); estado `showAlerts`; atajo `A` en el switch `:430-501` y fila en `SHORTCUTS`
+- [ ] Contador en la barra superior del homepage
+- [ ] `MobileFeedTab.tsx`: sección "Alertas" arriba del feed
+- [ ] i18n
+- [ ] E2E `e2e/alerts-panel.spec.ts` con `alerts.json` fixture
+
+### E3.H3 — Página de auditoría enlaza con el panel
+
+**Tareas** (XS)
+
+- [ ] `TriageLogBoard.tsx`: usar `alert-severity.ts` para colorear igual que el panel
+- [ ] Enlace "Ver auditoría completa" desde el panel a `/breaking-news-audit/`
+
+---
+
+## E4 — Dossier contextual por clic
+
+**Objetivo:** clic derecho (o pulsación larga) en cualquier punto del
+globo o del mapa abre un panel con país, datos básicos, trackers de
+Watchboard para ese país y eventos cercanos.
+
+**Procedencia OSIRIS:** `api/region-dossier/route.ts` (Nominatim → Wikipedia + Wikidata en paralelo, caché 1 h), `page.tsx:448-454` y `:1748-1779` (card). NO copiar: reverse geocoding en hover (`page.tsx:425-444`).
+
+**Inserción Watchboard:** `useConflictData.ts:15-16` (único `ScreenSpaceEventHandler`), `LeafletMap.tsx:397` (clics solo en marcadores), `CommandCenter.tsx:311-338` (`handleGeoClick`, precedente), `layout-presets.ts:7-14` (`PanelId`), `src/pages/api/event-points.json.ts` (índice lat/lon por tracker), `serializedTrackers` (`country`, `geoPath`). Leer antes: `docs/superpowers/specs/2026-04-07-globe-click-to-drill-design.md`.
+
+### E4.H1 — Librería `dossier`
+
+Como desarrollador, quiero `buildDossier(lat, lon, ctx)` pura (con
+fetch inyectable) que combine reverse geocoding, datos de país y
+trackers, para testearla sin red.
+
+**Criterios de aceptación**
+
+- GIVEN lat/lon WHEN llamo `reverseGeocode` THEN usa `nominatim.openstreetmap.org/reverse?format=jsonv2&zoom=5`, clave de caché redondeada a 0.1°, `sessionStorage` 24 h, y nunca más de 1 petición por segundo (cola con rate limiter).
+- GIVEN un país ISO-2 WHEN llamo `countryFacts` THEN consulta Wikidata SPARQL (capital, población, jefe de estado, bandera) con caché 7 días en `localStorage`.
+- GIVEN un país THEN `trackersForCountry(country, trackers)` devuelve los trackers cuyo `country` o `geoPath` incluye ese país, ordenados por `activity` (E7) o `lastUpdated`.
+- GIVEN lat/lon THEN `eventsNear(lat, lon, points, 300 km)` devuelve los puntos de `/api/event-points.json` dentro del radio (haversine de `geo-utils.ts`).
+- GIVEN Nominatim falla THEN el dossier se construye con lo demás y `degraded: ['geocode']`.
+- Tests con fetch mock para los tres proveedores; test live opt-in contra Nominatim.
+
+**Tareas** (M)
+
+- [ ] `src/lib/dossier.ts` con `reverseGeocode`, `countryFacts`, `trackersForCountry`, `eventsNear`, `buildDossier`
+- [ ] `src/lib/rate-limiter.ts` (cola 1 req/s) con test
+- [ ] `src/lib/dossier.test.ts` + `tests/live/dossier.live.test.ts`
+- [ ] Añadir `nominatim.openstreetmap.org` y `query.wikidata.org` a `connect-src` en `BaseLayout.astro` y `public/_headers` (el test de E0.H3 obliga)
+- [ ] Atribución "© OpenStreetMap contributors" y "Wikidata CC0" en el panel
+
+### E4.H2 — Clic de fondo en globo y mapa
+
+Como lector, quiero hacer clic derecho en el globo o en el mapa y
+obtener lat/lon del punto.
+
+**Criterios de aceptación**
+
+- GIVEN el globo WHEN hago clic derecho (o pulsación larga 600 ms en táctil) sobre terreno THEN se emite `onGroundClick({lat, lon})`; sobre una entidad se mantiene el comportamiento actual.
+- GIVEN el mapa Leaflet WHEN `contextmenu` THEN lo mismo.
+- GIVEN un clic derecho THEN el menú contextual del navegador no aparece.
+
+**Tareas** (S)
+
+- [ ] `useConflictData.ts`: añadir `RIGHT_CLICK` y `pickEllipsoid` para lat/lon; callback `onGroundClick`
+- [ ] `LeafletMap.tsx`: `map.on('contextmenu')`
+- [ ] Pulsación larga en móvil en ambos (`GlobeMobileSheet`, `MobileMapTab`)
+
+### E4.H3 — `DossierPanel`
+
+Como lector, quiero ver el dossier en un panel del globo, del mapa y del
+homepage, con enlaces a los trackers.
+
+**Criterios de aceptación**
+
+- GIVEN clic derecho en Bagdad THEN el panel muestra: "Irak · Bagdad", bandera, capital, población, jefe de estado, extracto de Wikipedia (≤ 300 caracteres), lista de trackers de Irak con su última actualización, y 5 eventos más cercanos con distancia.
+- GIVEN un tracker de la lista WHEN hago clic THEN navego a `/{slug}/` (en el homepage: `handleSelect`).
+- GIVEN un evento cercano WHEN hago clic THEN abro su permalink (`eventPermalink`).
+- GIVEN `degraded` no vacío THEN se muestra "Sin geocodificación" o "Sin datos de país" en gris, no un panel vacío.
+- GIVEN el globo THEN el panel ocupa el slot `right-top` en `layout-presets.ts` y se puede cerrar con `Esc`.
+- GIVEN móvil THEN se abre como bottom sheet.
+
+**Tareas** (M)
+
+- [ ] `src/components/islands/shared/DossierPanel.tsx`
+- [ ] Añadir `'dossier'` a `PanelId` (`layout-presets.ts:7-14`) y al slot; render en `CesiumGlobe.tsx` guardado por `hasPanelInSlot`
+- [ ] Montar en `IntelMap.tsx` como overlay
+- [ ] `CommandCenter.tsx`: en `handleGeoClick` (`:311-338`) abrir el dossier del país además del acordeón; usar `serializedTrackers` como fuente de trackers
+- [ ] i18n
+- [ ] E2E `e2e/dossier.spec.ts` con fetch mockeado vía `page.route`
+
+---
+
+## E5 — Capas geoespaciales con procedencia
+
+**Objetivo:** añadir capas reales relevantes para trackers existentes
+(frente de Ucrania, alertas de desastres) y capas estáticas de
+infraestructura con procedencia, todas declaradas en el registro de E0.H3.
+
+**Procedencia OSIRIS:** `api/frontlines/route.ts` (DeepState, `s-maxage=1800`), `api/gdelt/route.ts` (GDACS RSS, `revalidate: 300`, mapeo de tipos), `public/data/submarine-cables.json`, `api/infrastructure/route.ts` (registro nuclear + join sísmico), `ArcGISPanel` (loader genérico de FeatureServer).
+
+**Verificado:** DeepState CORS `*`, 628 KB, `max-age=300`, licencia no declarada; GDACS sin CORS, CC BY 4.0, 1.3 MB.
+
+### E5.H1 — Frente DeepState en el tracker de Ucrania
+
+Como lector del tracker de Ucrania, quiero ver la línea de frente actual
+sobre el mapa y el globo.
+
+**Criterios de aceptación**
+
+- GIVEN `trackers/ukraine-*/tracker.json` con `map.liveLayers: ['deepstate-frontline']` THEN aparece el toggle "Frente (DeepState)" en mapa y globo, desactivado por defecto.
+- GIVEN el toggle activo THEN se cargan los 29 polígonos vía `useLiveSource` con TTL 30 min y se pintan con el `fill`/`stroke` que trae cada feature; leyenda con los tres estados.
+- GIVEN el panel de fuentes THEN muestra "DeepStateMAP · actualizado hace X · enlace".
+- GIVEN un tracker sin `liveLayers` THEN no hay toggle.
+- GIVEN respuesta de DeepState de más de 2 MB o sin `map.features` THEN se rechaza y la capa queda en `error` (no se pinta basura).
+- **Bloqueante legal:** antes de mergear, pedir permiso por escrito a DeepState (formulario o correo) y guardar la respuesta en `docs/licenses/deepstate.md`. Si no hay respuesta en 3 semanas, la capa se publica detrás de un flag `PUBLIC_ENABLE_DEEPSTATE=false`.
+
+**Tareas** (M)
+
+- [ ] Extender `TrackerConfigSchema`: `map.liveLayers?: LiveLayerId[]` (`tracker-config.ts:33-42`)
+- [ ] Registrar `deepstate-frontline` en `LIVE_LAYERS` con `kind: 'feed'`, `ttlMs: 1_800_000`, `license: 'permission-pending'`
+- [ ] `src/lib/deepstate.ts`: `parseDeepState(json): FeatureCollection` con Zod, límite de tamaño, test con fixture recortada
+- [ ] Cesium: `useGeoJsonLayer(spec)` genérico con `GeoJsonDataSource` (reutilizable por E5.H3); Leaflet: `L.geoJSON` en `LeafletMap.tsx`
+- [ ] Toggle y leyenda en `CesiumControls.tsx` y `MapLayerToggles.tsx`, derivados del registro
+- [ ] CSP: `deepstatemap.live`
+- [ ] Test live opt-in
+- [ ] `docs/licenses/deepstate.md` y solicitud de permiso
+
+### E5.H2 — GDACS: ingesta en el light scan y capa de desastres
+
+Como lector, quiero ver alertas naranja y rojas de GDACS en el globo y
+que el scan las considere candidatas para los trackers de la región.
+
+**Criterios de aceptación**
+
+- GIVEN una corrida del light scan THEN descarga `gdacs.org/xml/rss.xml`, parsea `gdacs:alertlevel`, `gdacs:eventtype`, `georss:point`, `gdacs:country`, `gdacs:severity`, `gdacs:population`, y escribe `public/_hourly/gdacs.json` con los eventos de los últimos 7 días con nivel Orange o Red (≤ 100 KB).
+- GIVEN un evento Red o Orange THEN entra al pipeline como `Candidate` con `feedOrigin: 'gdacs'`, `sourceTier: 1`, `geo: {lat, lon, place: country, method: 'georss'}` y título "GDACS {tipo} {severidad} · {país}".
+- GIVEN la primera corrida tras el despliegue THEN siembra `seen` y no alerta (principio 7).
+- GIVEN el globo del homepage y de trackers con `region` afectada THEN la capa "Desastres (GDACS)" muestra pines por tipo (sismo, inundación, ciclón, volcán, incendio) con nivel de alerta, atribución "GDACS · European Union · CC BY 4.0".
+- GIVEN la descarga falla THEN se conserva el `gdacs.json` anterior y se registra en el step summary (no se borra).
+
+**Tareas** (M)
+
+- [ ] `scripts/lib/gdacs.ts`: `fetchGdacs`, `parseGdacsRss(xml)` (sin dependencia nueva: `fast-xml-parser` no está; usar regex robusta o añadir `fast-xml-parser` justificándolo), `toCandidates`, `buildGdacsFile`
+- [ ] Tests con fixture XML recortada
+- [ ] `hourly-light-scan.ts`: fase GDACS con presupuesto de 10 s; `hourly-types.ts:63-74` gana `feedOrigin: 'gdacs'` y `geo?`
+- [ ] `light-scan.yml`: incluir `public/_hourly/gdacs.json` en el commit
+- [ ] Registrar `gdacs-alerts` en `LIVE_LAYERS` (`kind: 'feed'`, `url: '/_hourly/gdacs.json'`, TTL 15 min)
+- [ ] Hook `useGdacs` sobre `useLiveSource` + iconos en `cesium-icons.ts`; Leaflet markers
+- [ ] `public/_headers`: `gdacs.json` `max-age=300`
+
+### E5.H3 — Capas estáticas de infraestructura con procedencia
+
+Como lector, quiero capas de contexto (cables submarinos, plantas
+nucleares, chokepoints marítimos) con fuente y fecha visibles.
+
+**Criterios de aceptación**
+
+- GIVEN `public/geo/layers/{id}.geojson` THEN cada archivo incluye `_provenance: {source, url, license, retrievedAt, transform?}` y pasa `GeoLayerSchema` en un test.
+- GIVEN el tracker declara `map.staticLayers: ['submarine-cables']` THEN el toggle aparece con chip "Instantánea · {retrievedAt}".
+- GIVEN los cables THEN provienen del dataset público original (TeleGeography en GitHub, licencia CC BY-NC-SA 3.0 o la vigente), no del archivo de OSIRIS, y la licencia se cumple en la atribución.
+- GIVEN el registro nuclear THEN se construye desde Wikidata (query SPARQL guardada en `scripts/geo/nuclear-plants.sparql`) con `retrievedAt`, no copiado a mano.
+- GIVEN `scripts/geo/refresh-layers.ts --layer nuclear-plants` THEN regenera el archivo y actualiza `retrievedAt` (patrón ArcGIS loader de OSIRIS, pero en build, no en runtime).
+
+**Tareas** (M)
+
+- [ ] `src/lib/geo-layer-schema.ts` + test
+- [ ] `scripts/geo/refresh-layers.ts` con adaptadores `telegeography-cables`, `wikidata-nuclear`, `maritime-chokepoints` (10 puntos curados a mano con fuente)
+- [ ] `public/geo/layers/*.geojson` iniciales
+- [ ] `TrackerConfigSchema`: `map.staticLayers?`
+- [ ] Reutilizar `useGeoJsonLayer` de E5.H1 y `L.geoJSON`
+- [ ] `docs/licenses/` con cada licencia
+
+### E5.H4 — Página de fuentes de capas
+
+**Tareas** (XS-S)
+
+- [ ] `src/pages/sources.astro` (o sección en `/about`) que lista `LIVE_LAYERS` con licencia, atribución, TTL y tipo, generada del registro
+- [ ] Enlace desde el panel "Fuentes degradadas" (E2.H4)
+
+---
+
+## E6 — Geoparsing de candidatos
+
+**Objetivo:** que los candidatos del light scan lleguen con coordenadas
+cuando el texto menciona un lugar conocido por los trackers, para
+mostrarlos en el globo antes de la triage y para que el panel de
+alertas vuele al punto.
+
+**Procedencia OSIRIS:** `api/news/route.ts:25-31` (15 topónimos → centroides), `api/osint/route.ts` (geoparsing multilingüe de Telegram). Watchboard tiene 5,876 puntos propios.
+
+### E6.H1 — Gazetteer desde los datos propios
+
+Como desarrollador, quiero un gazetteer generado de `map-points.json`,
+`map.center` y `country` de los 125 trackers, para geolocalizar sin
+servicio externo.
+
+**Criterios de aceptación**
+
+- GIVEN `scripts/lib/gazetteer.ts` WHEN corre `buildGazetteer()` THEN produce `scripts/state/gazetteer.json` con `{name, normalized, lat, lon, trackers[], kind: 'point'|'center'|'country', aliases[]}` para cada nombre único (normalizado sin acentos, minúsculas).
+- GIVEN nombres ambiguos (mismo nombre en dos trackers) THEN se conservan ambos y `resolve` prefiere el del `matchedTracker`.
+- GIVEN un texto "Explosión en Kharkiv esta madrugada" y `matchedTracker: 'ukraine-war'` THEN `geoparse` devuelve `{lat, lon, place: 'Kharkiv', confidence ≥ 0.8, method: 'gazetteer'}`.
+- GIVEN un texto sin topónimo conocido THEN `geo` es `undefined`, no un centro por defecto.
+- GIVEN aliases en `country-names.ts` THEN "Estados Unidos" y "United States" resuelven igual.
+
+**Tareas** (M)
+
+- [ ] `scripts/lib/gazetteer.ts`: `buildGazetteer`, `normalizeName`, `geoparse(text, matchedTracker)`; longest-match primero, mínimo 4 caracteres, lista de stopwords (nombres como "Centro", "Norte")
+- [ ] Tests con 20 frases en es/en/fr/pt
+- [ ] `hourly-light-scan.ts`: llamar `geoparse` tras `scoreCandidate`; propagar a `PendingCandidate` y `TriageLogEntry` (`hourly-types.ts:112-134`)
+- [ ] Regenerar gazetteer al inicio de cada scan (barato) o en `generate-api.ts`
+
+### E6.H2 — Candidatos pendientes en el globo
+
+Como lector, quiero ver en el globo los candidatos geolocalizados que
+aún no han pasado triage, marcados como no verificados.
+
+**Criterios de aceptación**
+
+- GIVEN `alerts.json` con entradas `geo` THEN el globo del homepage muestra pines punteados tier-4 con tooltip "Candidato sin verificar · {fuente}".
+- GIVEN la triage lo convierte en evento THEN el pin punteado desaparece y aparece el evento normal (dedupe por `url`).
+
+**Tareas** (S)
+
+- [ ] Capa `pending-candidates` en `LIVE_LAYERS` (`url: '/_hourly/alerts.json'`)
+- [ ] Render en `GlobePanel.tsx` (globe.gl) con estilo tier-4
+- [ ] Dedupe contra eventos por `url` en `hourly-scan.ts`
+
+---
+
+## E7 — Índice de actividad por tracker
+
+**Objetivo:** ordenar y destacar trackers por actividad reciente con
+una cifra calculada de datos reales y factores visibles, sustituyendo
+heurísticas dispersas (`hero-selection.ts`, scorer del video, orden de
+la sidebar).
+
+**Procedencia OSIRIS:** `api/country-risk/route.ts` como contraejemplo (tabla hardcodeada + bono sísmico). Se adopta la idea de "índice por región", no la implementación.
+
+### E7.H1 — Librería `activity-index`
+
+Como desarrollador, quiero `computeActivity(tracker, data, now)` pura
+que devuelva 0-100 y los factores.
+
+**Criterios de aceptación**
+
+- GIVEN eventos de los últimos 7 días, `meta.breaking`, `sectionsUpdatedCount`, deltas de KPI y edad del digest THEN el índice se calcula con pesos declarados en una constante exportada y `factors: [{name, value, contribution}]`.
+- GIVEN un tracker histórico (`temporal: 'historical'`) THEN el índice se normaliza por su `updateIntervalDays` para no penalizar cadencia lenta.
+- GIVEN dos corridas con los mismos datos THEN el resultado es idéntico (determinista).
+- Test con 5 fixtures: breaking, tranquilo, histórico, sin digest, sin eventos.
+
+**Tareas** (S-M)
+
+- [ ] `src/lib/activity-index.ts` + test
+- [ ] `KpiSchema`: campo opcional `delta: {value, direction, period}` (BL-024) en `schemas.ts`; el updater nocturno lo rellena (instrucción en `update-data.yml` STEP 3)
+
+### E7.H2 — Exponer y usar el índice
+
+**Criterios de aceptación**
+
+- GIVEN `public/api/v1/trackers.json` THEN cada tracker tiene `activity: {score, factors}`.
+- GIVEN el homepage THEN `serializedTrackers` incluye `activity.score`; `SidebarPanel` ofrece orden "Actividad"; el badge muestra el score con tooltip de factores.
+- GIVEN `hero-selection.ts` y el scorer de `video/render.ts` THEN usan `activity` en lugar de heurísticas propias (o las combinan con peso documentado).
+- GIVEN el MCP THEN `list_trackers` acepta `sort: 'activity'`.
+
+**Tareas** (S-M)
+
+- [ ] `generate-api.ts:319-338`: añadir `activity`
+- [ ] `index.astro:26-146`: añadir `activity.score`
+- [ ] `SidebarPanel.tsx`: orden y badge; `FeedRow.tsx` tooltip
+- [ ] `hero-selection.ts`, `video/render.ts`: consumir
+- [ ] `mcp/server.ts:230`: parámetro `sort`
+- [ ] `KpiStrip.astro`: mostrar `delta` (BL-024)
+
+---
+
+## E8 — Distribución self-host
+
+**Objetivo:** imagen Docker pequeña que sirva `dist/`, publicada en
+GHCR, con compose y documentación honesta de variables.
+
+**Procedencia OSIRIS:** `Dockerfile` (3 etapas, usuario no root), `docker-compose.yml` (bloque `x-casaos`), `nginx/nginx.conf` (gzip JSON, cache-control por ruta), `docker-publish.yml` (buildx amd64+arm64, `concurrency`). Contraejemplo: la deriva entre `.env.template`/`.env.example` y las 17 variables no documentadas.
+
+### E8.H1 — Dockerfile multi-stage y nginx
+
+**Criterios de aceptación**
+
+- GIVEN `docker build -t watchboard .` THEN la imagen final es `nginx:alpine` + `dist/`, < 150 MB, sin `node_modules`, usuario no root, `HEALTHCHECK` sobre `/`.
+- GIVEN la etapa de build THEN ejecuta `npm ci && npm run build` (incluye `generate-api`, `copy-cesium`, pagefind, `csp-hashes`).
+- GIVEN `nginx.conf` THEN aplica las mismas cabeceras que `public/_headers` (generadas por un script, no copiadas a mano), gzip para `application/json` y `Cache-Control` largo para `/cesium/` y `/_astro/`.
+- GIVEN `docker run -p 8080:80` THEN `/`, `/iran-conflict/`, `/api/v1/trackers.json` y `/_hourly/alerts.json` responden 200.
+
+**Tareas** (S)
+
+- [ ] `Dockerfile`, `.dockerignore`
+- [ ] `scripts/headers-to-nginx.ts` que convierte `public/_headers` a `docker/nginx.conf` (test de ida y vuelta con dos reglas)
+- [ ] `docker-compose.yml` con `x-casaos`
+- [ ] Smoke test en `tests/docker.smoke.sh` (curl a 4 rutas)
+
+### E8.H2 — Publicación en GHCR
+
+**Criterios de aceptación**
+
+- GIVEN push a `main` o tag `v*` THEN `.github/workflows/docker-publish.yml` construye amd64+arm64 y publica `ghcr.io/artemiopadilla/watchboard:{latest,sha,semver}` con `concurrency` para no pisar `latest`.
+- GIVEN el step summary THEN muestra el tamaño de la imagen y las 4 rutas del smoke test en verde (verificar el artefacto, no el exit code).
+
+**Tareas** (S)
+
+- [ ] Workflow con `docker/build-push-action`, QEMU, cache GHA
+- [ ] Smoke test dentro del workflow contra la imagen recién construida
+
+### E8.H3 — Documentación y listados
+
+**Criterios de aceptación**
+
+- GIVEN `docs/self-hosting.md` THEN explica `docker run`, compose, y que los datos se actualizan al reconstruir la imagen (o montando `dist/` de un build propio), y lista **todas** las variables de entorno leídas por el código, generadas por `scripts/list-env-vars.ts` (grep de `process.env.` e `import.meta.env.`) para no repetir la deriva de OSIRIS.
+- GIVEN README THEN sección "Self-host" con el comando de una línea.
+- GIVEN `docs/osint-list-submissions.md` THEN se añaden awesome-selfhosted y awesome-osint con el texto propuesto.
+
+**Tareas** (XS-S)
+
+- [ ] `scripts/list-env-vars.ts` + salida en `docs/self-hosting.md`
+- [ ] README y `docs/osint-list-submissions.md`
+
+---
+
+## E9 — Procedencia y honestidad en UI
+
+**Objetivo:** que todo texto generado por IA, toda cifra derivada y toda
+fuente degradada se vean como lo que son.
+
+**Procedencia OSIRIS:** `AiOverview.tsx:127-130` (badge GEMINI vs HEURISTIC), `ChainBrief.tsx:219-226` (DEGRADED SOURCES), taxonomía del módulo username, doctrina de `camera-feed.ts:108-115` (IDs reciclados).
+
+### E9.H1 — Badge de procedencia en texto generado
+
+**Criterios de aceptación**
+
+- GIVEN `digests.json` y `meta.heroHeadline` THEN llevan `provenance: {model, generatedAt, method: 'llm'|'heuristic'|'human'}` (campo opcional en `schemas.ts`, rellenado por `update-data.yml` y `hourly-triage.ts`).
+- GIVEN el hero y la sección de digest THEN muestran un badge discreto "IA · Claude · 6 sep" o "Editorial".
+- GIVEN un dato sin `provenance` THEN muestra "Sin procedencia registrada" en gris (no se oculta).
+
+**Tareas** (S)
+
+- [ ] `schemas.ts`: `ProvenanceSchema`
+- [ ] Prompts de `update-data.yml` y `hourly-triage.ts`: emitir `provenance`
+- [ ] `src/components/static/ProvenanceBadge.astro`; montar en `Hero.astro` y en la vista de digest
+- [ ] i18n
+
+### E9.H2 — Bloque "Fuentes degradadas" en la página del tracker
+
+**Criterios de aceptación**
+
+- GIVEN un tracker con capas en `stale|error` (E2) o con `digestGap` en `_health/status.json` THEN aparece un bloque colapsado bajo el `KpiStrip` con la lista y la hora del último dato bueno.
+- GIVEN todo ok THEN el bloque no se renderiza.
+
+**Tareas** (S)
+
+- [ ] `src/components/islands/shared/DegradedSources.tsx` consumiendo `getLiveStatus` y `_health`
+- [ ] Montar en `[tracker]/index.astro`
+
+### E9.H3 — Verificación de thumbnails reciclados
+
+Como mantenedor, quiero detectar `og:image` que cambiaron de contenido
+bajo la misma URL, para no mostrar una foto equivocada con un pie
+confiado.
+
+**Criterios de aceptación**
+
+- GIVEN `backfill-media.ts` THEN guarda `media[].hash` (sha1 de los primeros 64 KB) y `fetchedAt` al descargar.
+- GIVEN la validación nocturna (HEAD de media) THEN si `Content-Length` o `ETag` cambian respecto a lo guardado, marca `media[].suspect: true` y lo lista en el step summary.
+- GIVEN `suspect: true` THEN las superficies de media muestran el gradiente de fallback en lugar de la imagen.
+
+**Tareas** (S)
+
+- [ ] `MediaItemSchema`: `hash?`, `fetchedAt?`, `suspect?`
+- [ ] `backfill-media.ts` y el paso de validación de `update-data.yml`
+- [ ] Fallback en `MobileStoryCarousel.tsx`, `TrackerDirectory.tsx`, `BroadcastOverlay.tsx`
+
+### E9.H4 — Taxonomía epistémica en claims
+
+**Criterios de aceptación**
+
+- GIVEN `ClaimSchema` THEN acepta `status: 'confirmed'|'contested'|'unverifiable'|'retracted'` además de los campos actuales; `ClaimsMatrix.astro` lo muestra con icono.
+- GIVEN datos existentes sin `status` THEN se infiere `contested` (compatibilidad).
+
+**Tareas** (XS-S)
+
+- [ ] `schemas.ts`, `ClaimsMatrix.astro`, prompt del updater
+
+---
+
+## E10 — Filtro espacial del directorio (diferida)
+
+**Objetivo:** dibujar un área en el globo y obtener los trackers y
+eventos dentro. Se pospone hasta que E4 y E7 existan, porque su valor
+depende del dossier y del índice de actividad.
+
+**Procedencia OSIRIS:** `draw.ts` (reducer puro, 4 modos → un anillo), `aoi.ts` (bbox reject + ray casting), `aoi-export.ts` (localStorage validado por registro, export CSV/GeoJSON). Se descarta `watch.ts`.
+
+**Historias previstas** (no detalladas): E10.H1 `src/lib/draw.ts` portado con tests; E10.H2 `selectInPolygon` sobre `/api/event-points.json` y centros de tracker; E10.H3 toolbar en el globo del homepage con export GeoJSON; E10.H4 persistencia en `localStorage` con validación por registro.
+
+---
+
+## Story map y dependencias
+
+```
+Fase A (2 semanas) — Quick wins y fundamentos
+  E0.H1 ADR ───────────────┐
+  E0.H2 tests live         │
+  E0.H3 registro capas ────┼──► E1.H1 view-state ──► E1.H2 globo ──► E1.H4 share
+                           │                      └► E1.H3 mapa      └► E1.H5 docs
+                           └──► E2.H1 live-source ──► E2.H2 vuelos
+                                                  ├► E2.H3 sismos/clima/sats
+                                                  ├► E2.H4 chip estado ──► E3.H2 panel alertas
+                                                  ├► E2.H5 snapshots
+                                                  └► E2.H6 _health
+                                E3.H1 alerts.json ──► E3.H2 ──► E3.H3
+  E8.H1 Dockerfile ──► E8.H2 GHCR ──► E8.H3 docs      (independiente)
+
+Fase B (3 semanas) — Contexto espacial y honestidad
+  E1 + E0 ──► E4.H1 dossier lib ──► E4.H2 clic fondo ──► E4.H3 panel
+  E2 + E0 ──► E5.H1 DeepState (bloqueo legal en paralelo desde semana 1)
+          ├─► E5.H2 GDACS (scan + capa)
+          ├─► E5.H3 capas estáticas
+          └─► E5.H4 página de fuentes
+  E2 ──► E9.H1 procedencia ──► E9.H2 degradadas ──► E9.H3 thumbnails ──► E9.H4 claims
+
+Fase C (3 semanas) — Señal
+  E3 + E5.H2 ──► E6.H1 gazetteer ──► E6.H2 candidatos en globo
+  E7.H1 índice ──► E7.H2 exponer (independiente; puede adelantarse)
+  E4 ──► E10 (diferida)
+```
+
+Orden recomendado de PRs en Fase A: E0.H3 → E2.H1 → E1.H1 → E8.H1 →
+E2.H2 → E1.H2 → E3.H1 → E2.H4 → E3.H2 → resto.
+
+---
+
+## Riesgos
+
+| Riesgo | Prob. | Impacto | Mitigación |
+|---|---|---|---|
+| DeepState no autoriza el uso | Media | Se pierde E5.H1 | Flag `PUBLIC_ENABLE_DEEPSTATE`; alternativa ISW (shapefiles públicos) documentada en E5.H1 |
+| Nominatim bloquea tráfico desde el navegador | Baja | Dossier degradado | Rate limiter 1 req/s, caché agresiva, `degraded: ['geocode']` con UI honesta; fallback a `country-names.ts` + `map.center` |
+| OpenSky cambia cuota o exige OAuth | Media | Capa de vuelos en `rate-limited` | El chip lo hace visible; adsb.fi como segunda fuente (patrón OSIRIS `flights/route.ts`) en historia futura |
+| `alerts.json`/`gdacs.json` no se commitean (post-mortem de `light-scan.yml`) | Media | Panel vacío en silencio | Step summary cuenta entradas y falla si el archivo no cambió en 24 h; test de E3.H1 |
+| Payload del homepage crece con `activity` y `geo` | Baja | LCP | Solo escalares en `serializedTrackers`; factores vía `/api/cards/{slug}.json` |
+| CSP rompe una fuente nueva en producción | Media | Capa muerta sin error visible | Test de E0.H3 que compara registro vs CSP en cada PR |
+| Playwright en CI es lento o inestable | Media | PRs bloqueados | Solo specs `*-share.spec.ts` y `alerts-panel` al inicio; `retries: 1`; fixtures locales, sin red |
+
+**Criterio de rollback por épica:** cada épica añade código detrás de
+un registro (`LIVE_LAYERS`) o de un campo opcional de schema; retirar
+la entrada del registro o el campo desactiva la feature sin migración.
+
+---
+
+## Definición de hecho (aplica a toda historia)
+
+- [ ] Criterios de aceptación cubiertos por tests unitarios (vitest) y, cuando hay UI, por un spec Playwright con fixtures sin red.
+- [ ] `npm run build` verde, incluido `csp-hashes.ts`; el test de CSP de E0.H3 pasa.
+- [ ] Ningún `fetch` nuevo sin estado expuesto (principio 1) ni sin entrada en `LIVE_LAYERS`.
+- [ ] i18n en/es/fr/pt de cualquier texto visible.
+- [ ] `CLAUDE.md` actualizado si hay archivo nuevo en `src/lib/` o `scripts/`.
+- [ ] `BACKLOG.md`, `docs/product-roadmap.md` y `src/data/roadmap-items.ts` actualizados en la misma PR (protocolo de doble escritura).
+- [ ] Verificación del artefacto, no del exit code: el PR incluye captura o salida que muestre el archivo generado, la capa pintada o la URL restaurada (`docs/silent-failure-patterns.md`).
+
+---
+
+## Fuera de alcance (decidido)
+
+RECON toolkit, CCTV, cripto, mercados, navegación, `WorldRemote`,
+`stealthFetch`, telemetría de IP, LLM bajo demanda en runtime,
+`country-risk` estático, StyleStudio completo. Razones en
+`competitive-analysis-osiris.md`, sección "Lo que no conviene tomar".


### PR DESCRIPTION
## Summary

- Adds `docs/competitive-analysis-osiris.md` (v2): source-level comparison of Watchboard against `simplifaisoul/osiris@d2c08c8`. Corrects first-pass assumptions (OSIRIS share links never read `lat/lon`, its `risk_score` is a keyword count, `machine_assessment` is a constant string), documents its security and test-coverage posture, and inventories Watchboard's own gaps (static overlays presented as live layers, fixed Middle East bbox on flights/earthquakes, no `visibilitychange` pause, unconsumed `_health/status.json`, no Dockerfile, no ADRs).
- Adds `docs/superpowers/plans/2026-09-07-osiris-adoption-program.md`: ten epics (E0-E10) with INVEST stories, GIVEN/WHEN/THEN acceptance criteria, checkbox tasks with `file:line` insertion points, dependency story map, three delivery phases, risks and a program-wide definition of done.

## Implementation PRs

The epics are implemented as stacked PRs on top of this branch, one per epic, each validated by an adversarial review workflow before opening.

## Test plan

- [x] Documents only; no code changes. Cited file:line references verified against `feead12`.
- [x] External claims (DeepState CORS, GDACS license, Nominatim CORS) verified with live requests on 2026-09-07.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZ81PJ4qfADtpwMnc12eWL

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZ81PJ4qfADtpwMnc12eWL)_