### PR TITLE
fix(docker): build the site once natively; only the nginx stage is per-arch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,7 +37,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,11 @@
 # updated by GitHub Actions committing JSON; a self-hosted copy refreshes by
 # rebuilding (or by mounting your own `dist/`). See docs/self-hosting.md.
 
-FROM node:22-alpine AS build
+# --platform=$BUILDPLATFORM: the site is static, so the build stage runs once,
+# natively on the builder, and only the nginx stage below is built per target
+# architecture. Without it the whole Astro build ran a second time under QEMU
+# for linux/arm64, which alone exceeded the job's time budget.
+FROM --platform=$BUILDPLATFORM node:22-alpine AS build
 WORKDIR /app
 ENV CI=1 \
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \


### PR DESCRIPTION
Follow-up to E8 (#270). The first `Docker image` run on `main` (run 4) built and smoke-tested the amd64 image successfully, then the **amd64 + arm64 push step was cancelled at the 45-minute job timeout**. The amd64 build alone took 27 minutes because `npm run build` (generate-api, Cesium copy, Astro, Pagefind, CSP hashes) runs inside the image, and the arm64 pass repeated all of it under QEMU emulation.

## What

- `Dockerfile`: the build stage is now `FROM --platform=$BUILDPLATFORM node:22-alpine`. The output is a static `dist/`, so it is built once, natively on the builder; only the `nginx:1.27-alpine` stage is built per target architecture (copy `dist/` and the generated headers). The resulting arm64 image is identical in content.
- `docker-publish.yml`: `timeout-minutes` 45 → 60 as margin. With the build stage shared and cached (`type=gha`) from the smoke-test step, the push step should now take minutes, not tens of minutes.

## Test plan

- [x] Dockerfile parses (`docker/dockerfile:1.7` syntax; `$BUILDPLATFORM` is provided by buildx).
- [ ] This PR touches `Dockerfile` and the workflow, so the PR build + smoke test runs here; the `main` run after merge is the real check of the multi-arch push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZ81PJ4qfADtpwMnc12eWL

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZ81PJ4qfADtpwMnc12eWL)_