### PR TITLE
chore: remove the node_modules symlink committed by mistake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ setup.sh
 .env.*.local
 
 # Astro
+node_modules
 node_modules/
 dist/
 .astro/

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/user/watchboard/node_modules


### PR DESCRIPTION
Follow-up to the OSIRIS adoption stack (#268–#277).

## What

- Removes `node_modules`, a **symlink** (mode 120000, target `/home/user/watchboard/node_modules`) that reached `main` through the E8 review-fix commit and the stacked epics. It came from a sandbox worktree that linked `node_modules` to a shared install.
- `.gitignore` gains `node_modules` without the trailing slash. The existing `node_modules/` rule only matches a directory, so a symlink by that name was not ignored and `git add` picked it up.

## Why it matters

Every fresh checkout of `main` currently creates a dangling symlink where `npm ci` expects to write its install directory.

## Test plan

- [x] `git ls-tree HEAD node_modules` on this branch returns nothing.
- [x] `git check-ignore -v node_modules` matches the new rule for both the directory and a symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZ81PJ4qfADtpwMnc12eWL

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZ81PJ4qfADtpwMnc12eWL)_