### PR TITLE
feat(view-state): shareable URL view state for globe, map and homepage (E1)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,39 @@
+name: E2E (Playwright)
+
+# Two Playwright specs existed for months without any workflow running them
+# (BACKLOG BL-022). This runs the shareable-view specs added by E1 on every
+# PR; the older specs are opted in once they are known to pass in CI.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Run shareable-view specs
+        run: npx playwright test e2e/globe-share.spec.ts e2e/map-share.spec.ts e2e/home-share.spec.ts --reporter=list
+      - name: Upload traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: test-results/
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,7 @@ AI-curated social media posting system. Replaces the old `generate-social-drafts
 ### Utilities (`src/lib/`)
 
 - `tracker-config.ts` — TrackerConfigSchema + types
+- `view-state.ts` — `encodeViewState` / `decodeViewState` / `mergeIntoUrl` / `createViewStateWriter`: the one URL format for shareable views (`lat, lon, alt|zoom, heading, pitch, layers, event, date, tracker`). Each island reads it on mount and writes it debounced with `replaceState`; see ADR-0001. Share button: `islands/shared/ShareViewButton.tsx`; `S` copies the link on globe and homepage.
 - `live-layers.ts` — `LIVE_LAYERS` registry (Zod `LiveLayerSpecSchema`): every external globe/map layer with kind (`feed` | `snapshot`), URL, TTL, CORS mode, license and tracker `scope`. `live-layers.test.ts` fails CI if a feed host is missing from `connect-src` in `BaseLayout.astro` or `public/_headers` (parser in `scripts/lib/csp-hosts.ts`). Rationale: `docs/adr/0002-live-layer-registry.md`.
 - `tracker-registry.ts` — discovers and loads tracker configs
 - `data.ts` — `loadTrackerData(slug)` parameterized data loader

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -74,7 +74,7 @@ The interactive view is at **[/roadmap/](https://watchboard.dev/roadmap/)** (kan
 |---|---|---|---|---|
 | Cross-tracker search & filter | UX | P1 | XL | Needs ADR on cross-island state (nanostores) before coding |
 | "What changed today" view | Growth | P1 | M | Diff/changelog for returning users — primary retention driver |
-| Shareable deep links | Growth | P2 | M | Depends on cross-island state from search |
+| Shareable deep links | Growth | P2 | S | 🔄 in progress — island-local per ADR-0001, no cross-island state needed. `src/lib/view-state.ts`; plan E1 |
 | Tree-shake Cesium bundle | Performance | P2 | L | 4.3 MB → ~1.5-2 MB; mobile parse 5s → ~2s |
 | Zod validation in CI workflow | Reliability | **P0** | S | Schema-valid-but-corrupt data can break the build today |
 | Build / nightly failure alerting | Reliability | **P0** | S | Site silently serves stale data on pipeline failure |

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -1,6 +1,6 @@
 # Watchboard Product Roadmap
 
-Last updated: 2026-04-28 (post-#135)
+Last updated: 2026-09-07 (post-#135)
 
 This is the **platform** roadmap — performance, growth, content, accessibility, infrastructure, UX. New tracker requests live in [`docs/tracker-roadmap.md`](./tracker-roadmap.md) and the community vote at `/vote`.
 
@@ -74,7 +74,7 @@ The interactive view is at **[/roadmap/](https://watchboard.dev/roadmap/)** (kan
 |---|---|---|---|---|
 | Cross-tracker search & filter | UX | P1 | XL | Needs ADR on cross-island state (nanostores) before coding |
 | "What changed today" view | Growth | P1 | M | Diff/changelog for returning users — primary retention driver |
-| Shareable deep links | Growth | P2 | S | 🔄 in progress — island-local per ADR-0001, no cross-island state needed. `src/lib/view-state.ts`; plan E1 |
+| Shareable deep links | Growth | P2 | S | 🚧 in progress — island-local per ADR-0001, no cross-island state needed. `src/lib/view-state.ts`; plan E1 |
 | Tree-shake Cesium bundle | Performance | P2 | L | 4.3 MB → ~1.5-2 MB; mobile parse 5s → ~2s |
 | Zod validation in CI workflow | Reliability | **P0** | S | Schema-valid-but-corrupt data can break the build today |
 | Build / nightly failure alerting | Reliability | **P0** | S | Site silently serves stale data on pipeline failure |

--- a/e2e/globe-share.spec.ts
+++ b/e2e/globe-share.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E1 acceptance: a globe URL with camera + layers reproduces that view, and
+ * the URL is rewritten from the real camera after it settles. Because the
+ * writer round-trips through Cesium's camera, the parameters coming back
+ * prove the camera actually landed there (within rounding), which is the
+ * regression the plan guards against: a share link that silently drops
+ * its location.
+ */
+test.describe('Globe shareable view state', () => {
+  test('restores camera and layers from the URL and keeps them in sync', async ({ page }) => {
+    await page.goto('./iran-conflict/globe/?lat=33.3&lon=44.4&alt=250000&heading=90&pitch=-45&layers=flights,quakes');
+
+    // The toolbar only renders once the Cesium viewer is ready.
+    await expect(page.locator('.globe-toolbar')).toBeVisible({ timeout: 45_000 });
+
+    // Wait for the debounced writer (500 ms) plus a margin.
+    await page.waitForFunction(() => new URLSearchParams(location.search).has('layers'), null, { timeout: 15_000 });
+    await page.waitForTimeout(800);
+
+    const params = new URLSearchParams(new URL(page.url()).search);
+    const lat = Number(params.get('lat'));
+    const lon = Number(params.get('lon'));
+    const alt = Number(params.get('alt'));
+    expect(Math.abs(lat - 33.3)).toBeLessThan(0.34);   // 1 %
+    expect(Math.abs(lon - 44.4)).toBeLessThan(0.45);
+    expect(Math.abs(alt - 250_000) / 250_000).toBeLessThan(0.05);
+    expect(params.get('layers')).toBe('flights,quakes');
+    expect(params.get('date')).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test('a broken parameter does not break the page', async ({ page }) => {
+    await page.goto('./iran-conflict/globe/?lat=abc&lon=999&layers=bogus');
+    await expect(page.locator('.globe-toolbar')).toBeVisible({ timeout: 45_000 });
+    await page.waitForTimeout(1200);
+    const params = new URLSearchParams(new URL(page.url()).search);
+    // The writer replaced the junk with the real camera and dropped the unknown layer.
+    expect(Number.isFinite(Number(params.get('lat')))).toBe(true);
+    expect(params.get('layers') ?? '').not.toContain('bogus');
+  });
+});

--- a/e2e/globe-share.spec.ts
+++ b/e2e/globe-share.spec.ts
@@ -12,11 +12,11 @@ test.describe('Globe shareable view state', () => {
   test('restores camera and layers from the URL and keeps them in sync', async ({ page }) => {
     await page.goto('./iran-conflict/globe/?lat=33.3&lon=44.4&alt=250000&heading=90&pitch=-45&layers=flights,quakes');
 
-    // The toolbar only renders once the Cesium viewer is ready.
     await expect(page.locator('.globe-toolbar')).toBeVisible({ timeout: 45_000 });
 
-    // Wait for the debounced writer (500 ms) plus a margin.
-    await page.waitForFunction(() => new URLSearchParams(location.search).has('layers'), null, { timeout: 15_000 });
+    // The writer only runs once the Cesium viewer exists, and it adds `date`,
+    // which the navigation URL did not carry: that is the real readiness gate.
+    await page.waitForFunction(() => new URLSearchParams(location.search).has('date'), null, { timeout: 45_000 });
     await page.waitForTimeout(800);
 
     const params = new URLSearchParams(new URL(page.url()).search);
@@ -33,7 +33,8 @@ test.describe('Globe shareable view state', () => {
   test('a broken parameter does not break the page', async ({ page }) => {
     await page.goto('./iran-conflict/globe/?lat=abc&lon=999&layers=bogus');
     await expect(page.locator('.globe-toolbar')).toBeVisible({ timeout: 45_000 });
-    await page.waitForTimeout(1200);
+    await page.waitForFunction(() => new URLSearchParams(location.search).has('date'), null, { timeout: 45_000 });
+    await page.waitForTimeout(800);
     const params = new URLSearchParams(new URL(page.url()).search);
     // The writer replaced the junk with the real camera and dropped the unknown layer.
     expect(Number.isFinite(Number(params.get('lat')))).toBe(true);

--- a/e2e/home-share.spec.ts
+++ b/e2e/home-share.spec.ts
@@ -1,19 +1,27 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Homepage ?tracker= selection', () => {
-  test('selects the tracker named in the URL and keeps the hash', async ({ page }) => {
-    await page.goto('./?tracker=iran-conflict#geo', { waitUntil: 'networkidle' });
+  test('selects the tracker named in the URL', async ({ page }) => {
+    await page.goto('./?tracker=iran-conflict', { waitUntil: 'networkidle' });
     await expect(page.locator('.cc-search-input')).toBeVisible();
-    // Selection actually happened: the sidebar expands the selected tracker.
+    // Selection actually happened: the sidebar expands the selected tracker
+    // (operations view; the geographic view renders an accordion instead).
     await expect(page.locator('.cc-tracker-expanded').first()).toBeVisible({ timeout: 10_000 });
     await page.waitForTimeout(500);
-    const url = new URL(page.url());
-    expect(url.searchParams.get('tracker')).toBe('iran-conflict');
-    expect(url.hash).toBe('#geo');
+    expect(new URL(page.url()).searchParams.get('tracker')).toBe('iran-conflict');
 
     // Deselecting removes the parameter (round trip in the other direction).
     await page.keyboard.press('Escape');
     await page.waitForFunction(() => !new URLSearchParams(location.search).has('tracker'), null, { timeout: 5_000 });
+  });
+
+  test('keeps the view hash next to the tracker parameter', async ({ page }) => {
+    await page.goto('./?tracker=iran-conflict#geo', { waitUntil: 'networkidle' });
+    await expect(page.locator('.cc-search-input')).toBeVisible();
+    await page.waitForTimeout(800);
+    const url = new URL(page.url());
+    expect(url.searchParams.get('tracker')).toBe('iran-conflict');
+    expect(url.hash).toBe('#geo');
   });
 
   test('ignores an unknown tracker slug', async ({ page }) => {

--- a/e2e/home-share.spec.ts
+++ b/e2e/home-share.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Homepage ?tracker= selection', () => {
+  test('selects the tracker named in the URL and keeps the hash', async ({ page }) => {
+    await page.goto('./?tracker=iran-conflict#geo', { waitUntil: 'networkidle' });
+    await expect(page.locator('.cc-search-input')).toBeVisible();
+    await page.waitForTimeout(800);
+    const url = new URL(page.url());
+    expect(url.searchParams.get('tracker')).toBe('iran-conflict');
+    expect(url.hash).toBe('#geo');
+  });
+
+  test('ignores an unknown tracker slug', async ({ page }) => {
+    await page.goto('./?tracker=does-not-exist', { waitUntil: 'networkidle' });
+    await expect(page.locator('.cc-search-input')).toBeVisible();
+    await page.waitForTimeout(800);
+    expect(new URL(page.url()).searchParams.get('tracker')).toBeNull();
+  });
+});

--- a/e2e/home-share.spec.ts
+++ b/e2e/home-share.spec.ts
@@ -4,10 +4,16 @@ test.describe('Homepage ?tracker= selection', () => {
   test('selects the tracker named in the URL and keeps the hash', async ({ page }) => {
     await page.goto('./?tracker=iran-conflict#geo', { waitUntil: 'networkidle' });
     await expect(page.locator('.cc-search-input')).toBeVisible();
-    await page.waitForTimeout(800);
+    // Selection actually happened: the sidebar expands the selected tracker.
+    await expect(page.locator('.cc-tracker-expanded').first()).toBeVisible({ timeout: 10_000 });
+    await page.waitForTimeout(500);
     const url = new URL(page.url());
     expect(url.searchParams.get('tracker')).toBe('iran-conflict');
     expect(url.hash).toBe('#geo');
+
+    // Deselecting removes the parameter (round trip in the other direction).
+    await page.keyboard.press('Escape');
+    await page.waitForFunction(() => !new URLSearchParams(location.search).has('tracker'), null, { timeout: 5_000 });
   });
 
   test('ignores an unknown tracker slug', async ({ page }) => {

--- a/e2e/home-share.spec.ts
+++ b/e2e/home-share.spec.ts
@@ -1,8 +1,22 @@
 import { test, expect } from '@playwright/test';
 
+// The first-visit tour is a modal that intercepts every click; mark it done
+// before the page scripts run (same keys as src/lib/onboarding.ts).
+const TOUR_DONE = () => {
+  const done = JSON.stringify({ completed: true, completedAt: '2026-01-01T00:00:00.000Z', replayCount: 0 });
+  localStorage.setItem('watchboard-tour-desktop-v1', done);
+  localStorage.setItem('watchboard-tour-mobile-v1', done);
+};
+
+// The homepage polls live layers, so it never reaches 'networkidle'; wait for
+// 'load' and then for the island to render.
 test.describe('Homepage ?tracker= selection', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(TOUR_DONE);
+  });
+
   test('selects the tracker named in the URL', async ({ page }) => {
-    await page.goto('./?tracker=iran-conflict', { waitUntil: 'networkidle' });
+    await page.goto('./?tracker=iran-conflict', { waitUntil: 'load' });
     await expect(page.locator('.cc-search-input')).toBeVisible();
     // Selection actually happened: the sidebar expands the selected tracker
     // (operations view; the geographic view renders an accordion instead).
@@ -16,7 +30,7 @@ test.describe('Homepage ?tracker= selection', () => {
   });
 
   test('keeps the view hash next to the tracker parameter', async ({ page }) => {
-    await page.goto('./?tracker=iran-conflict#geo', { waitUntil: 'networkidle' });
+    await page.goto('./?tracker=iran-conflict#geo', { waitUntil: 'load' });
     await expect(page.locator('.cc-search-input')).toBeVisible();
     await page.waitForTimeout(800);
     const url = new URL(page.url());
@@ -25,7 +39,7 @@ test.describe('Homepage ?tracker= selection', () => {
   });
 
   test('ignores an unknown tracker slug', async ({ page }) => {
-    await page.goto('./?tracker=does-not-exist', { waitUntil: 'networkidle' });
+    await page.goto('./?tracker=does-not-exist', { waitUntil: 'load' });
     await expect(page.locator('.cc-search-input')).toBeVisible();
     await page.waitForTimeout(800);
     expect(new URL(page.url()).searchParams.get('tracker')).toBeNull();

--- a/e2e/map-share.spec.ts
+++ b/e2e/map-share.spec.ts
@@ -8,10 +8,18 @@ test.describe('2D map shareable view state', () => {
     await map.scrollIntoViewIfNeeded();
     await page.waitForTimeout(1200);
 
+    // Reading: the two layers named in the URL are the active ones.
+    await page.locator('.map-layers-toggle:visible').first().click();
+    await expect(page.locator('.map-layers-panel:visible .map-layer-item.active')).toHaveCount(2);
+    await expect(page.locator('.map-layers-panel:visible .map-layer-item.active').nth(0)).toContainText(/Earthquakes/i);
+
+    // Writing: a real zoom changes the URL to the new zoom (not the value we typed).
+    await page.locator('.leaflet-control-zoom-in:visible').first().click();
+    await page.waitForFunction(() => new URLSearchParams(location.search).get('zoom') === '7', null, { timeout: 5_000 });
     const params = new URLSearchParams(new URL(page.url()).search);
+    expect(Number(params.get('zoom'))).toBe(7);
     expect(Math.abs(Number(params.get('lat')) - 30)).toBeLessThan(0.3);
     expect(Math.abs(Number(params.get('lon')) - 50)).toBeLessThan(0.5);
-    expect(Number(params.get('zoom'))).toBe(6);
     expect(params.get('layers')).toBe('earthquakes,terminator');
   });
 

--- a/e2e/map-share.spec.ts
+++ b/e2e/map-share.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('2D map shareable view state', () => {
+  test('restores centre, zoom and layers from the URL', async ({ page }) => {
+    await page.goto('./iran-conflict/?lat=30&lon=50&zoom=6&layers=earthquakes,terminator');
+    const map = page.locator('.leaflet-container:visible').first();
+    await expect(map).toBeVisible({ timeout: 30_000 });
+    await map.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(1200);
+
+    const params = new URLSearchParams(new URL(page.url()).search);
+    expect(Math.abs(Number(params.get('lat')) - 30)).toBeLessThan(0.3);
+    expect(Math.abs(Number(params.get('lon')) - 50)).toBeLessThan(0.5);
+    expect(Number(params.get('zoom'))).toBe(6);
+    expect(params.get('layers')).toBe('earthquakes,terminator');
+  });
+
+  test('the share button copies the current URL', async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await page.goto('./iran-conflict/?lat=30&lon=50&zoom=6');
+    await expect(page.locator('.leaflet-container:visible').first()).toBeVisible({ timeout: 30_000 });
+    await page.locator('.map-layers-toggle:visible').first().click();
+    await page.locator('.map-layers-share:visible').first().click();
+    await expect(page.locator('.map-layers-share:visible').first()).toHaveAttribute('data-status', 'copied');
+    const clip = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clip).toContain('zoom=6');
+    expect(clip).toContain('lat=');
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,19 +1,29 @@
 import { defineConfig } from '@playwright/test';
 
+// The site is served at base '/' (astro.config.mjs). Specs use relative
+// paths ('./iran-conflict/') so they follow baseURL.
 export default defineConfig({
   testDir: './e2e',
-  timeout: 30_000,
+  timeout: 60_000,
+  retries: process.env.CI ? 1 : 0,
   expect: {
     timeout: 10_000,
   },
   use: {
-    baseURL: 'http://localhost:4321/watchboard/',
+    baseURL: 'http://localhost:4321/',
     headless: true,
+    launchOptions: {
+      // Cesium needs WebGL; SwiftShader gives headless Chromium a software GL.
+      args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'],
+      // Sandboxes that pre-install Chromium at a fixed path set this instead
+      // of downloading the pinned build (e.g. PW_CHROMIUM_PATH=/opt/pw-browsers/chromium-1194/chrome-linux/chrome).
+      ...(process.env.PW_CHROMIUM_PATH ? { executablePath: process.env.PW_CHROMIUM_PATH } : {}),
+    },
   },
   webServer: {
     command: 'npm run dev',
     port: 4321,
     reuseExistingServer: true,
-    timeout: 60_000,
+    timeout: 120_000,
   },
 });

--- a/src/components/islands/CesiumGlobe/CesiumControls.tsx
+++ b/src/components/islands/CesiumGlobe/CesiumControls.tsx
@@ -6,6 +6,7 @@ import type { VisualMode } from './cesium-shaders';
 import type { OrbitMode } from './useCesiumCamera';
 import { SAT_GROUPS, type SatGroupCounts } from './useSatellites';
 import type { VectorToggles } from './useMissionVectors';
+import ShareViewButton from '../shared/ShareViewButton';
 
 interface Props {
   activeFilters: Set<string>;
@@ -19,6 +20,10 @@ interface Props {
     nfz: boolean; ships: boolean; gpsJam: boolean; internetBlackout: boolean; groundTruth: boolean;
   };
   onToggleLayer: (layer: 'satellites' | 'flights' | 'quakes' | 'weather' | 'nfz' | 'ships' | 'gpsJam' | 'internetBlackout' | 'groundTruth') => void;
+  /** Returns the shareable URL for the current view (E1). */
+  onShareView?: () => string;
+  /** Bumped by the `S` shortcut to copy without clicking. */
+  shareTrigger?: number;
   persistLines: boolean;
   onTogglePersist: () => void;
   satGroupCounts?: SatGroupCounts;
@@ -83,6 +88,8 @@ export default function CesiumControls({
   onToggleCinematic,
   vectorToggles,
   onToggleVector,
+  onShareView,
+  shareTrigger,
 }: Props) {
   const [activeSection, setActiveSection] = useState<ToolbarSection | null>(null);
   const [aisKeyDraft, setAisKeyDraft] = useState('');
@@ -395,6 +402,9 @@ export default function CesiumControls({
         >
           <svg viewBox="0 0 16 16" width="16" height="16"><path d="M8 1L1 5l7 4 7-4zM1 8l7 4 7-4M1 11l7 4 7-4" fill="none" stroke="currentColor" strokeWidth="1.5"/></svg>
         </button>
+        {onShareView && (
+          <ShareViewButton buildUrl={onShareView} trigger={shareTrigger} compact className="globe-toolbar-icon" />
+        )}
         {onToggleCinematic && (
           <button
             className={`globe-toolbar-icon${cinematicMode ? ' active cinematic-active' : ''}`}

--- a/src/components/islands/CesiumGlobe/CesiumGlobe.tsx
+++ b/src/components/islands/CesiumGlobe/CesiumGlobe.tsx
@@ -47,6 +47,8 @@ import GlobeMobileSheet from './GlobeMobileSheet';
 import type { MissionTrajectory } from '../../../lib/schemas';
 import { resolveLayout, type PanelId } from './layout-presets';
 import IslandErrorBoundary from '../shared/IslandErrorBoundary';
+import { readViewState, createViewStateWriter, type ViewState } from '../../../lib/view-state';
+import { eventToSlug } from '../../../lib/event-slug';
 import { IslandErrorFallback } from '../shared/IslandErrorFallback';
 
 interface Props {
@@ -76,6 +78,12 @@ const KPI_COLORS: Record<string, string> = {
 
 // Today's date for mode detection
 const TODAY = new Date().toISOString().split('T')[0];
+
+/** Layer keys accepted in the `layers` URL parameter (ADR-0001). */
+export const GLOBE_LAYER_KEYS = [
+  'satellites', 'flights', 'quakes', 'weather', 'nfz', 'ships', 'gpsJam', 'internetBlackout', 'groundTruth',
+] as const;
+type GlobeLayerKey = typeof GLOBE_LAYER_KEYS[number];
 
 // ── Time helpers ──
 
@@ -115,6 +123,13 @@ function CesiumGlobeInner({ points, lines, kpis, meta, events = [], cameraPreset
   const [cesiumViewer, setCesiumViewer] = useState<CesiumViewer | null>(null);
   const { flyTo, flyToPosition, startOrbit, stopOrbit, orbitModeRef } = useCesiumCamera(viewerRef, cameraPresets);
 
+  // ── Shareable view state (URL) — read once on mount, written debounced ──
+  // client:only island, so reading window here cannot cause a hydration mismatch.
+  const urlViewRef = useRef<ViewState>(readViewState(GLOBE_LAYER_KEYS));
+  const viewWriterRef = useRef(createViewStateWriter(500));
+  const [urlEventSlug, setUrlEventSlug] = useState<string | undefined>(urlViewRef.current.event);
+  const [shareTrigger, setShareTrigger] = useState(0);
+
   // ── Filters ──
   const [activeFilters, setActiveFilters] = useState<Set<string>>(
     () => new Set(categories.map(c => c.id)),
@@ -128,10 +143,16 @@ function CesiumGlobeInner({ points, lines, kpis, meta, events = [], cameraPreset
   // ── Live data layer toggles ──
   const [layers, setLayers] = useState(() => {
     const mil = categories.some(c => c.id === 'strike' || c.id === 'retaliation');
-    return {
+    const defaults: Record<GlobeLayerKey, boolean> = {
       satellites: true, flights: true, quakes: false, weather: false, nfz: mil, ships: mil,
       gpsJam: mil, internetBlackout: mil, groundTruth: true,
     };
+    const fromUrl = urlViewRef.current.layers;
+    if (!fromUrl) return defaults;
+    // `layers=` present means the sender chose exactly these (possibly none).
+    const chosen: Record<GlobeLayerKey, boolean> = { ...defaults };
+    for (const k of GLOBE_LAYER_KEYS) chosen[k] = fromUrl.includes(k);
+    return chosen;
   });
 
   // ── Events panel (default collapsed) ──
@@ -195,7 +216,9 @@ function CesiumGlobeInner({ points, lines, kpis, meta, events = [], cameraPreset
     };
   }, [points, lines, isHistorical, endDate]);
 
-  const initialDate = isHistorical ? dateRange.min : dateRange.max;
+  const defaultDate = isHistorical ? dateRange.min : dateRange.max;
+  const urlDate = urlViewRef.current.date;
+  const initialDate = urlDate && urlDate >= dateRange.min && urlDate <= dateRange.max ? urlDate : defaultDate;
   const [currentDate, setCurrentDate] = useState(initialDate);
   const currentDateRef = useRef(currentDate);
   currentDateRef.current = currentDate;
@@ -414,18 +437,84 @@ function CesiumGlobeInner({ points, lines, kpis, meta, events = [], cameraPreset
     viewer.scene.fog.enabled = true;
     viewer.scene.fog.density = 0.0002;
 
-    // Fly to initial position
+    // Initial position: a shared URL wins over the tracker's first preset.
+    const u = urlViewRef.current;
+    const hasUrlCamera = u.lat !== undefined && u.lon !== undefined;
     viewer.camera.setView({
-      destination: Cartesian3.fromDegrees(initLon, initLat, initAlt),
+      destination: hasUrlCamera
+        ? Cartesian3.fromDegrees(u.lon!, u.lat!, u.alt ?? initAlt)
+        : Cartesian3.fromDegrees(initLon, initLat, initAlt),
       orientation: {
-        heading: CesiumMath.toRadians(firstPreset?.heading ?? 0),
-        pitch: CesiumMath.toRadians(firstPreset?.pitch ?? -90),
+        heading: CesiumMath.toRadians(hasUrlCamera ? (u.heading ?? 0) : (firstPreset?.heading ?? 0)),
+        pitch: CesiumMath.toRadians(hasUrlCamera ? (u.pitch ?? -90) : (firstPreset?.pitch ?? -90)),
         roll: 0,
       },
     });
 
     setCesiumViewer(viewer);
   }, [cameraPresets, mapCenter]);
+
+  /** Current camera as view-state fields; undefined before the viewer exists. */
+  const readCamera = useCallback((): Pick<ViewState, 'lat' | 'lon' | 'alt' | 'heading' | 'pitch'> => {
+    const viewer = viewerRef.current?.cesiumElement;
+    if (!viewer || viewer.isDestroyed()) return {};
+    const c = viewer.camera.positionCartographic;
+    return {
+      lat: CesiumMath.toDegrees(c.latitude),
+      lon: CesiumMath.toDegrees(c.longitude),
+      alt: c.height,
+      heading: CesiumMath.toDegrees(viewer.camera.heading),
+      pitch: CesiumMath.toDegrees(viewer.camera.pitch),
+    };
+  }, []);
+
+  const layersRef = useRef(layers);
+  layersRef.current = layers;
+  const urlEventRef = useRef(urlEventSlug);
+  urlEventRef.current = urlEventSlug;
+
+  const buildViewState = useCallback((): ViewState => ({
+    ...readCamera(),
+    layers: GLOBE_LAYER_KEYS.filter(k => layersRef.current[k]),
+    date: currentDateRef.current,
+    ...(urlEventRef.current ? { event: urlEventRef.current } : {}),
+  }), [readCamera]);
+
+  // Write the URL after the camera settles.
+  useEffect(() => {
+    if (!cesiumViewer) return;
+    const writer = viewWriterRef.current;
+    const onMoveEnd = () => writer.write(buildViewState());
+    cesiumViewer.camera.moveEnd.addEventListener(onMoveEnd);
+    onMoveEnd();
+    return () => {
+      cesiumViewer.camera.moveEnd.removeEventListener(onMoveEnd);
+      writer.cancel();
+    };
+  }, [cesiumViewer, buildViewState]);
+
+  // ...and when layers, date or the open event change.
+  useEffect(() => {
+    if (!cesiumViewer) return;
+    viewWriterRef.current.write(buildViewState());
+  }, [cesiumViewer, layers, currentDate, urlEventSlug, buildViewState]);
+
+  // `?event=` opens that event: jump the scrubber to its date, open the
+  // intel panel, and fly to its map point when one shares the event id.
+  useEffect(() => {
+    if (!cesiumViewer || !urlViewRef.current.event) return;
+    const slug = urlViewRef.current.event;
+    const ev = events.find(e => eventToSlug(e.resolvedDate, e.id) === slug);
+    if (!ev) { setUrlEventSlug(undefined); return; }
+    setCurrentDate(ev.resolvedDate);
+    setEventsOpen(true);
+    const pt = points.find(p => p.id === ev.id);
+    if (pt && urlViewRef.current.lat === undefined) {
+      flyToPosition({ lon: pt.lon, lat: pt.lat, alt: 400_000, duration: 1.5 });
+    }
+  }, [cesiumViewer, events, points, flyToPosition]);
+
+  const buildShareUrl = useCallback(() => viewWriterRef.current.flush(buildViewState()), [buildViewState]);
 
   // ── Conflict data (imperative entities) — points + past arcs ──
   const handlePointSelect = useCallback((point: MapPoint | null) => {
@@ -530,9 +619,20 @@ function CesiumGlobeInner({ points, lines, kpis, meta, events = [], cameraPreset
     });
   }, [handleOrbitMode]);
 
+  useEffect(() => {
+    if (!eventsOpen && urlEventSlug) setUrlEventSlug(undefined);
+  }, [eventsOpen, urlEventSlug]);
+
   // ── Escape key to dismiss floating card ──
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      const tgt = e.target as HTMLElement | null;
+      const isInput = !!tgt && (tgt.tagName === 'INPUT' || tgt.tagName === 'TEXTAREA' || tgt.isContentEditable);
+      if (!isInput && (e.key === 's' || e.key === 'S') && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        e.preventDefault();
+        setShareTrigger(n => n + 1);
+        return;
+      }
       if (e.key === 'Escape' && carouselEntities.length > 0) {
         setCarouselEntities([]);
       }
@@ -745,6 +845,8 @@ function CesiumGlobeInner({ points, lines, kpis, meta, events = [], cameraPreset
             onVisualMode={setVisualMode}
             layers={layers}
             onToggleLayer={toggleLayer}
+          onShareView={buildShareUrl}
+          shareTrigger={shareTrigger}
             persistLines={persistLines}
             onTogglePersist={() => setPersistLines(prev => !prev)}
             satGroupCounts={satGroupCounts}
@@ -806,6 +908,8 @@ function CesiumGlobeInner({ points, lines, kpis, meta, events = [], cameraPreset
           onVisualMode={setVisualMode}
           layers={layers}
           onToggleLayer={toggleLayer}
+          onShareView={buildShareUrl}
+          shareTrigger={shareTrigger}
           persistLines={persistLines}
           onTogglePersist={() => setPersistLines(prev => !prev)}
           carouselEntities={carouselEntities}

--- a/src/components/islands/CesiumGlobe/CesiumGlobe.tsx
+++ b/src/components/islands/CesiumGlobe/CesiumGlobe.tsx
@@ -128,6 +128,7 @@ function CesiumGlobeInner({ points, lines, kpis, meta, events = [], cameraPreset
   const urlViewRef = useRef<ViewState>(readViewState(GLOBE_LAYER_KEYS));
   const viewWriterRef = useRef(createViewStateWriter(500));
   const [urlEventSlug, setUrlEventSlug] = useState<string | undefined>(urlViewRef.current.event);
+  const [urlEventId, setUrlEventId] = useState<string | null>(null);
   const [shareTrigger, setShareTrigger] = useState(0);
 
   // ── Filters ──
@@ -508,6 +509,8 @@ function CesiumGlobeInner({ points, lines, kpis, meta, events = [], cameraPreset
     if (!ev) { setUrlEventSlug(undefined); return; }
     setCurrentDate(ev.resolvedDate);
     setEventsOpen(true);
+    setUrlEventSlug(slug);
+    setUrlEventId(ev.id);
     const pt = points.find(p => p.id === ev.id);
     if (pt && urlViewRef.current.lat === undefined) {
       flyToPosition({ lon: pt.lon, lat: pt.lat, alt: 400_000, duration: 1.5 });
@@ -619,8 +622,15 @@ function CesiumGlobeInner({ points, lines, kpis, meta, events = [], cameraPreset
     });
   }, [handleOrbitMode]);
 
+  // Drop the event from the URL only when the user closes the intel panel,
+  // not on mount (the panel starts closed before the ?event= effect runs).
+  const prevEventsOpen = useRef(eventsOpen);
   useEffect(() => {
-    if (!eventsOpen && urlEventSlug) setUrlEventSlug(undefined);
+    if (prevEventsOpen.current && !eventsOpen && urlEventSlug) {
+      setUrlEventSlug(undefined);
+      setUrlEventId(null);
+    }
+    prevEventsOpen.current = eventsOpen;
   }, [eventsOpen, urlEventSlug]);
 
   // ── Escape key to dismiss floating card ──
@@ -755,7 +765,7 @@ function CesiumGlobeInner({ points, lines, kpis, meta, events = [], cameraPreset
                   return !prev;
                 });
               }}
-              activeEventId={cinematicMode ? cinematicEventId : undefined}
+              activeEventId={cinematicMode ? cinematicEventId : urlEventId ?? undefined}
             />
           </CollapsiblePanel>
         )}
@@ -899,7 +909,7 @@ function CesiumGlobeInner({ points, lines, kpis, meta, events = [], cameraPreset
           onTrackSpacecraft={trackSpacecraft}
           eventsOpen={eventsOpen}
           onToggleEvents={() => setEventsOpen(prev => !prev)}
-          activeEventId={cinematicMode ? cinematicEventId : undefined}
+          activeEventId={cinematicMode ? cinematicEventId : urlEventId ?? undefined}
           activeFilters={activeFilters}
           onToggleFilter={toggleFilter}
           pointCounts={pointCounts}

--- a/src/components/islands/CesiumGlobe/GlobeMobileSheet.tsx
+++ b/src/components/islands/CesiumGlobe/GlobeMobileSheet.tsx
@@ -501,6 +501,9 @@ export default function GlobeMobileSheet(props: Props) {
 
       {/* Tab bar */}
       <div className="mobile-sheet-tabs">
+        {onShareView && (
+          <ShareViewButton buildUrl={onShareView} trigger={shareTrigger} compact className="mobile-sheet-share" />
+        )}
         {tabs.map(tab => (
           <button
             key={tab}

--- a/src/components/islands/CesiumGlobe/GlobeMobileSheet.tsx
+++ b/src/components/islands/CesiumGlobe/GlobeMobileSheet.tsx
@@ -8,6 +8,7 @@
  * Tabs: Timeline | Mission | Intel | Filters
  * Mission tab only appears when missionTrajectory is provided.
  */
+import ShareViewButton from '../shared/ShareViewButton';
 import { useState, useRef, useCallback, useEffect, useMemo, type MutableRefObject, type ReactNode } from 'react';
 import { t } from '../../../i18n/translations';
 import { useLocale } from '../../../i18n/useLocale';
@@ -72,6 +73,8 @@ interface Props {
     nfz: boolean; ships: boolean; gpsJam: boolean; internetBlackout: boolean; groundTruth: boolean;
   };
   onToggleLayer: (layer: 'satellites' | 'flights' | 'quakes' | 'weather' | 'nfz' | 'ships' | 'gpsJam' | 'internetBlackout' | 'groundTruth') => void;
+  onShareView?: () => string;
+  shareTrigger?: number;
   persistLines: boolean;
   onTogglePersist: () => void;
 
@@ -167,7 +170,7 @@ export default function GlobeMobileSheet(props: Props) {
     events, currentDate, activeEventId,
     activeFilters, onToggleFilter, pointCounts, categories,
     visualMode, onVisualMode,
-    layers, onToggleLayer,
+    layers, onToggleLayer, onShareView, shareTrigger,
     persistLines, onTogglePersist,
     missionTrajectory, telemetryRef, vectorsRef, vectorToggles, onToggleVector, onTrackSpacecraft,
     carouselEntities, activeCardIndex, onCloseCard,

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -204,28 +204,6 @@ function CommandCenterInner({
     }
   }, [viewMode]);
 
-  // ── Shareable selection: ?tracker=slug (ADR-0001). Applied after mount so
-  // the hydrated first render matches the server HTML.
-  const viewWriterRef = useRef(createViewStateWriter(300));
-  const [shareTrigger, setShareTrigger] = useState(0);
-  const urlTrackerApplied = useRef(false);
-  useEffect(() => {
-    if (urlTrackerApplied.current) return;
-    urlTrackerApplied.current = true;
-    const { tracker } = readViewState();
-    if (tracker && trackers.some(t => t.slug === tracker)) {
-      setActiveTracker(tracker);
-      setSidebarCollapsed(false);
-    }
-  }, [trackers]);
-  useEffect(() => {
-    if (!urlTrackerApplied.current) return;
-    viewWriterRef.current.write(activeTracker ? { tracker: activeTracker } : {});
-  }, [activeTracker]);
-  const buildShareUrl = useCallback(
-    () => viewWriterRef.current.flush(activeTracker ? { tracker: activeTracker } : {}),
-    [activeTracker],
-  );
 
   // Lazy-load country GeoJSON when entering geographic mode
   useEffect(() => {
@@ -331,6 +309,32 @@ function CommandCenterInner({
       }
     }
   }, [broadcastOff]);
+
+  // ── Shareable selection: ?tracker=slug (ADR-0001). Applied after mount so
+  // the hydrated first render matches the server HTML.
+  const viewWriterRef = useRef(createViewStateWriter(300));
+  const [shareTrigger, setShareTrigger] = useState(0);
+  const urlTrackerApplied = useRef(false);
+  useEffect(() => {
+    if (urlTrackerApplied.current) return;
+    urlTrackerApplied.current = true;
+    const { tracker } = readViewState();
+    if (tracker && trackers.some(t => t.slug === tracker)) {
+      // Same path as a click: selects, and in broadcast mode jumps the
+      // globe to the tracker (the only fly-to path that is live by default).
+      handleSelect(tracker);
+      setSidebarCollapsed(false);
+    }
+  }, [trackers, handleSelect]);
+  useEffect(() => () => viewWriterRef.current.cancel(), []);
+  useEffect(() => {
+    if (!urlTrackerApplied.current) return;
+    viewWriterRef.current.write(activeTracker ? { tracker: activeTracker } : {});
+  }, [activeTracker]);
+  const buildShareUrl = useCallback(
+    () => viewWriterRef.current.flush(activeTracker ? { tracker: activeTracker } : {}),
+    [activeTracker],
+  );
 
   const handleHover = useCallback((slug: string | null) => {
     setHoveredTracker(slug);

--- a/src/components/islands/CommandCenter/CommandCenter.tsx
+++ b/src/components/islands/CommandCenter/CommandCenter.tsx
@@ -21,6 +21,8 @@ import DesktopStoryStrip from './DesktopStoryStrip';
 import { getDiscoveredFeatures, markFeatureDiscovered, getNextCoachHint, getTourState, resetTour } from '../../../lib/onboarding';
 import OnboardingTour, { TOUR_REPLAY_EVENT } from '../Onboarding/OnboardingTour';
 import IslandErrorBoundary from '../shared/IslandErrorBoundary';
+import ShareViewButton from '../shared/ShareViewButton';
+import { readViewState, createViewStateWriter } from '../../../lib/view-state';
 import { IslandErrorFallback } from '../shared/IslandErrorFallback';
 
 const FOLLOWS_KEY = 'watchboard-follows';
@@ -48,6 +50,7 @@ const SHORTCUTS = [
   { key: 'L', tKey: 'shortcuts.cityLights' },
   { key: 'O', tKey: 'shortcuts.openSelected' },
   { key: 'Esc', tKey: 'shortcuts.deselect' },
+  { key: 'S', tKey: 'shortcuts.share' },
   { key: '?', tKey: 'shortcuts.help' },
 ] as const;
 
@@ -191,13 +194,38 @@ function CommandCenterInner({
   broadcastRef.current = broadcast;
 
   useEffect(() => {
+    // Keep the query string (?tracker=, utm_*) when switching the view hash.
     const hash = viewMode === 'operations' ? '' : viewMode === 'geographic' ? '#geo' : '#domain';
+    const base = window.location.pathname + window.location.search;
     if (hash) {
-      window.history.replaceState(null, '', hash);
+      window.history.replaceState(null, '', base + hash);
     } else if (window.location.hash) {
-      window.history.replaceState(null, '', window.location.pathname);
+      window.history.replaceState(null, '', base);
     }
   }, [viewMode]);
+
+  // ── Shareable selection: ?tracker=slug (ADR-0001). Applied after mount so
+  // the hydrated first render matches the server HTML.
+  const viewWriterRef = useRef(createViewStateWriter(300));
+  const [shareTrigger, setShareTrigger] = useState(0);
+  const urlTrackerApplied = useRef(false);
+  useEffect(() => {
+    if (urlTrackerApplied.current) return;
+    urlTrackerApplied.current = true;
+    const { tracker } = readViewState();
+    if (tracker && trackers.some(t => t.slug === tracker)) {
+      setActiveTracker(tracker);
+      setSidebarCollapsed(false);
+    }
+  }, [trackers]);
+  useEffect(() => {
+    if (!urlTrackerApplied.current) return;
+    viewWriterRef.current.write(activeTracker ? { tracker: activeTracker } : {});
+  }, [activeTracker]);
+  const buildShareUrl = useCallback(
+    () => viewWriterRef.current.flush(activeTracker ? { tracker: activeTracker } : {}),
+    [activeTracker],
+  );
 
   // Lazy-load country GeoJSON when entering geographic mode
   useEffect(() => {
@@ -486,6 +514,13 @@ function CommandCenterInner({
             handleToggleCompare(activeTracker);
           }
           break;
+        case 's':
+        case 'S':
+          if (!e.metaKey && !e.ctrlKey && !e.altKey) {
+            e.preventDefault();
+            setShareTrigger(n => n + 1);
+          }
+          break;
         case 'o':
         case 'O':
           if (activeTracker) {
@@ -520,6 +555,7 @@ function CommandCenterInner({
       }} role="banner" aria-label="Watchboard navigation">
         <div style={styles.overlayNavLogo}>WATCHBOARD</div>
         <div style={styles.overlayNavBadges}>
+          <ShareViewButton buildUrl={buildShareUrl} trigger={shareTrigger} compact className="cc-share-btn" />
           {isMobile ? (
             <>
               <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '0.5rem', color: 'var(--accent-green)' }}>

--- a/src/components/islands/IntelMap.tsx
+++ b/src/components/islands/IntelMap.tsx
@@ -91,12 +91,18 @@ function IntelMapInner({ points, lines, events, categories, mapCenter, mapBounds
       ? { lat: urlView.lat, lon: urlView.lon, zoom: urlView.zoom }
       : {},
   );
+  // Refs keep handleViewChange's identity stable so LeafletMap's moveend
+  // listener is registered once, not on every layer/date change.
+  const layersRef = useRef(layers);
+  layersRef.current = layers;
+  const dateRef = useRef(currentDate);
+  dateRef.current = currentDate;
   const buildViewState = useCallback((): ViewState => ({
     ...cameraRef.current,
-    layers: MAP_LAYER_KEYS.filter(k => layers[k]),
-    date: currentDate,
-  }), [layers, currentDate]);
-  useEffect(() => { viewWriter.write(buildViewState()); }, [buildViewState, viewWriter]);
+    layers: MAP_LAYER_KEYS.filter(k => layersRef.current[k]),
+    date: dateRef.current,
+  }), []);
+  useEffect(() => { viewWriter.write(buildViewState()); }, [layers, currentDate, buildViewState, viewWriter]);
   useEffect(() => () => viewWriter.cancel(), [viewWriter]);
   const handleViewChange = useCallback((lat: number, lon: number, zoom: number) => {
     cameraRef.current = { lat, lon, zoom };

--- a/src/components/islands/IntelMap.tsx
+++ b/src/components/islands/IntelMap.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { trackEvent } from '../../lib/analytics';
 import type { MapPoint, MapLine } from '../../lib/schemas';
 import type { FlatEvent } from '../../lib/timeline-utils';
@@ -10,6 +10,12 @@ import MapEventsPanel from './MapEventsPanel';
 import MapLayerToggles from './MapLayerToggles';
 import { useMapOverlays } from './useMapOverlays';
 import type { LayerState } from './useMapOverlays';
+import { readViewState, createViewStateWriter, type ViewState } from '../../lib/view-state';
+
+/** Layer keys accepted in the `layers` URL parameter (ADR-0001). */
+export const MAP_LAYER_KEYS = [
+  'noFlyZones', 'gpsJamming', 'internetBlackout', 'earthquakes', 'weather', 'flights', 'terminator', 'factCards',
+] as const satisfies readonly (keyof LayerState)[];
 import { useMapFlights } from './useMapFlights';
 import { useTerminator } from './useTerminator';
 import IslandErrorBoundary from './shared/IslandErrorBoundary';
@@ -56,23 +62,47 @@ function IntelMapInner({ points, lines, events, categories, mapCenter, mapBounds
     };
   }, [points, lines]);
 
-  const [currentDate, setCurrentDate] = useState(dateRange.max);
+  // Shareable view state: client:only island, so reading window is safe.
+  const urlView = useMemo(() => readViewState(MAP_LAYER_KEYS), []);
+  const viewWriter = useMemo(() => createViewStateWriter(500), []);
+  const [currentDate, setCurrentDate] = useState(
+    urlView.date && urlView.date >= dateRange.min && urlView.date <= dateRange.max ? urlView.date : dateRange.max,
+  );
   const [isPlaying, setIsPlaying] = useState(false);
   const [playbackSpeed, setPlaybackSpeed] = useState(200);
   const [eventsOpen, setEventsOpen] = useState(false);
   const [persistLines, setPersistLines] = useState(false);
 
   // ── Overlay layers ──
-  const [layers, setLayers] = useState<LayerState>({
-    noFlyZones: false,
-    gpsJamming: false,
-    internetBlackout: false,
-    earthquakes: false,
-    weather: false,
-    flights: false,
-    terminator: false,
-    factCards: false,
+  const [layers, setLayers] = useState<LayerState>(() => {
+    const defaults: LayerState = {
+      noFlyZones: false, gpsJamming: false, internetBlackout: false, earthquakes: false,
+      weather: false, flights: false, terminator: false, factCards: false,
+    };
+    if (!urlView.layers) return defaults;
+    const chosen = { ...defaults };
+    for (const k of MAP_LAYER_KEYS) chosen[k] = urlView.layers.includes(k);
+    return chosen;
   });
+
+  // Camera (centre + zoom) reported by LeafletMap on every moveend.
+  const cameraRef = useRef<Pick<ViewState, 'lat' | 'lon' | 'zoom'>>(
+    urlView.lat !== undefined && urlView.lon !== undefined
+      ? { lat: urlView.lat, lon: urlView.lon, zoom: urlView.zoom }
+      : {},
+  );
+  const buildViewState = useCallback((): ViewState => ({
+    ...cameraRef.current,
+    layers: MAP_LAYER_KEYS.filter(k => layers[k]),
+    date: currentDate,
+  }), [layers, currentDate]);
+  useEffect(() => { viewWriter.write(buildViewState()); }, [buildViewState, viewWriter]);
+  useEffect(() => () => viewWriter.cancel(), [viewWriter]);
+  const handleViewChange = useCallback((lat: number, lon: number, zoom: number) => {
+    cameraRef.current = { lat, lon, zoom };
+    viewWriter.write(buildViewState());
+  }, [buildViewState, viewWriter]);
+  const buildShareUrl = useCallback(() => viewWriter.flush(buildViewState()), [buildViewState, viewWriter]);
 
   const toggleLayer = useCallback((layer: keyof LayerState) => {
     setLayers(prev => ({ ...prev, [layer]: !prev[layer] }));
@@ -188,6 +218,8 @@ function IntelMapInner({ points, lines, events, categories, mapCenter, mapBounds
 
       <div className="map-container">
         <LeafletMap
+          initialView={urlView.lat !== undefined && urlView.lon !== undefined ? { lat: urlView.lat, lon: urlView.lon, zoom: urlView.zoom ?? 5 } : undefined}
+          onViewChange={handleViewChange}
           points={filteredPoints}
           lines={filteredLines}
           categories={mapCategories}
@@ -227,6 +259,7 @@ function IntelMapInner({ points, lines, events, categories, mapCenter, mapBounds
           layers={layers}
           onToggle={toggleLayer}
           counts={mergedCounts}
+          onShareView={buildShareUrl}
         />
 
         {/* Overlay: info panel (right side) */}

--- a/src/components/islands/LeafletMap.tsx
+++ b/src/components/islands/LeafletMap.tsx
@@ -34,6 +34,10 @@ interface Props {
   showFactCards?: boolean;
   mapCenter?: { lon: number; lat: number };
   mapBounds?: { lonMin: number; lonMax: number; latMin: number; latMax: number };
+  /** Camera from a shared URL; wins over mapBounds when present. */
+  initialView?: { lat: number; lon: number; zoom: number };
+  /** Called after every moveend with the new centre and zoom. */
+  onViewChange?: (lat: number, lon: number, zoom: number) => void;
 }
 
 // ────────────────────────────────────────────
@@ -181,6 +185,30 @@ function ScrollZoomGuard() {
   return null;
 }
 
+/**
+ * Reports centre/zoom to the parent after each move so the URL can be kept
+ * in sync (ADR-0001). Emits once on mount so a fresh page has a URL too.
+ */
+function ViewReporter({ onViewChange }: { onViewChange?: (lat: number, lon: number, zoom: number) => void }) {
+  const map = useMap();
+  useEffect(() => {
+    if (!onViewChange) return;
+    const report = () => {
+      // The tracker page mounts the map twice (desktop layout + mobile tab
+      // shell) and CSS hides one. A hidden Leaflet has a 0x0 container and
+      // a meaningless centre; it must never write the URL.
+      const el = map.getContainer();
+      if (el.offsetParent === null || el.clientWidth === 0) return;
+      const c = map.getCenter();
+      onViewChange(c.lat, c.lng, map.getZoom());
+    };
+    map.on('moveend', report);
+    report();
+    return () => { map.off('moveend', report); };
+  }, [map, onViewChange]);
+  return null;
+}
+
 // ────────────────────────────────────────────
 //  Component
 // ────────────────────────────────────────────
@@ -188,7 +216,7 @@ function ScrollZoomGuard() {
 export default function LeafletMap({
   points, lines, categories, onSelectPoint, onSelectLine, overlays,
   flights, terminatorPolygon, currentDate, isPlaying,
-  events, showFactCards, mapCenter, mapBounds,
+  events, showFactCards, mapCenter, mapBounds, initialView, onViewChange,
 }: Props) {
   const locale = useLocale();
   const center: LatLngExpression = mapCenter ? [mapCenter.lat, mapCenter.lon] : [29, 49];
@@ -206,7 +234,9 @@ export default function LeafletMap({
 
   return (
     <MapContainer
-      {...(bounds ? { bounds } : { center, zoom: 5 })}
+      {...(initialView
+        ? { center: [initialView.lat, initialView.lon] as LatLngExpression, zoom: initialView.zoom }
+        : bounds ? { bounds } : { center, zoom: 5 })}
       minZoom={3}
       maxZoom={12}
       style={{ width: '100%', height: '100%', background: '#0d0f14' }}
@@ -214,6 +244,7 @@ export default function LeafletMap({
       zoomControl={false}
     >
       <ScrollZoomGuard />
+      <ViewReporter onViewChange={onViewChange} />
       <ZoomControl position="topright" />
       <TileLayer
         url="https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"

--- a/src/components/islands/MapLayerToggles.tsx
+++ b/src/components/islands/MapLayerToggles.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import type { LayerState } from './useMapOverlays';
+import ShareViewButton from './shared/ShareViewButton';
 
 // ────────────────────────────────────────────
 //  Layer metadata
@@ -32,13 +33,15 @@ interface Props {
   layers: LayerState;
   onToggle: (layer: keyof LayerState) => void;
   counts: Record<keyof LayerState, number>;
+  /** Returns the shareable URL for the current map view (E1). */
+  onShareView?: () => string;
 }
 
 // ────────────────────────────────────────────
 //  Component
 // ────────────────────────────────────────────
 
-export default function MapLayerToggles({ layers, onToggle, counts }: Props) {
+export default function MapLayerToggles({ layers, onToggle, counts, onShareView }: Props) {
   const [expanded, setExpanded] = useState(false);
 
   const toggleExpanded = useCallback(() => {
@@ -68,6 +71,7 @@ export default function MapLayerToggles({ layers, onToggle, counts }: Props) {
     <div className="map-layers-panel">
       <div className="map-layers-header">
         <span className="map-layers-title">OVERLAY LAYERS</span>
+        {onShareView && <ShareViewButton buildUrl={onShareView} compact className="map-layers-share" />}
         <button
           className="map-layers-close"
           onClick={toggleExpanded}

--- a/src/components/islands/shared/ShareViewButton.tsx
+++ b/src/components/islands/shared/ShareViewButton.tsx
@@ -75,7 +75,8 @@ export default function ShareViewButton({ buildUrl, trigger, className = '', com
       type="button"
       className={`share-view-btn${status !== 'idle' ? ` share-view-btn--${status}` : ''} ${className}`.trim()}
       onClick={() => void copy()}
-      title={t('share.copyView', locale)}
+      title={`${t('share.copyView', locale)} (S)`}
+      aria-label={label}
       aria-live="polite"
       data-status={status}
     >

--- a/src/components/islands/shared/ShareViewButton.tsx
+++ b/src/components/islands/shared/ShareViewButton.tsx
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { t } from '../../../i18n/translations';
+import { useLocale } from '../../../i18n/useLocale';
+
+interface Props {
+  /** Returns the URL to copy. Callers flush their view-state writer here so
+   *  the link reflects the camera as it is now, not as it was 500 ms ago. */
+  buildUrl: () => string;
+  /** Bump this counter to trigger a copy from a keyboard shortcut. */
+  trigger?: number;
+  className?: string;
+  compact?: boolean;
+}
+
+async function copyText(text: string): Promise<boolean> {
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    /* fall through to the legacy path */
+  }
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * "Share view" button: copies the current URL (with view state) to the
+ * clipboard and confirms with a 2 s toast. Reused by the globe toolbar,
+ * the 2D map layer panel and the homepage.
+ */
+export default function ShareViewButton({ buildUrl, trigger, className = '', compact = false }: Props) {
+  const locale = useLocale();
+  const [status, setStatus] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastTrigger = useRef(trigger);
+
+  const copy = useCallback(async () => {
+    const ok = await copyText(buildUrl());
+    setStatus(ok ? 'copied' : 'failed');
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setStatus('idle'), 2000);
+  }, [buildUrl]);
+
+  useEffect(() => {
+    if (trigger !== undefined && trigger !== lastTrigger.current) {
+      lastTrigger.current = trigger;
+      void copy();
+    }
+  }, [trigger, copy]);
+
+  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current); }, []);
+
+  const label = status === 'copied'
+    ? t('share.copied', locale)
+    : status === 'failed'
+      ? t('share.copyFailed', locale)
+      : t('share.copyView', locale);
+
+  return (
+    <button
+      type="button"
+      className={`share-view-btn${status !== 'idle' ? ` share-view-btn--${status}` : ''} ${className}`.trim()}
+      onClick={() => void copy()}
+      title={t('share.copyView', locale)}
+      aria-live="polite"
+      data-status={status}
+    >
+      <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+        <path d="M6 10a3 3 0 010-4l2-2a3 3 0 014 4l-1 1M10 6a3 3 0 010 4l-2 2a3 3 0 01-4-4l1-1" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+      </svg>
+      {!compact && <span className="share-view-label">{label}</span>}
+      {compact && status !== 'idle' && <span className="share-view-toast">{label}</span>}
+    </button>
+  );
+}

--- a/src/data/roadmap-items.ts
+++ b/src/data/roadmap-items.ts
@@ -253,9 +253,9 @@ export const ROADMAP_ITEMS: RoadmapItem[] = [
     id: 'rm-shareable-deeplinks',
     title: 'Shareable deep links',
     description:
-      'URL parameters for date / event / view state so a link to a specific event in a specific tracker reopens with that exact view. Depends on the cross-island state shipped with rm-search-filter.',
-    status: 'planned', area: 'growth', priority: 'P2', effort: 'M', milestone: 'M3',
-    date: '2026-04-26', dependsOn: ['rm-search-filter'],
+      'URL parameters for camera, zoom, layers, date, event and selected tracker so a link reopens the exact view on the globe, the 2D map and the homepage. Island-local per ADR-0001 (docs/adr/0001-url-view-state-is-island-local.md), so it no longer waits for cross-island search state.',
+    status: 'in-progress', area: 'growth', priority: 'P2', effort: 'S', milestone: 'M3',
+    date: '2026-09-07',
   },
   {
     id: 'rm-tree-shake-cesium',

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -80,6 +80,10 @@ const en = {
   'shortcuts.openSelected': 'Open selected tracker',
   'shortcuts.deselect': 'Deselect / close',
   'shortcuts.help': 'Show this help',
+  'shortcuts.share': 'Copy link to this view',
+  'share.copyView': 'Share view',
+  'share.copied': 'Link copied',
+  'share.copyFailed': 'Could not copy',
   'shortcuts.close': 'to close',
 
   // Time
@@ -665,6 +669,10 @@ const es: TranslationKeys = {
   'shortcuts.openSelected': 'Abrir rastreador seleccionado',
   'shortcuts.deselect': 'Deseleccionar / cerrar',
   'shortcuts.help': 'Mostrar esta ayuda',
+  'shortcuts.share': 'Copiar enlace a esta vista',
+  'share.copyView': 'Compartir vista',
+  'share.copied': 'Enlace copiado',
+  'share.copyFailed': 'No se pudo copiar',
   'shortcuts.close': 'para cerrar',
 
   'broadcast.live': 'EN VIVO',
@@ -1232,6 +1240,10 @@ const fr: TranslationKeys = {
   'shortcuts.openSelected': 'Ouvrir le tracker sélectionné',
   'shortcuts.deselect': 'Désélectionner / fermer',
   'shortcuts.help': 'Afficher cette aide',
+  'shortcuts.share': 'Copier le lien vers cette vue',
+  'share.copyView': 'Partager la vue',
+  'share.copied': 'Lien copié',
+  'share.copyFailed': 'Copie impossible',
   'shortcuts.close': 'pour fermer',
 
   'broadcast.live': 'EN DIRECT',
@@ -1799,6 +1811,10 @@ const pt: TranslationKeys = {
   'shortcuts.openSelected': 'Abrir tracker selecionado',
   'shortcuts.deselect': 'Desselecionar / fechar',
   'shortcuts.help': 'Mostrar esta ajuda',
+  'shortcuts.share': 'Copiar link para esta vista',
+  'share.copyView': 'Compartilhar vista',
+  'share.copied': 'Link copiado',
+  'share.copyFailed': 'Não foi possível copiar',
   'shortcuts.close': 'para fechar',
 
   'broadcast.live': 'AO VIVO',

--- a/src/lib/view-state.test.ts
+++ b/src/lib/view-state.test.ts
@@ -82,6 +82,9 @@ describe('decodeViewState validation (BVA)', () => {
   it('rejects malformed event/date/tracker', () => {
     expect(decodeViewState('event=<script>')).toEqual({});
     expect(decodeViewState('date=2026-1-2')).toEqual({});
+    expect(decodeViewState('date=2026-02-31')).toEqual({});
+    expect(decodeViewState('date=2026-13-01')).toEqual({});
+    expect(decodeViewState('date=2024-02-29')).toEqual({ date: '2024-02-29' });
     expect(decodeViewState('tracker=Iran_Conflict')).toEqual({});
     expect(decodeViewState('tracker=iran-conflict')).toEqual({ tracker: 'iran-conflict' });
   });

--- a/src/lib/view-state.test.ts
+++ b/src/lib/view-state.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  encodeViewState, decodeViewState, mergeIntoUrl, normalizeHeading, createViewStateWriter,
+  VIEW_STATE_KEYS, type ViewState,
+} from './view-state';
+
+const FULL: ViewState = {
+  lat: 33.31234567, lon: 44.36123456, alt: 250000.7, heading: 90.04, pitch: -45.06,
+  layers: ['flights', 'quakes'], event: '2026-03-05-strike-on-natanz', date: '2026-03-05', tracker: 'iran-conflict',
+};
+
+describe('encode/decode round trip', () => {
+  it('every key written is read back (rounded)', () => {
+    const qs = encodeViewState(FULL).toString();
+    const back = decodeViewState(qs);
+    expect(back).toEqual({
+      lat: 33.3123, lon: 44.3612, alt: 250001, heading: 90, pitch: -45.1,
+      layers: ['flights', 'quakes'], event: FULL.event, date: FULL.date, tracker: FULL.tracker,
+    });
+    // Guard against a key being added to the schema but not to encode/decode.
+    for (const key of VIEW_STATE_KEYS) {
+      if (key === 'zoom') continue; // zoom and alt are alternatives, tested below
+      expect(back, `key ${key} lost in round trip`).toHaveProperty(key);
+    }
+  });
+
+  it('zoom round-trips for the 2D map', () => {
+    const back = decodeViewState(encodeViewState({ lat: 1, lon: 2, zoom: 6.123 }).toString());
+    expect(back).toEqual({ lat: 1, lon: 2, zoom: 6.12 });
+  });
+
+  it('an empty layers array survives as "all off"', () => {
+    const qs = encodeViewState({ layers: [] }).toString();
+    expect(qs).toBe('layers=');
+    expect(decodeViewState(qs)).toEqual({ layers: [] });
+  });
+
+  it('is stable: encoding a decoded state yields the same string', () => {
+    const once = encodeViewState(FULL).toString();
+    const twice = encodeViewState(decodeViewState(once)).toString();
+    expect(twice).toBe(once);
+  });
+});
+
+describe('decodeViewState validation (BVA)', () => {
+  it('ignores non-numeric and out-of-range values without throwing', () => {
+    expect(decodeViewState('lat=abc&lon=10')).toEqual({});
+    expect(decodeViewState('lat=90.0001&lon=10')).toEqual({});
+    expect(decodeViewState('lat=-90&lon=180')).toEqual({ lat: -90, lon: 180 });
+    expect(decodeViewState('lat=10&lon=180.5')).toEqual({});
+    expect(decodeViewState('alt=0&lat=1&lon=1')).toEqual({ lat: 1, lon: 1 });
+    expect(decodeViewState('alt=-5')).toEqual({});
+    expect(decodeViewState('zoom=25')).toEqual({});
+    expect(decodeViewState('pitch=91')).toEqual({});
+    expect(decodeViewState('lat=NaN&lon=Infinity')).toEqual({});
+  });
+
+  it('drops lat without lon and lon without lat', () => {
+    expect(decodeViewState('lat=10')).toEqual({});
+    expect(decodeViewState('lon=10')).toEqual({});
+  });
+
+  it('normalises heading into [0, 360)', () => {
+    expect(decodeViewState('heading=-90')).toEqual({ heading: 270 });
+    expect(decodeViewState('heading=720')).toEqual({ heading: 0 });
+    expect(normalizeHeading(360)).toBe(0);
+  });
+
+  it('keeps good fields when a sibling is bad', () => {
+    expect(decodeViewState('lat=oops&lon=1&layers=flights&date=2026-01-02')).toEqual({
+      layers: ['flights'], date: '2026-01-02',
+    });
+  });
+
+  it('filters unknown layer ids against the allowlist and dedupes', () => {
+    expect(decodeViewState('layers=flights,quakes,flights,bogus', ['flights', 'quakes'])).toEqual({
+      layers: ['flights', 'quakes'],
+    });
+    expect(decodeViewState('layers=bogus', ['flights'])).toEqual({ layers: [] });
+  });
+
+  it('rejects malformed event/date/tracker', () => {
+    expect(decodeViewState('event=<script>')).toEqual({});
+    expect(decodeViewState('date=2026-1-2')).toEqual({});
+    expect(decodeViewState('tracker=Iran_Conflict')).toEqual({});
+    expect(decodeViewState('tracker=iran-conflict')).toEqual({ tracker: 'iran-conflict' });
+  });
+
+  it('accepts URLSearchParams input', () => {
+    expect(decodeViewState(new URLSearchParams('zoom=4'))).toEqual({ zoom: 4 });
+  });
+});
+
+describe('mergeIntoUrl', () => {
+  const loc = { pathname: '/iran-conflict/', search: '?utm_source=x&lat=1&lon=1&layers=old', hash: '#map' };
+
+  it('replaces our keys, preserves foreign params and the hash', () => {
+    const url = mergeIntoUrl({ lat: 5, lon: 6, layers: ['flights'] }, loc);
+    expect(url).toBe('/iran-conflict/?utm_source=x&lat=5&lon=6&layers=flights#map');
+  });
+
+  it('removes our keys that are absent from the new state', () => {
+    expect(mergeIntoUrl({}, loc)).toBe('/iran-conflict/?utm_source=x#map');
+  });
+
+  it('emits no "?" when nothing remains', () => {
+    expect(mergeIntoUrl({}, { pathname: '/x/', search: '?lat=1&lon=2', hash: '' })).toBe('/x/');
+  });
+});
+
+describe('createViewStateWriter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('window', {
+      location: { pathname: '/g/', search: '?a=1', hash: '#h', origin: 'https://w.dev', href: 'https://w.dev/g/?a=1#h' },
+      history: { state: null, replaceState: vi.fn() },
+    });
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('collapses rapid writes into one replaceState after the delay', () => {
+    const w = createViewStateWriter(500);
+    w.write({ lat: 1, lon: 1 });
+    w.write({ lat: 2, lon: 2 });
+    expect(window.history.replaceState).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(499);
+    expect(window.history.replaceState).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(window.history.replaceState).toHaveBeenCalledTimes(1);
+    expect(window.history.replaceState).toHaveBeenCalledWith(null, '', '/g/?a=1&lat=2&lon=2#h');
+  });
+
+  it('flush writes immediately and returns an absolute URL', () => {
+    const w = createViewStateWriter(500);
+    w.write({ zoom: 3 });
+    const url = w.flush();
+    expect(url).toBe('https://w.dev/g/?a=1&zoom=3#h');
+    expect(window.history.replaceState).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(1000);
+    expect(window.history.replaceState).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancel drops the pending write', () => {
+    const w = createViewStateWriter(100);
+    w.write({ zoom: 3 });
+    w.cancel();
+    vi.advanceTimersByTime(500);
+    expect(window.history.replaceState).not.toHaveBeenCalled();
+  });
+
+  it('never uses pushState', () => {
+    const w = createViewStateWriter(10);
+    w.write({ zoom: 3 });
+    vi.advanceTimersByTime(20);
+    expect((window.history as unknown as Record<string, unknown>).pushState).toBeUndefined();
+  });
+});

--- a/src/lib/view-state.ts
+++ b/src/lib/view-state.ts
@@ -1,0 +1,230 @@
+/**
+ * view-state.ts — the one place that knows how a shareable view is written
+ * to and read from the URL.
+ *
+ * Globe, 2D map and homepage each own their view (camera, zoom, layer
+ * toggles, open event, scrubber date, selected tracker). None of that state
+ * is shared between islands, so no global store is involved: each island
+ * calls `decodeViewState` on mount and a debounced writer after changes.
+ * See docs/adr/0001-url-view-state-is-island-local.md.
+ *
+ * Rules:
+ *  - Every key that is written is also read. The competitor this was
+ *    modelled on generated lat/lon/zoom/layers and read back only layers,
+ *    so every shared link silently lost its location. The round-trip test
+ *    in view-state.test.ts exists to make that regression impossible.
+ *  - Invalid or unknown values are dropped, never thrown. A broken URL must
+ *    never break the page.
+ *  - Writers use history.replaceState, never pushState: a camera move is
+ *    not a navigation and must not pollute the back button.
+ *  - Parameters that are not ours are preserved; the section hash
+ *    (#map, #timeline) is preserved.
+ */
+import { z } from 'zod';
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const SLUG = /^[a-z0-9][a-z0-9-]*$/;
+
+export const ViewStateSchema = z
+  .object({
+    lat: z.number().min(-90).max(90),
+    lon: z.number().min(-180).max(180),
+    /** Cesium camera height in metres. */
+    alt: z.number().positive().max(100_000_000),
+    /** Leaflet zoom level. */
+    zoom: z.number().min(0).max(24),
+    /** Degrees, normalised to [0, 360). */
+    heading: z.number().min(0).max(360),
+    /** Degrees, -90 (straight down) to 90. */
+    pitch: z.number().min(-90).max(90),
+    /** Active layer ids; an empty array means "all layers off". */
+    layers: z.array(z.string().regex(/^[A-Za-z0-9_-]+$/)),
+    /** Event slug from event-slug.ts ({YYYY-MM-DD}-{kebab-id}). */
+    event: z.string().regex(SLUG).max(200),
+    /** Scrubber date. */
+    date: z.string().regex(ISO_DATE),
+    /** Selected tracker slug (homepage). */
+    tracker: z.string().regex(SLUG).max(100),
+  })
+  .partial();
+
+export type ViewState = z.infer<typeof ViewStateSchema>;
+
+export const VIEW_STATE_KEYS = [
+  'lat', 'lon', 'alt', 'zoom', 'heading', 'pitch', 'layers', 'event', 'date', 'tracker',
+] as const satisfies readonly (keyof ViewState)[];
+
+const round = (n: number, decimals: number) => {
+  const f = 10 ** decimals;
+  return Math.round(n * f) / f;
+};
+
+/** Normalises a heading in degrees into [0, 360). */
+export function normalizeHeading(deg: number): number {
+  const h = deg % 360;
+  return h < 0 ? h + 360 : h;
+}
+
+/**
+ * Serialises a view state. Numbers are rounded so two cameras that differ
+ * by less than the rounding produce identical URLs (stable share links,
+ * no jitter while the camera settles): lat/lon 4 decimals (~11 m), alt to
+ * the metre, zoom 2 decimals, heading/pitch 1 decimal.
+ */
+export function encodeViewState(state: ViewState): URLSearchParams {
+  const params = new URLSearchParams();
+  if (state.lat !== undefined) params.set('lat', String(round(state.lat, 4)));
+  if (state.lon !== undefined) params.set('lon', String(round(state.lon, 4)));
+  if (state.alt !== undefined) params.set('alt', String(Math.round(state.alt)));
+  if (state.zoom !== undefined) params.set('zoom', String(round(state.zoom, 2)));
+  if (state.heading !== undefined) params.set('heading', String(round(normalizeHeading(state.heading), 1)));
+  if (state.pitch !== undefined) params.set('pitch', String(round(state.pitch, 1)));
+  if (state.layers !== undefined) params.set('layers', state.layers.join(','));
+  if (state.event !== undefined) params.set('event', state.event);
+  if (state.date !== undefined) params.set('date', state.date);
+  if (state.tracker !== undefined) params.set('tracker', state.tracker);
+  return params;
+}
+
+function num(raw: string | null): number | undefined {
+  if (raw === null || raw.trim() === '') return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/**
+ * Parses a query string into a view state. Each field is validated on its
+ * own: a bad `lat` does not discard a good `layers`. When `allowedLayers`
+ * is given, unknown layer ids are dropped (a layer that does not exist on
+ * this page cannot be toggled on). `layers=` (present but empty) decodes
+ * to `[]`, which callers must honour as "everything off".
+ */
+export function decodeViewState(
+  search: string | URLSearchParams,
+  allowedLayers?: readonly string[],
+): ViewState {
+  const params = typeof search === 'string' ? new URLSearchParams(search) : search;
+  const candidate: Record<string, unknown> = {};
+
+  const lat = num(params.get('lat'));
+  const lon = num(params.get('lon'));
+  const alt = num(params.get('alt'));
+  const zoom = num(params.get('zoom'));
+  const heading = num(params.get('heading'));
+  const pitch = num(params.get('pitch'));
+  if (lat !== undefined) candidate.lat = lat;
+  if (lon !== undefined) candidate.lon = lon;
+  if (alt !== undefined) candidate.alt = alt;
+  if (zoom !== undefined) candidate.zoom = zoom;
+  if (heading !== undefined) candidate.heading = normalizeHeading(heading);
+  if (pitch !== undefined) candidate.pitch = pitch;
+
+  const layersRaw = params.get('layers');
+  if (layersRaw !== null) {
+    let ids = layersRaw.split(',').map((s) => s.trim()).filter(Boolean);
+    if (allowedLayers) ids = ids.filter((id) => allowedLayers.includes(id));
+    candidate.layers = [...new Set(ids)];
+  }
+
+  for (const key of ['event', 'date', 'tracker'] as const) {
+    const v = params.get(key);
+    if (v !== null && v !== '') candidate[key] = v;
+  }
+
+  // Validate field by field so one bad value does not sink the rest.
+  const out: ViewState = {};
+  for (const key of VIEW_STATE_KEYS) {
+    if (!(key in candidate)) continue;
+    const parsed = ViewStateSchema.safeParse({ [key]: candidate[key] });
+    if (parsed.success && parsed.data[key] !== undefined) {
+      (out as Record<string, unknown>)[key] = parsed.data[key];
+    }
+  }
+  // lat and lon only make sense together.
+  if ((out.lat === undefined) !== (out.lon === undefined)) {
+    delete out.lat;
+    delete out.lon;
+  }
+  return out;
+}
+
+export interface LocationLike {
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+/**
+ * Builds the URL for `state` on top of the current location: our keys are
+ * replaced wholesale (a key absent from `state` is removed), every other
+ * query parameter and the hash survive untouched.
+ */
+export function mergeIntoUrl(state: ViewState, current: LocationLike): string {
+  const params = new URLSearchParams(current.search);
+  for (const key of VIEW_STATE_KEYS) params.delete(key);
+  for (const [k, v] of encodeViewState(state)) params.set(k, v);
+  const qs = params.toString();
+  return `${current.pathname}${qs ? `?${qs}` : ''}${current.hash}`;
+}
+
+/** Reads the current view state from `window.location`; `{}` during SSR. */
+export function readViewState(allowedLayers?: readonly string[]): ViewState {
+  if (typeof window === 'undefined') return {};
+  return decodeViewState(window.location.search, allowedLayers);
+}
+
+export interface ViewStateWriter {
+  /** Schedules a write; consecutive calls within `delayMs` collapse into one. */
+  write(state: ViewState): void;
+  /** Writes immediately and returns the resulting URL (used by "Share"). */
+  flush(state?: ViewState): string;
+  cancel(): void;
+}
+
+/**
+ * Debounced `history.replaceState` writer. `replaceState` only: a camera
+ * move is not a navigation. Safe to construct during SSR; every method is
+ * a no-op without `window`.
+ */
+export function createViewStateWriter(delayMs = 500): ViewStateWriter {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let pending: ViewState | null = null;
+
+  const apply = (state: ViewState): string => {
+    if (typeof window === 'undefined') return '';
+    const url = mergeIntoUrl(state, window.location);
+    if (url !== `${window.location.pathname}${window.location.search}${window.location.hash}`) {
+      try {
+        window.history.replaceState(window.history.state, '', url);
+      } catch {
+        /* some embedded contexts forbid history access */
+      }
+    }
+    return window.location.origin + url;
+  };
+
+  return {
+    write(state) {
+      pending = state;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = null;
+        if (pending) apply(pending);
+        pending = null;
+      }, delayMs);
+    },
+    flush(state) {
+      if (timer) clearTimeout(timer);
+      timer = null;
+      const s = state ?? pending;
+      pending = null;
+      if (s) return apply(s);
+      return typeof window === 'undefined' ? '' : window.location.href;
+    },
+    cancel() {
+      if (timer) clearTimeout(timer);
+      timer = null;
+      pending = null;
+    },
+  };
+}

--- a/src/lib/view-state.ts
+++ b/src/lib/view-state.ts
@@ -23,6 +23,13 @@
 import { z } from 'zod';
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** `2026-02-31` matches the regex and would still throw downstream. */
+function isCalendarDate(s: string): boolean {
+  if (!ISO_DATE.test(s)) return false;
+  const d = new Date(`${s}T00:00:00Z`);
+  return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s;
+}
 const SLUG = /^[a-z0-9][a-z0-9-]*$/;
 
 export const ViewStateSchema = z
@@ -42,7 +49,7 @@ export const ViewStateSchema = z
     /** Event slug from event-slug.ts ({YYYY-MM-DD}-{kebab-id}). */
     event: z.string().regex(SLUG).max(200),
     /** Scrubber date. */
-    date: z.string().regex(ISO_DATE),
+    date: z.string().regex(ISO_DATE).refine(isCalendarDate, 'not a calendar date'),
     /** Selected tracker slug (homepage). */
     tracker: z.string().regex(SLUG).max(100),
   })

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3764,3 +3764,6 @@ body::before {
 .map-layers-share { margin-left: auto; margin-right: 8px; padding: 2px 6px; border-color: transparent; }
 .cc-share-btn { padding: 2px 6px; font-size: 0.5rem; }
 .globe-toolbar-icon.share-view-btn { padding: 0; gap: 0; border-radius: 8px; }
+.globe-toolbar-icon.share-view-btn--copied { color: var(--accent-green, #3fb950); border-color: var(--accent-green, #3fb950); }
+.globe-toolbar-icon.share-view-btn--failed { color: var(--accent-amber, #d29922); border-color: var(--accent-amber, #d29922); }
+.mobile-sheet-share { margin: 0 4px; padding: 4px 6px; align-self: center; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3727,3 +3727,40 @@ body::before {
   border-top: none;
   margin-top: 0;
 }
+
+/* ── Share view button (src/components/islands/shared/ShareViewButton.tsx) ── */
+.share-view-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  color: var(--text-muted, #8b949e);
+  cursor: pointer;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  padding: 4px 8px;
+  transition: color 0.15s, border-color 0.15s;
+}
+.share-view-btn:hover { color: var(--text-primary, #e6edf3); border-color: rgba(255, 255, 255, 0.35); }
+.share-view-btn--copied { color: var(--accent-green, #3fb950); border-color: var(--accent-green, #3fb950); }
+.share-view-btn--failed { color: var(--accent-amber, #d29922); border-color: var(--accent-amber, #d29922); }
+.share-view-toast {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  white-space: nowrap;
+  background: rgba(10, 11, 14, 0.95);
+  border: 1px solid currentColor;
+  border-radius: 4px;
+  padding: 3px 8px;
+  font-size: 0.55rem;
+  z-index: 50;
+  pointer-events: none;
+}
+.map-layers-share { margin-left: auto; margin-right: 8px; padding: 2px 6px; border-color: transparent; }
+.cc-share-btn { padding: 2px 6px; font-size: 0.5rem; }
+.globe-toolbar-icon.share-view-btn { padding: 0; gap: 0; border-radius: 8px; }


### PR DESCRIPTION
Epic **E1 — Estado de vista compartible en URL** of the adoption plan. Stacked on #268 (E0); retarget once that merges. Closes BL-003 (now S, no dependency on BL-001 per ADR-0001).

## Summary

- **`src/lib/view-state.ts`**: `encodeViewState` / `decodeViewState` / `mergeIntoUrl` / `createViewStateWriter`. Keys: `lat, lon, alt|zoom, heading, pitch, layers, event, date, tracker`. Each field is validated on its own (a bad `lat` never discards a good `layers`), dates must be real calendar dates, numbers are rounded so links are stable, foreign params and the section hash survive, and the writer only ever uses `replaceState`. The round-trip test exists because OSIRIS writes `lat/lon/zoom/layers` and reads back only `layers`.
- **Globe** (`CesiumGlobe.tsx`): URL camera beats the first preset; `layers=` selects exactly those layers (empty = all off); `date` positions the scrubber; `event=<slug>` opens the intel panel at that date, expands the event and flies to the matching map point. URL rewritten after `camera.moveEnd` and on layer/date changes. `S` copies the link; share button in the toolbar and in the mobile sheet.
- **2D map** (`IntelMap.tsx`, `LeafletMap.tsx`, `MapLayerToggles.tsx`): `lat/lon/zoom/layers/date`; share button in the layers panel. The tracker page mounts the map twice (desktop + mobile shell), so the hidden 0x0 instance is prevented from reporting its camera; the view handler keeps a stable identity so the `moveend` listener is registered once.
- **Homepage** (`CommandCenter.tsx`): `?tracker=` selects the tracker after hydration and flies the globe to it, the `#geo/#domain` effect preserves the query string, `S` copies the link, new row in the `?` help.
- `ShareViewButton` (shared, clipboard with `execCommand` fallback, 2 s toast); i18n en/es/fr/pt.
- **Playwright**: `baseURL` fixed to `/` (config still pointed at `/watchboard/`), SwiftShader flags for Cesium in headless, `PW_CHROMIUM_PATH` override for sandboxes; `e2e.yml` runs the three new specs on every PR (BL-022 had no workflow).
- Roadmap: `docs/product-roadmap.md` + `src/data/roadmap-items.ts` (item now `in-progress`, effort S, no `dependsOn`).

## Adversarial review
A workflow of adversarial reviewer agents (4 attack lenses, 3 refuters per finding) ran against the epic diff. 7 findings survived verification and are fixed in `35104e5` + `fca4474`: mobile sheet never rendered the share button; `?tracker=` selected without flying the globe; `?event=` was cleared on mount and the event not expanded; calendar-invalid dates accepted; unstable `handleViewChange` re-registering listeners; two specs that proved nothing (now assert against the real camera/URL), and the homepage spec split so the selection assertion runs in the view that renders tracker rows.

`ab2f895` makes `home-share.spec.ts` wait for `load` instead of `networkidle` and pre-complete the first-visit tour: once the alerts feed from E3 polls the homepage, `networkidle` never arrives and the spec timed out at the top of the stack.

## Test plan

- [x] `npm test`: 327 passing (18 new in `view-state.test.ts`: round trip, BVA on every range, lat-without-lon, calendar validation, heading normalisation, allowlist filtering, malformed slugs, debounce/flush/cancel, no `pushState`).
- [x] `npx playwright test e2e/globe-share.spec.ts e2e/map-share.spec.ts e2e/home-share.spec.ts`: passing against the dev server on this head, and again on the top of the stack (E7 head) with all later epics merged in.
- [x] `npx astro check`: no new errors (two pre-existing `missionTrajectory` type errors in `CesiumGlobe.tsx` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZ81PJ4qfADtpwMnc12eWL